### PR TITLE
fix a problem with signature validation due to incorrect cloning of refe...

### DIFF
--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -606,11 +606,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             );
         }
         $referencedElement = $xpathResults->item(0);
-        $referencedDocument  = new DomDocument();
-        $importedNode = $referencedDocument->importNode($referencedElement->cloneNode(true), true);
-        $referencedDocument->appendChild($importedNode);
-
-        $referencedDocumentXml = $referencedDocument->saveXML();
+        $referencedDocumentXml = $document->saveXML($referencedElement);
 
         // First process any transforms
         if (isset($reference['ds:Transforms']['ds:Transform'])) {


### PR DESCRIPTION
...renced element

When cloning elements that are signed using XMLDSig there is a risk of pulling in namespace declarations from parent nodes. This alters the XML document in such a way that the digest changes, and hence the signature breaks.

By applying transform on the original data, we can circumvent this problem.
