### PR TITLE
Bugfix for issue #71 Improve dumping attachments to syslog.

### DIFF
--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -133,12 +133,12 @@ class EngineBlock_ApplicationSingleton
             $severity = EngineBlock_Log::ERR;
         }
 
-        $log->attach((string) $exception, 'trace');
+        $log->attach($exception, 'trace');
 
         // attach previous exceptions
         $prevException = $exception;
         while ($prevException = $prevException->getPrevious()) {
-            $log->attach((string) $prevException, 'previous exception');
+            $log->attach($prevException, 'previous exception');
         }
 
         $message = $exception->getMessage();

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -426,7 +426,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             $action = $sspMessage->getDestination();
 
             $log = $this->_server->getSessionLog();
-            $log->attach($message, 'SAML message')
+            $log->attach($xml, 'SAML message')
                 ->info('HTTP-Post: Sending Message');
 
             $output = $this->_server->renderTemplate(

--- a/library/EngineBlock/Log.php
+++ b/library/EngineBlock/Log.php
@@ -31,16 +31,11 @@ class EngineBlock_Log extends Zend_Log
      */
     static public function encodeAttachments(array $attachments)
     {
+        $messageLimit = 128 * 1024;
         foreach ($attachments as $key => $attachment) {
-            if (is_string($attachment['message'])) {
-                continue;
-            }
-
-            $attachment['message'] = print_r($attachment['message'], true);
-
-            if (strlen($attachment['message']) > 128*1024) {
-                $attachment['message'] = substr($attachment['message'], 0, 128*1024)
-                                        . '... (message truncated to 128K)';
+            if (strlen($attachment['message']) > $messageLimit) {
+                $attachment['message'] = substr($attachment['message'], 0, $messageLimit);
+                $attachment['message'] .= '... (message truncated to 128K)';
             }
 
             $attachments[$key] = $attachment;
@@ -217,18 +212,26 @@ class EngineBlock_Log extends Zend_Log
     }
 
     /**
-     * Add data to append serialized after next log message
-     *  - if log() is not called after attach(), data is discarded
+     * Add message to append serialized after next log message
      *
-     * @param mixed $data
+     * Note:
+     * - if log() is not called after attach(), data is discarded.
+     * - you MAY pass non-strings and attach, it will attempt to cast to string and finally do a json_encode.
+     *   if this doesn't fit your needs, please do serialization before calling attach.
+     *
+     * @param mixed $message
      * @param string $name
      * @return EngineBlock_Log
      */
-    public function attach($data, $name)
+    public function attach($message, $name)
     {
+        if (is_object($message) && method_exists($message, '__toString')) {
+            $message = (string) $message;
+        }
+
         $this->_attachments[] = array(
-            'name' => $name,
-            'message' => $data,
+            'name'      => $name,
+            'message'   => json_encode($message),
         );
 
         return $this;

--- a/library/EngineBlock/Rest/Client.php
+++ b/library/EngineBlock/Rest/Client.php
@@ -40,7 +40,7 @@ class EngineBlock_Rest_Client extends Zend_Rest_Client
         $this->_data = array();//Initializes for next Rest method.
 
         if ($response->getStatus() !== 200) {
-            EngineBlock_ApplicationSingleton::getLog()->attach($response, 'Response');
+            EngineBlock_ApplicationSingleton::getLog()->attach($response->asString(), 'Response');
 
             throw new EngineBlock_Exception(
                 'Response status !== 200', EngineBlock_Exception::CODE_WARNING
@@ -54,7 +54,7 @@ class EngineBlock_Rest_Client extends Zend_Rest_Client
                 return new Zend_Rest_Client_Result($response->getBody());
             }
             catch (Zend_Rest_Client_Result_Exception $e) {
-                EngineBlock_ApplicationSingleton::getLog()->attach($response, 'Response');
+                EngineBlock_ApplicationSingleton::getLog()->attach($response->asString(), 'Response');
 
                 throw new EngineBlock_Exception(
                     'Error parsing response', null, $e

--- a/library/EngineBlock/Saml2/MessageAnnotationDecorator.php
+++ b/library/EngineBlock/Saml2/MessageAnnotationDecorator.php
@@ -104,4 +104,16 @@ class EngineBlock_Saml2_MessageAnnotationDecorator
         }
         throw new \RuntimeException('Unknown message type?!');
     }
+
+    /**
+     * Dump a string representation of this annotated message used for debugging.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $vars = get_object_vars($this);
+        $vars['sspMessage'] = $this->sspMessage->toUnsignedXML()->ownerDocument->saveXML();
+        return json_encode($vars);
+    }
 }

--- a/tests/library/EngineBlock/Test/Saml2/AuthnRequestAnnotationDecoratorTest.php
+++ b/tests/library/EngineBlock/Test/Saml2/AuthnRequestAnnotationDecoratorTest.php
@@ -1,0 +1,19 @@
+<?php
+
+class EngineBlock_Test_Saml2_AuthnRequestAnnotationDecoratorTest extends PHPUnit_Framework_TestCase
+{
+    public function testToString()
+    {
+        $request = new SAML2_AuthnRequest();
+        $request->setId('TEST123');
+        $request->setIssueInstant(0);
+
+        $annotatedRequest = new EngineBlock_Saml2_AuthnRequestAnnotationDecorator($request);
+        $annotatedRequest->setDebug();
+
+        $this->assertEquals(
+            '{"sspMessage":"<?xml version=\"1.0\"?>\n<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"TEST123\" Version=\"2.0\" IssueInstant=\"1970-01-01T00:00:00Z\"\/>\n","voContext":null,"keyId":null,"explicitVoContext":true,"wasSigned":false,"debug":true,"unsolicited":false,"transparent":false,"deliverByBinding":null}',
+            $annotatedRequest->__toString()
+        );
+    }
+}


### PR DESCRIPTION
No longer dump the trace arguments so as to not exhaust the available memory.
