### PR TITLE
Disable the loading of external entities in XML documents.

### DIFF
--- a/library/EngineBlock/Application/Bootstrapper.php
+++ b/library/EngineBlock/Application/Bootstrapper.php
@@ -155,6 +155,8 @@ class EngineBlock_Application_Bootstrapper
     {
         $settings = $this->_application->getConfiguration()->phpSettings->toArray();
         $this->_setIniSettings($settings);
+        // prevent any XXE attacks when processing XML
+        libxml_disable_entity_loader();
     }
 
     protected function _setIniSettings($settings, $prefix = '')


### PR DESCRIPTION
This is to proactively defend against local and remote file inclusion attacks.
This is in most cases already disabled by default in system libraries, but to
be safe we explicitly disable it also.