### PR TITLE
Remove old-style logging in Material theme footer

### DIFF
--- a/theme/material/templates/modules/Default/View/Error/include/footer.php
+++ b/theme/material/templates/modules/Default/View/Error/include/footer.php
@@ -1,7 +1,5 @@
 <?php
-$log = EngineBlock_ApplicationSingleton::getInstance()->getLog();
-$log->log('Showing feedback page with message: ' . $layout->title, EngineBlock_Log::INFO);
-$log->getQueueWriter()->flush('feedback page shown');
+EngineBlock_ApplicationSingleton::getInstance()->flushLog('Showing feedback page with message: ' . $layout->title);
 ?>
 
     <div class="l-overflow">


### PR DESCRIPTION
Somehow an old-style log flush is still present in the Material theme's footer. This is copied over when working on the theme, and could inadvertently be committed, producing fatal errors.