### PR TITLE
Allow for multiple signing keys in metadata documents if entity has Cert...

### DIFF
--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -357,10 +357,8 @@ class EngineBlock_Corto_Adapter
             $remoteEntities[$idpEntityId] = array();
         }
         $remoteEntities[$idpEntityId]['EntityID'] = $idpEntityId;
-        $remoteEntities[$idpEntityId]['certificates'] = array(
-            'public'    => $application->getConfiguration()->encryption->key->public,
-            'private'   => $application->getConfiguration()->encryption->key->private,
-        );
+        $remoteEntities[$idpEntityId]['certificates']['public'] = $application->getConfiguration()->encryption->key->public;
+        $remoteEntities[$idpEntityId]['certificates']['private'] = $application->getConfiguration()->encryption->key->private;
         $remoteEntities[$idpEntityId]['NameIDFormats'] = array(
             EngineBlock_Urn::SAML2_0_NAMEID_FORMAT_PERSISTENT,
             EngineBlock_Urn::SAML2_0_NAMEID_FORMAT_TRANSIENT,

--- a/library/EngineBlock/Corto/Mapper/Metadata/Entity/SsoDescriptor/Certificates.php
+++ b/library/EngineBlock/Corto/Mapper/Metadata/Entity/SsoDescriptor/Certificates.php
@@ -20,42 +20,37 @@ class EngineBlock_Corto_Mapper_Metadata_Entity_SsoDescriptor_Certificates
         if (empty($publicCertificate)) {
             return $rootElement;
         }
-        $rootElement['md:KeyDescriptor'] = array(
-            array(
-                EngineBlock_Corto_XmlToArray::ATTRIBUTE_PFX . 'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
-                EngineBlock_Corto_XmlToArray::ATTRIBUTE_PFX . 'use' => 'signing',
-                'ds:KeyInfo' => array(
-                    'ds:X509Data' => array(
-                        'ds:X509Certificate' => array(
-                            EngineBlock_Corto_XmlToArray::VALUE_PFX => $this->_mapPem($publicCertificate),
-                        ),
-                    ),
-                ),
-            ),
-/**
- * https://jira.surfconext.nl/jira/browse/BACKLOG-874
- *
- * Encryption key is no longer provided to prevent the idp returning an encrypted response
 
-            array(
-                EngineBlock_Corto_XmlToArray::ATTRIBUTE_PFX . 'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
-                EngineBlock_Corto_XmlToArray::ATTRIBUTE_PFX . 'use' => 'encryption',
-                'ds:KeyInfo' => array(
-                    'ds:X509Data' => array(
-                        'ds:X509Certificate' => array(
-                            EngineBlock_Corto_XmlToArray::VALUE_PFX => $this->_mapPem($publicCertificate),
-                        ),
-                    ),
-                ),
-                'md:EncryptionMethod' => array(
-                    array(
-                        EngineBlock_Corto_XmlToArray::ATTRIBUTE_PFX . 'Algorithm' => 'http://www.w3.org/2001/04/xmlenc#rsa-1_5',
+        $rootElement['md:KeyDescriptor'] = array($this->getSigningKeyMetadataForCert($publicCertificate));
+
+        if (isset($this->_entity['certificates']['public-fallback'])) {
+            $rootElement['md:KeyDescriptor'][] = $this->getSigningKeyMetadataForCert(
+                $this->_entity['certificates']['public-fallback']
+            );
+        }
+
+        if (isset($this->_entity['certificates']['public-fallback2'])) {
+            $rootElement['md:KeyDescriptor'][] = $this->getSigningKeyMetadataForCert(
+                $this->_entity['certificates']['public-fallback2']
+            );
+        }
+
+        return $rootElement;
+    }
+
+    protected function getSigningKeyMetadataForCert($publicCertificate)
+    {
+        return array(
+            EngineBlock_Corto_XmlToArray::ATTRIBUTE_PFX . 'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
+            EngineBlock_Corto_XmlToArray::ATTRIBUTE_PFX . 'use' => 'signing',
+            'ds:KeyInfo' => array(
+                'ds:X509Data' => array(
+                    'ds:X509Certificate' => array(
+                        EngineBlock_Corto_XmlToArray::VALUE_PFX => $this->_mapPem($publicCertificate),
                     ),
                 ),
             ),
-*/
         );
-        return $rootElement;
     }
 
     protected function _mapPem($pemKey)

--- a/library/EngineBlock/Corto/Mapper/ServiceRegistry/KeyValue.php
+++ b/library/EngineBlock/Corto/Mapper/ServiceRegistry/KeyValue.php
@@ -162,9 +162,10 @@ class EngineBlock_Corto_Mapper_ServiceRegistry_KeyValue
         }
 
         // In general
+        $cortoEntity['certificates'] = array();
         if (isset($serviceRegistryEntity['certData']) && $serviceRegistryEntity['certData']) {
-            $cortoEntity['certificates'] = array(
-                'public' => EngineBlock_X509Certificate::getPublicPemCertFromCertData($serviceRegistryEntity['certData']),
+            $cortoEntity['certificates']['public'] = EngineBlock_X509Certificate::getPublicPemCertFromCertData(
+                $serviceRegistryEntity['certData']
             );
             if (isset($serviceRegistryEntity['certData2']) && $serviceRegistryEntity['certData2']) {
                 $cortoEntity['certificates']['public-fallback'] = EngineBlock_X509Certificate::getPublicPemCertFromCertData(


### PR DESCRIPTION
Because of [HeartBleed](http://heartbleed.com) we will need to renew the private key for EB. However to do that we first need to let the SPs know that there will be another key for signing.

With this patch, if an entity has CertData2 and/or CertData3 defined, they will appear in the metadata document as signing keys.
