### PR TITLE
Keep track of consent type given

### DIFF
--- a/database/patch/patch-0022.sql
+++ b/database/patch/patch-0022.sql
@@ -1,0 +1,4 @@
+-- Add consent_type column to consent table
+ALTER TABLE consent
+ADD COLUMN consent_type VARCHAR(20)
+DEFAULT 'explicit';

--- a/library/EngineBlock/Corto/Model/Consent.php
+++ b/library/EngineBlock/Corto/Model/Consent.php
@@ -1,12 +1,10 @@
 <?php
 
 use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Authentication\Value\ConsentType;
 
 class EngineBlock_Corto_Model_Consent
 {
-    const EXPLICIT = 'explicit';
-    const IMPLICIT = 'implicit';
-
     /**
      * @var string
      */
@@ -54,21 +52,21 @@ class EngineBlock_Corto_Model_Consent
     }
 
     public function explicitConsentWasGivenFor(ServiceProvider $serviceProvider) {
-        return $this->_hasStoredConsent($serviceProvider, self::EXPLICIT);
+        return $this->_hasStoredConsent($serviceProvider, ConsentType::TYPE_EXPLICIT);
     }
 
     public function implicitConsentWasGivenFor(ServiceProvider $serviceProvider) {
-        return $this->_hasStoredConsent($serviceProvider, self::IMPLICIT);
+        return $this->_hasStoredConsent($serviceProvider, ConsentType::TYPE_IMPLICIT);
     }
 
     public function giveExplicitConsentFor(ServiceProvider $serviceProvider)
     {
-        return $this->_storeConsent($serviceProvider, self::EXPLICIT);
+        return $this->_storeConsent($serviceProvider, ConsentType::TYPE_EXPLICIT);
     }
 
     public function giveImplicitConsentFor(ServiceProvider $serviceProvider)
     {
-        return $this->_storeConsent($serviceProvider, self::IMPLICIT);
+        return $this->_storeConsent($serviceProvider, ConsentType::TYPE_IMPLICIT);
     }
 
     public function countTotalConsent()

--- a/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
@@ -1,7 +1,5 @@
 <?php
 
-use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;
-
 class EngineBlock_Corto_Module_Service_ProcessConsent
     implements EngineBlock_Corto_Module_Service_ServiceInterface
 {
@@ -81,7 +79,7 @@ class EngineBlock_Corto_Module_Service_ProcessConsent
 
         $attributes = $response->getAssertion()->getAttributes();
         $consent = $this->_consentFactory->create($this->_server, $response, $attributes);
-        $consent->storeConsent($destinationMetadata);
+        $consent->giveExplicitConsentFor($destinationMetadata);
         if ($consent->countTotalConsent() === 1) {
             $this->_sendIntroductionMail($attributes);
         }

--- a/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
@@ -78,9 +78,9 @@ class EngineBlock_Corto_Module_Service_ProcessConsent
         }
 
         $attributes = $response->getAssertion()->getAttributes();
-        $consent = $this->_consentFactory->create($this->_server, $response, $attributes);
-        $consent->giveExplicitConsentFor($destinationMetadata);
-        if ($consent->countTotalConsent() === 1) {
+        $consentRepository = $this->_consentFactory->create($this->_server, $response, $attributes);
+        $consentRepository->giveExplicitConsentFor($destinationMetadata);
+        if ($consentRepository->countTotalConsent() === 1) {
             $this->_sendIntroductionMail($attributes);
         }
 

--- a/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
@@ -63,11 +63,11 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
         $serviceProviderMetadata = $spMetadataChain[0];
 
         $attributes = $response->getAssertion()->getAttributes();
-        $consent = $this->_consentFactory->create($this->_server, $response, $attributes);
+        $consentRepository = $this->_consentFactory->create($this->_server, $response, $attributes);
 
         if ($this->isConsentDisabled($spMetadataChain, $identityProvider)) {
-            if (!$consent->implicitConsentWasGivenFor($serviceProviderMetadata)) {
-                $consent->giveImplicitConsentFor($serviceProviderMetadata);
+            if (!$consentRepository->implicitConsentWasGivenFor($serviceProviderMetadata)) {
+                $consentRepository->giveImplicitConsentFor($serviceProviderMetadata);
             }
 
             $response->setConsent(SAML2_Const::CONSENT_INAPPLICABLE);
@@ -81,7 +81,7 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
             return;
         }
 
-        $priorConsent = $consent->explicitConsentWasGivenFor($serviceProviderMetadata);
+        $priorConsent = $consentRepository->explicitConsentWasGivenFor($serviceProviderMetadata);
         if ($priorConsent) {
             $response->setConsent(SAML2_Const::CONSENT_PRIOR);
 

--- a/src/OpenConext/EngineBlock/ApiBundle/Dto/Consent.php
+++ b/src/OpenConext/EngineBlock/ApiBundle/Dto/Consent.php
@@ -64,6 +64,7 @@ final class Consent
             'service_provider' => $serviceProvider,
             'consent_given_on' => $this->consent->getDateConsentWasGivenOn()->format(DateTime::ATOM),
             'last_used_on'     => $this->consent->getDateLastUsedOn()->format(DateTime::ATOM),
+            'consent_type'     => $this->consent->getConsentType()->jsonSerialize(),
         );
     }
 }

--- a/src/OpenConext/EngineBlock/Authentication/Entity/Consent.php
+++ b/src/OpenConext/EngineBlock/Authentication/Entity/Consent.php
@@ -4,6 +4,7 @@ namespace OpenConext\EngineBlock\Authentication\Entity;
 
 use DateTime;
 use OpenConext\EngineBlock\Authentication\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Authentication\Value\ConsentType;
 
 final class Consent
 {
@@ -32,13 +33,24 @@ final class Consent
     private $lastUsedOn;
 
     /**
-     * @param string   $userId
-     * @param string   $serviceProviderEntityId
+     * @var ConsentType
+     */
+    private $consentType;
+
+    /**
+     * @param string $userId
+     * @param string $serviceProviderEntityId
      * @param DateTime $consentGivenOn
      * @param DateTime $lastUsedOn
+     * @param ConsentType $consentType
      */
-    public function __construct($userId, $serviceProviderEntityId, DateTime $consentGivenOn, DateTime $lastUsedOn)
-    {
+    public function __construct(
+        $userId,
+        $serviceProviderEntityId,
+        DateTime $consentGivenOn,
+        DateTime $lastUsedOn,
+        ConsentType $consentType
+    ) {
         if (!is_string($userId)) {
             throw InvalidArgumentException::invalidType('string', 'userId', $userId);
         }
@@ -51,6 +63,7 @@ final class Consent
         $this->serviceProviderEntityId = $serviceProviderEntityId;
         $this->consentGivenOn          = $consentGivenOn;
         $this->lastUsedOn              = $lastUsedOn;
+        $this->consentType             = $consentType;
     }
 
     /**
@@ -77,5 +90,13 @@ final class Consent
     public function getDateLastUsedOn()
     {
         return clone $this->lastUsedOn;
+    }
+
+    /**
+     * @return ConsentType
+     */
+    public function getConsentType()
+    {
+        return $this->consentType;
     }
 }

--- a/src/OpenConext/EngineBlock/Authentication/Repository/ConsentRepository.php
+++ b/src/OpenConext/EngineBlock/Authentication/Repository/ConsentRepository.php
@@ -6,6 +6,7 @@ use DateTime;
 use Doctrine\DBAL\Connection as DbalConnection;
 use Doctrine\DBAL\DBALException;
 use OpenConext\EngineBlock\Authentication\Entity\Consent;
+use OpenConext\EngineBlock\Authentication\Value\ConsentType;
 use PDO;
 
 final class ConsentRepository
@@ -30,7 +31,18 @@ final class ConsentRepository
      */
     public function findAllFor($userId)
     {
-        $sql       = 'SELECT service_id, consent_date, usage_date FROM consent WHERE hashed_user_id=:hashed_user_id';
+        $sql       = '
+            SELECT
+                service_id
+            ,   consent_date
+            ,   usage_date
+            ,   consent_type
+            FROM
+                consent
+            WHERE
+                hashed_user_id=:hashed_user_id
+        ';
+
         $statement = $this->connection->executeQuery($sql, array('hashed_user_id' => sha1($userId)));
         $rows      = $statement->fetchAll(PDO::FETCH_ASSOC);
 
@@ -40,7 +52,8 @@ final class ConsentRepository
                     $userId,
                     $row['service_id'],
                     new DateTime($row['consent_date']),
-                    new DateTime($row['usage_date'])
+                    new DateTime($row['usage_date']),
+                    new ConsentType($row['consent_type'])
                 );
             },
             $rows

--- a/src/OpenConext/EngineBlock/Authentication/Tests/Value/ConsentTypeTest.php
+++ b/src/OpenConext/EngineBlock/Authentication/Tests/Value/ConsentTypeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace OpenConext\EngineBlock\Authentication\Tests\Value;
+
+use OpenConext\EngineBlock\Authentication\Value\ConsentType;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ConsentTypeTest extends TestCase
+{
+    /**
+     * @test
+     * @group Authentication
+     * @group Consent
+     * @group Value
+     *
+     * @dataProvider invalidConsentTypeProvider
+     * @expectedException \OpenConext\EngineBlock\Authentication\Exception\InvalidArgumentException
+     */
+    public function cannot_be_other_than_implicit_or_explicit($invalid)
+    {
+        $invalidConsentType = new ConsentType($invalid);
+    }
+
+    /**
+     * @test
+     * @group Authentication
+     * @group Consent
+     * @group Value
+     */
+    public function different_consent_types_are_not_equal()
+    {
+        $explicit = ConsentType::explicit();
+        $implicit = ConsentType::implicit();
+
+        $this->assertFalse($explicit->equals($implicit));
+        $this->assertFalse($implicit->equals($explicit));
+    }
+
+    /**
+     * @test
+     * @group Authentication
+     * @group Consent
+     * @group Value
+     */
+    public function same_type_of_consent_types_are_equal()
+    {
+        $explicit = ConsentType::explicit();
+        $implicit = ConsentType::implicit();
+
+        $this->assertTrue($explicit->equals(ConsentType::explicit()));
+        $this->assertTrue($implicit->equals(ConsentType::implicit()));
+    }
+
+    public function invalidConsentTypeProvider()
+    {
+        return array(
+            'invalid string'    => array('invalid'),
+            'empty string'      => array(''),
+            'integer'           => array(1),
+            'null'              => array(null),
+            'array'             => array(array()),
+            'boolean'           => array(true)
+        );
+    }
+}

--- a/src/OpenConext/EngineBlock/Authentication/Value/ConsentType.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/ConsentType.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace OpenConext\EngineBlock\Authentication\Value;
+
+use OpenConext\EngineBlock\Authentication\Exception\InvalidArgumentException;
+
+final class ConsentType
+{
+    const TYPE_EXPLICIT = 'explicit';
+    const TYPE_IMPLICIT = 'implicit';
+
+    /**
+     * @var string
+     */
+    private $consentType;
+
+    /**
+     * @return ConsentType
+     */
+    public static function explicit()
+    {
+        return new self(self::TYPE_EXPLICIT);
+    }
+
+    /**
+     * @return ConsentType
+     */
+    public static function implicit()
+    {
+        return new self(self::TYPE_IMPLICIT);
+    }
+
+    /**
+     * @param ConsentType::TYPE_EXPLICIT|ConsentType::TYPE_IMPLICIT $consentType
+     *
+     * @deprecated Use the implicit and explicit named constructors. Will be removed
+     *             when Doctrine ORM is implemented.
+     */
+    public function __construct($consentType)
+    {
+        if (!in_array($consentType, array(self::TYPE_EXPLICIT, self::TYPE_IMPLICIT), true)) {
+            throw InvalidArgumentException::invalidType(
+                'ConsentType::TYPE_EXPLICIT|ConsentType::TYPE_IMPLICIT',
+                'consentType',
+                $consentType
+            );
+        }
+
+        $this->consentType = $consentType;
+    }
+
+    /**
+     * @param ConsentType $other
+     * @return bool
+     */
+    public function equals(ConsentType $other)
+    {
+        return $this->consentType === $other->consentType;
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->consentType;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->consentType;
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -10,6 +10,7 @@
         <testsuite name="All">
             <!-- Look for our unit tests in the following directory. They must end with Test.php -->
             <directory suffix="Test.php">.</directory>
+            <directory suffix="Test.php">../src</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
To determine what type of consent a user has given for a certain service, this should be stored. 

This way, it is possible to inform the user about whether he has implicitly or explicitly consented to releasing his data to a specific service.

Part of: Profile [ticket #106401530](https://www.pivotaltracker.com/story/show/106401530)
