### PR TITLE
Fix english language string to add missing variable.

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -269,8 +269,8 @@ If you want to use this application you have to:<br />
     'error_attribute_validator_type_emailaddress'   => '\'%3$s\' is not a valid email address',
     'error_attribute_validator_minlength'           => '\'%3$s\' is not long enough (minimum is %2$d characters)',
     'error_attribute_validator_maxlength'           => '\'%3$s\' is too long (maximum is %2$d characters)',
-    'error_attribute_validator_min'                 => 'Require at least %2$d values (%3d given)',
-    'error_attribute_validator_max'                 => 'Must have no more than %2$d values (%3d given)',
+    'error_attribute_validator_min'                 => '%1$s requires at least %2$d values (%3d given)',
+    'error_attribute_validator_max'                 => '%1$s may have no more than %2$d values (%3d given)',
     'error_attribute_validator_regex'               => '\'%3$s\' does not match the expected format of this attribute (%2$s)',
     'error_attribute_validator_not_in_definitions'  => '%1$s is not known in the SURFconext schema',
 


### PR DESCRIPTION
The english language string of attributes that failed validation missed one of the used variables.

Partially addresses #45.
