### PR TITLE
Ensure clicking "Press enter to select" location forwards to IdP

### DIFF
--- a/application/modules/Authentication/View/Proxy/discover.phtml
+++ b/application/modules/Authentication/View/Proxy/discover.phtml
@@ -128,7 +128,7 @@ $layout->assign('helpLink', '/authentication/idp/help-discover?lang=' . $lang);
             <img class="logo" src="/images/placeholder.png" data-original="<?= $idp['Logo'] ?>" />
           </div>
           <h3><?= EngineBlock_View::htmlSpecialCharsAttributeValue($idp['Name_' . $lang]); ?></h3>
-          <button class="c-button white action" data-toggle-text="<img class='deleteable' src='/images/cross.svg'>"><?php echo $this->t('press_enter_to_select'); ?></button>
+          <span class="c-button white action" data-toggle-text="<img class='deleteable' src='/images/cross.svg'>"><?php echo $this->t('press_enter_to_select'); ?></span>
           <noscript>
             <button type="submit" class="c-button white" name="idp" value="<?= EngineBlock_View::htmlSpecialCharsAttributeValue($idp['EntityID']); ?>">Login</button>
           </noscript>

--- a/theme/material/templates/modules/Authentication/View/Proxy/discover.phtml
+++ b/theme/material/templates/modules/Authentication/View/Proxy/discover.phtml
@@ -127,7 +127,7 @@ $layout->assign('helpLink', '/authentication/idp/help-discover?lang=' . $lang);
             <img class="logo" src="/images/placeholder.png" data-original="<?= $idp['Logo'] ?>" />
           </div>
           <h3><?= EngineBlock_View::htmlSpecialCharsAttributeValue($idp['Name_' . $lang]); ?></h3>
-          <button class="c-button white action" data-toggle-text="<img class='deleteable' src='/images/cross.svg'>"><?php echo $this->t('press_enter_to_select'); ?></button>
+          <span class="c-button white action" data-toggle-text="<img class='deleteable' src='/images/cross.svg'>"><?php echo $this->t('press_enter_to_select'); ?></span>
           <noscript>
             <button type="submit" class="c-button white" name="idp" value="<?= EngineBlock_View::htmlSpecialCharsAttributeValue($idp['EntityID']); ?>">Login</button>
           </noscript>


### PR DESCRIPTION
Pivotal Tracker: https://www.pivotaltracker.com/story/show/103782428

> Als je precies op die plek waar de 'press enter to select' knop zit dan verschijnt de knop, in plaats van  dat je de IdP selecteert en inlogt. Probleem bestaat in meerdere browsers!

Clicking an IdP makes the anchor element receive focus. Immediately after that, the button also receives focus, making the anchor element lose focus. By changing the button into an span element, the anchor element doesn't lose focus, and the click event is handled, forwarding the user to the clicked IdP.

The issue could also have been addressed by not showing the button when clicking. However, the button is shown when navigating using the keyboard. Hiding it when using the mouse is confusing. As such, the above solution has been applied.