### PR TITLE
Set admin.protectindexpage to TRUE.

### DIFF
--- a/config/simplesamlphp/config/config.php
+++ b/config/simplesamlphp/config/config.php
@@ -75,7 +75,7 @@ $config = array (
 	 * metadata listing and diagnostics pages.
 	 */
 	'auth.adminpassword'		=> $appConfig->auth->simplesamlphp->adminPassword,
-	'admin.protectindexpage'	=> false,
+	'admin.protectindexpage'	=> TRUE,
 	'admin.protectmetadata'		=> false,
 
 	/**


### PR DESCRIPTION
Otherwise everyone can get the EB version, installation path and some
other info from https://profile.{{openconext_url}}/simplesaml/
Not a large risk in itself, but still unexpected behaviour.
