### PR TITLE
Fix typo in technical contact

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -86,7 +86,7 @@ auth.simplesamlphp.adminPassword  = "123"
 auth.simplesamlphp.showErrors     = false
 auth.simplesamlphp.secretSalt     = f4afad5d6fisoaaif6s6ida4ii6o6fsf
 auth.simplesamlphp.technicalContactName = 'OpenConext Admin'
-auth.simplesamlphp.techincalContactEmail = 'admin@openconext.example.edu'
+auth.simplesamlphp.technicalContactEmail = 'admin@openconext.example.edu'
 
 profile.simplesamlphp.baseurlpath = "simplesaml/"
 engine.simplesamlphp.baseurlpath = "simplesaml/"


### PR DESCRIPTION
Currently the config has a typo in the technical contact email which causes an exception