### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.php.ini
+++ b/.travis.php.ini
@@ -1,0 +1,1 @@
+date.timezone = "Europe/Amsterdam"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: php
+
+php:
+  - 7.0
+  - 5.6
+
+matrix:
+  allow_failures:
+  - php: 7.0
+
+env:
+  global:
+    - SYMFONY_ENV=test
+
+cache:
+  directories:
+    - ~/.composer
+
+before_script:
+  - phpenv config-add .travis.php.ini
+
+script:
+  - ant
+
+branches:
+  only:
+    - 5.x-dev
+    - 5.x-refactor


### PR DESCRIPTION
[Ticket 111133268](https://www.pivotaltracker.com/story/show/111133268)

This adds a basic travis configuration for 5.x-dev and 5.x-refactor.
It runs `ant`, which runs its `build` target by default. `Build` consists of cleaning the build (artefacts) directory, creating directories, installing composer dependencies and running `lint` and `phpunit`.

Soon, [extra qa-tools should be added for our src directory](https://www.pivotaltracker.com/story/show/111133448).

Please review/merge #240 first, so we can see passing unit tests.