### PR TITLE
Embed EngineBlock Fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bin/ignore_me.php
 /web/bundles
 /web/app_dev.php
 /app/cache
+/app/logs
 /app/SymfonyRequirements.php
 /app/check.php
 /tmp/

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "incenteev/composer-parameter-handler": "~2.0",
         "openconext/saml-value-object": "^1.1",
         "symfony/monolog-bundle": "~2.4",
-        "beberlei/assert": "^2.4",
-        "openconext/engineblock-fixtures": "^0.5.2"
+        "beberlei/assert": "^2.4"
     },
     "require-dev": {
         "phake/phake": "2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0492cdf951f05e8691f085d765b8d8e8",
-    "content-hash": "9d9efb21acc214a823f4c82407cd16e5",
+    "hash": "6469663e13193ab297d67234f29f26e9",
+    "content-hash": "1ccedfada6b33a31070cbcc23f0a92db",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -906,36 +906,6 @@
             "description": "Minify is a PHP5 app that helps you follow several rules for client-side performance. It combines multiple CSS or Javascript files, removes unnecessary whitespace and comments, and serves them with gzip encoding and optimal client-side cache headers",
             "homepage": "http://code.google.com/p/minify/",
             "time": "2014-10-30 22:58:02"
-        },
-        {
-            "name": "openconext/engineblock-fixtures",
-            "version": "0.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/OpenConext/OpenConext-engineblock-fixtures.git",
-                "reference": "a990f6cead9067a21662ec4bb2ba2e76d4f95498"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/OpenConext-engineblock-fixtures/zipball/a990f6cead9067a21662ec4bb2ba2e76d4f95498",
-                "reference": "a990f6cead9067a21662ec4bb2ba2e76d4f95498",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "OpenConext\\Component\\EngineBlockFixtures\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "OpenConext Component for EngineBlock Fixtures",
-            "time": "2016-01-19 10:03:57"
         },
         {
             "name": "openconext/engineblock-metadata",
@@ -2856,7 +2826,7 @@
                     "name": "Manuel Pichler",
                     "email": "github@manuel-pichler.de",
                     "homepage": "https://github.com/manuelpichler",
-                    "role": "Project founder"
+                    "role": "Project Founder"
                 },
                 {
                     "name": "Other contributors",

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -200,7 +200,7 @@ class EngineBlock_Application_DiContainer extends Pimple implements ContainerInt
     }
 
     /**
-     * @return EngineBlock_Saml2_IdGenerator_Interface
+     * @return EngineBlock_Saml2_IdGenerator
      */
     public function getSaml2IdGenerator()
     {

--- a/library/EngineBlock/Application/SuperGlobalManager.php
+++ b/library/EngineBlock/Application/SuperGlobalManager.php
@@ -1,5 +1,8 @@
 <?php
 
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\SuperGlobalsFixture;
+
 class EngineBlock_Application_SuperGlobalManager
 {
     /**
@@ -19,11 +22,9 @@ class EngineBlock_Application_SuperGlobalManager
 
     public function injectOverrides()
     {
-        $fixture = new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\SuperGlobalsFixture(
-            new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore(
-                ENGINEBLOCK_FOLDER_ROOT . self::FILE
-            )
-        );
+        $jsonDataStore = new JsonDataStore(ENGINEBLOCK_FOLDER_ROOT . self::FILE);
+        $fixture = new SuperGlobalsFixture($jsonDataStore);
+
         $overrides = $fixture->getAll();
 
         foreach ($overrides as $superGlobalName => $values) {

--- a/library/EngineBlock/Application/SuperGlobalManager.php
+++ b/library/EngineBlock/Application/SuperGlobalManager.php
@@ -19,8 +19,8 @@ class EngineBlock_Application_SuperGlobalManager
 
     public function injectOverrides()
     {
-        $fixture = new \OpenConext\Component\EngineBlockFixtures\SuperGlobalsFixture(
-            new \OpenConext\Component\EngineBlockFixtures\DataStore\JsonDataStore(
+        $fixture = new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\SuperGlobalsFixture(
+            new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore(
                 ENGINEBLOCK_FOLDER_ROOT . self::FILE
             )
         );

--- a/library/EngineBlock/Corto/Module/Service/EdugainMetadata.php
+++ b/library/EngineBlock/Corto/Module/Service/EdugainMetadata.php
@@ -46,7 +46,7 @@ class EngineBlock_Corto_Module_Service_EdugainMetadata extends EngineBlock_Corto
 
         // Map the IdP configuration to a Corto XMLToArray structured document array
         $mapper = new EngineBlock_Corto_Mapper_Metadata_EdugainDocument(
-            $this->_server->getNewId(\OpenConext\Component\EngineBlockFixtures\IdFrame::ID_USAGE_SAML2_METADATA),
+            $this->_server->getNewId(\OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_SAML2_METADATA),
             $this->_server->timeStamp($this->_server->getConfig('metadataValidUntilSeconds', 86400)),
             true
         );

--- a/library/EngineBlock/Corto/Module/Service/EdugainMetadata.php
+++ b/library/EngineBlock/Corto/Module/Service/EdugainMetadata.php
@@ -46,7 +46,7 @@ class EngineBlock_Corto_Module_Service_EdugainMetadata extends EngineBlock_Corto
 
         // Map the IdP configuration to a Corto XMLToArray structured document array
         $mapper = new EngineBlock_Corto_Mapper_Metadata_EdugainDocument(
-            $this->_server->getNewId(\OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_SAML2_METADATA),
+            $this->_server->getNewId(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_METADATA),
             $this->_server->timeStamp($this->_server->getConfig('metadataValidUntilSeconds', 86400)),
             true
         );
@@ -73,12 +73,9 @@ class EngineBlock_Corto_Module_Service_EdugainMetadata extends EngineBlock_Corto
         $this->_server->sendOutput($xml);
     }
 
-
     protected function _addRequestAttributes($entity)
     {
         $arpRequestedAttributes = new EngineBlock_Corto_Module_Service_Metadata_ArpRequestedAttributes();
         return $arpRequestedAttributes->addRequestAttributes($entity);
     }
-
-
 }

--- a/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
+++ b/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
@@ -1,7 +1,6 @@
 <?php
 
 use EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer as ServiceReplacer;
-use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
 
 class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Module_Service_Abstract
 {
@@ -35,8 +34,7 @@ class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Mo
                     $spEntity
                 )
             );
-        }
-        else {
+        } else {
             $identityProviders = $this->_server->getRepository()->findIdentityProviders();
         }
 
@@ -71,7 +69,7 @@ class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Mo
 
         // Map the IdP configuration to a Corto XMLToArray structured document array
         $mapper = new EngineBlock_Corto_Mapper_Metadata_EdugainDocument(
-            $this->_server->getNewId(\OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_SAML2_METADATA),
+            $this->_server->getNewId(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_METADATA),
             $this->_server->timeStamp($this->_server->getConfig('metadataValidUntilSeconds', 86400)),
             false
         );
@@ -97,5 +95,4 @@ class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Mo
         $this->_server->sendHeader('Content-Type', 'application/xml');
         $this->_server->sendOutput($xml);
     }
-
 }

--- a/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
+++ b/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
@@ -71,7 +71,7 @@ class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Mo
 
         // Map the IdP configuration to a Corto XMLToArray structured document array
         $mapper = new EngineBlock_Corto_Mapper_Metadata_EdugainDocument(
-            $this->_server->getNewId(\OpenConext\Component\EngineBlockFixtures\IdFrame::ID_USAGE_SAML2_METADATA),
+            $this->_server->getNewId(\OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_SAML2_METADATA),
             $this->_server->timeStamp($this->_server->getConfig('metadataValidUntilSeconds', 86400)),
             false
         );

--- a/library/EngineBlock/Corto/Module/Service/Metadata.php
+++ b/library/EngineBlock/Corto/Module/Service/Metadata.php
@@ -1,7 +1,6 @@
 <?php
 
 use EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer as ServiceReplacer;
-use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 
 class EngineBlock_Corto_Module_Service_Metadata extends EngineBlock_Corto_Module_Service_Abstract
 {
@@ -31,7 +30,7 @@ class EngineBlock_Corto_Module_Service_Metadata extends EngineBlock_Corto_Module
 
         // Map the IdP configuration to a Corto XMLToArray structured document array
         $mapper = new EngineBlock_Corto_Mapper_Metadata_EdugainDocument(
-            $this->_server->getNewId(IdFrame::ID_USAGE_SAML2_METADATA),
+            $this->_server->getNewId(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_METADATA),
             $this->_server->timeStamp($this->_server->getConfig('metadataValidUntilSeconds', 86400)),
             false
         );

--- a/library/EngineBlock/Corto/Module/Service/Metadata.php
+++ b/library/EngineBlock/Corto/Module/Service/Metadata.php
@@ -1,7 +1,7 @@
 <?php
 
 use EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer as ServiceReplacer;
-use OpenConext\Component\EngineBlockFixtures\IdFrame;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 
 class EngineBlock_Corto_Module_Service_Metadata extends EngineBlock_Corto_Module_Service_Abstract
 {

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -1,6 +1,6 @@
 <?php
 
-use \OpenConext\Component\EngineBlockFixtures\IdFrame;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
 use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Logger\Message\AdditionalInfo;
@@ -258,7 +258,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
     protected function _createDebugRequest()
     {
         $sspRequest = new SAML2_AuthnRequest();
-        $sspRequest->setId($this->_server->getNewId(\OpenConext\Component\EngineBlockFixtures\IdFrame::ID_USAGE_SAML2_REQUEST));
+        $sspRequest->setId($this->_server->getNewId(\OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_SAML2_REQUEST));
         $sspRequest->setIssuer($this->_server->getUrl('spMetadataService'));
 
         $request = new EngineBlock_Saml2_AuthnRequestAnnotationDecorator($sspRequest);

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -233,7 +233,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         $relayState  = !empty($_GET['RelayState'])   ? $_GET['RelayState']  : null;
 
         $sspRequest = new SAML2_AuthnRequest();
-        $sspRequest->setId($this->_server->getNewId(IdFrame::ID_USAGE_SAML2_REQUEST));
+        $sspRequest->setId($this->_server->getNewId(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_REQUEST));
         $sspRequest->setIssuer($entityId);
         $sspRequest->setRelayState($relayState);
 
@@ -258,7 +258,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
     protected function _createDebugRequest()
     {
         $sspRequest = new SAML2_AuthnRequest();
-        $sspRequest->setId($this->_server->getNewId(\OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_SAML2_REQUEST));
+        $sspRequest->setId($this->_server->getNewId(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_REQUEST));
         $sspRequest->setIssuer($this->_server->getUrl('spMetadataService'));
 
         $request = new EngineBlock_Saml2_AuthnRequestAnnotationDecorator($sspRequest);

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -1,6 +1,5 @@
 <?php
 
-use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
 use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Logger\Message\AdditionalInfo;

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -1,6 +1,5 @@
 <?php
 
-use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
 use OpenConext\Component\EngineBlockMetadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -1,6 +1,6 @@
 <?php
 
-use OpenConext\Component\EngineBlockFixtures\IdFrame;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
 use OpenConext\Component\EngineBlockMetadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -430,7 +430,7 @@ class EngineBlock_Corto_ProxyServer
         // Create a new assertion by us.
         $newAssertion = new SAML2_Assertion();
         $newResponse->setAssertions(array($newAssertion));
-        $newAssertion->setId($this->getNewId(IdFrame::ID_USAGE_SAML2_ASSERTION));
+        $newAssertion->setId($this->getNewId(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_ASSERTION));
         $newAssertion->setIssueInstant(time());
         $newAssertion->setIssuer($newResponse->getIssuer());
 
@@ -530,7 +530,7 @@ class EngineBlock_Corto_ProxyServer
         $response = new SAML2_Response();
         /** @var SAML2_AuthnRequest $request */
         $response->setRelayState($request->getRelayState());
-        $response->setId($this->getNewId(IdFrame::ID_USAGE_SAML2_RESPONSE));
+        $response->setId($this->getNewId(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_RESPONSE));
         $response->setIssueInstant(time());
         if (!$requestWasUnsolicited) {
             $response->setInResponseTo($request->getId());
@@ -1014,7 +1014,7 @@ class EngineBlock_Corto_ProxyServer
         return $provider->timestamp($deltaSeconds);
     }
 
-    public function getNewId($usage = IdFrame::ID_USAGE_OTHER)
+    public function getNewId($usage = EngineBlock_Saml2_IdGenerator::ID_USAGE_OTHER)
     {
         $generator = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getSaml2IdGenerator();
         return $generator->generate(self::ID_PREFIX, $usage);

--- a/library/EngineBlock/Saml2/AuthnRequestFactory.php
+++ b/library/EngineBlock/Saml2/AuthnRequestFactory.php
@@ -26,7 +26,7 @@ class EngineBlock_Saml2_AuthnRequestFactory
         /** @var SAML2_AuthnRequest $originalRequest */
 
         $sspRequest = new SAML2_AuthnRequest();
-        $sspRequest->setId($server->getNewId(\OpenConext\Component\EngineBlockFixtures\IdFrame::ID_USAGE_SAML2_REQUEST));
+        $sspRequest->setId($server->getNewId(\OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_SAML2_REQUEST));
         $sspRequest->setIssueInstant(time());
         $sspRequest->setDestination($idpMetadata->singleSignOnServices[0]->location);
         $sspRequest->setForceAuthn($originalRequest->getForceAuthn());

--- a/library/EngineBlock/Saml2/AuthnRequestFactory.php
+++ b/library/EngineBlock/Saml2/AuthnRequestFactory.php
@@ -26,7 +26,7 @@ class EngineBlock_Saml2_AuthnRequestFactory
         /** @var SAML2_AuthnRequest $originalRequest */
 
         $sspRequest = new SAML2_AuthnRequest();
-        $sspRequest->setId($server->getNewId(\OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_SAML2_REQUEST));
+        $sspRequest->setId($server->getNewId(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_REQUEST));
         $sspRequest->setIssueInstant(time());
         $sspRequest->setDestination($idpMetadata->singleSignOnServices[0]->location);
         $sspRequest->setForceAuthn($originalRequest->getForceAuthn());

--- a/library/EngineBlock/Saml2/IdGenerator.php
+++ b/library/EngineBlock/Saml2/IdGenerator.php
@@ -1,0 +1,12 @@
+<?php
+
+interface EngineBlock_Saml2_IdGenerator
+{
+    const ID_USAGE_SAML2_METADATA  = 'saml2-metadata';
+    const ID_USAGE_OTHER           = 'other';
+    const ID_USAGE_SAML2_RESPONSE  = 'saml2-response';
+    const ID_USAGE_SAML2_REQUEST   = 'saml2-request';
+    const ID_USAGE_SAML2_ASSERTION = 'saml2-assertion';
+
+    public function generate($prefix = 'EB', $usage = self::ID_USAGE_OTHER);
+}

--- a/library/EngineBlock/Saml2/IdGenerator/Default.php
+++ b/library/EngineBlock/Saml2/IdGenerator/Default.php
@@ -1,8 +1,8 @@
 <?php
 
-class EngineBlock_Saml2_IdGenerator_Default implements EngineBlock_Saml2_IdGenerator_Interface
+class EngineBlock_Saml2_IdGenerator_Default implements EngineBlock_Saml2_IdGenerator
 {
-    public function generate($prefix = 'EB', $usage = \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_OTHER)
+    public function generate($prefix = 'EB', $usage = EngineBlock_Saml2_IdGenerator::ID_USAGE_OTHER)
     {
         return  $prefix . sha1(uniqid(mt_rand(), true));
     }

--- a/library/EngineBlock/Saml2/IdGenerator/Default.php
+++ b/library/EngineBlock/Saml2/IdGenerator/Default.php
@@ -2,7 +2,7 @@
 
 class EngineBlock_Saml2_IdGenerator_Default implements EngineBlock_Saml2_IdGenerator_Interface
 {
-    public function generate($prefix = 'EB', $usage = \OpenConext\Component\EngineBlockFixtures\IdFrame::ID_USAGE_OTHER)
+    public function generate($prefix = 'EB', $usage = \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_OTHER)
     {
         return  $prefix . sha1(uniqid(mt_rand(), true));
     }

--- a/library/EngineBlock/Saml2/IdGenerator/Fixture.php
+++ b/library/EngineBlock/Saml2/IdGenerator/Fixture.php
@@ -1,5 +1,8 @@
 <?php
 
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\SerializedDataStore;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture;
+
 class EngineBlock_Saml2_IdGenerator_Fixture implements EngineBlock_Saml2_IdGenerator
 {
     const FIXTURE_FILE = 'tmp/eb-fixtures/saml2/id';
@@ -36,11 +39,7 @@ class EngineBlock_Saml2_IdGenerator_Fixture implements EngineBlock_Saml2_IdGener
 
     protected function loadFrame()
     {
-        $fixture = new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture(
-            new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\SerializedDataStore(
-                ENGINEBLOCK_FOLDER_ROOT . self::FIXTURE_FILE
-            )
-        );
+        $fixture = new IdFixture(new SerializedDataStore(ENGINEBLOCK_FOLDER_ROOT . self::FIXTURE_FILE));
         $this->frame = $fixture->shiftFrame();
     }
 }

--- a/library/EngineBlock/Saml2/IdGenerator/Fixture.php
+++ b/library/EngineBlock/Saml2/IdGenerator/Fixture.php
@@ -5,7 +5,7 @@ class EngineBlock_Saml2_IdGenerator_Fixture implements EngineBlock_Saml2_IdGener
     const FIXTURE_FILE = 'tmp/eb-fixtures/saml2/id';
 
     /**
-     * @var \OpenConext\Component\EngineBlockFixtures\IdFrame
+     * @var \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame
      */
     protected $frame;
 
@@ -14,7 +14,7 @@ class EngineBlock_Saml2_IdGenerator_Fixture implements EngineBlock_Saml2_IdGener
 
     }
 
-    public function generate($prefix = 'EB', $usage = \OpenConext\Component\EngineBlockFixtures\IdFrame::ID_USAGE_OTHER)
+    public function generate($prefix = 'EB', $usage = \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_OTHER)
     {
         if (!file_exists(ENGINEBLOCK_FOLDER_ROOT . self::FIXTURE_FILE)) {
             $defaultGenerator = new EngineBlock_Saml2_IdGenerator_Default();
@@ -37,8 +37,8 @@ class EngineBlock_Saml2_IdGenerator_Fixture implements EngineBlock_Saml2_IdGener
 
     protected function loadFrame()
     {
-        $fixture = new \OpenConext\Component\EngineBlockFixtures\IdFixture(
-            new \OpenConext\Component\EngineBlockFixtures\DataStore\SerializedDataStore(
+        $fixture = new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture(
+            new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\SerializedDataStore(
                 ENGINEBLOCK_FOLDER_ROOT . self::FIXTURE_FILE
             )
         );

--- a/library/EngineBlock/Saml2/IdGenerator/Fixture.php
+++ b/library/EngineBlock/Saml2/IdGenerator/Fixture.php
@@ -1,6 +1,6 @@
 <?php
 
-class EngineBlock_Saml2_IdGenerator_Fixture implements EngineBlock_Saml2_IdGenerator_Interface
+class EngineBlock_Saml2_IdGenerator_Fixture implements EngineBlock_Saml2_IdGenerator
 {
     const FIXTURE_FILE = 'tmp/eb-fixtures/saml2/id';
 
@@ -11,10 +11,9 @@ class EngineBlock_Saml2_IdGenerator_Fixture implements EngineBlock_Saml2_IdGener
 
     public function __construct()
     {
-
     }
 
-    public function generate($prefix = 'EB', $usage = \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_OTHER)
+    public function generate($prefix = 'EB', $usage = EngineBlock_Saml2_IdGenerator::ID_USAGE_OTHER)
     {
         if (!file_exists(ENGINEBLOCK_FOLDER_ROOT . self::FIXTURE_FILE)) {
             $defaultGenerator = new EngineBlock_Saml2_IdGenerator_Default();

--- a/library/EngineBlock/Saml2/IdGenerator/Interface.php
+++ b/library/EngineBlock/Saml2/IdGenerator/Interface.php
@@ -1,6 +1,0 @@
-<?php
-
-interface EngineBlock_Saml2_IdGenerator_Interface
-{
-    public function generate($prefix = 'EB', $usage = \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_OTHER);
-}

--- a/library/EngineBlock/Saml2/IdGenerator/Interface.php
+++ b/library/EngineBlock/Saml2/IdGenerator/Interface.php
@@ -2,5 +2,5 @@
 
 interface EngineBlock_Saml2_IdGenerator_Interface
 {
-    public function generate($prefix = 'EB', $usage = \OpenConext\Component\EngineBlockFixtures\IdFrame::ID_USAGE_OTHER);
+    public function generate($prefix = 'EB', $usage = \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame::ID_USAGE_OTHER);
 }

--- a/library/EngineBlock/TimeProvider/Fixture.php
+++ b/library/EngineBlock/TimeProvider/Fixture.php
@@ -1,5 +1,8 @@
 <?php
 
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\TimeFixture;
+
 class EngineBlock_TimeProvider_Fixture implements EngineBlock_TimeProvider_Interface
 {
     const FIXTURE_FILE = 'tmp/eb-fixtures/saml2/time';
@@ -16,8 +19,8 @@ class EngineBlock_TimeProvider_Fixture implements EngineBlock_TimeProvider_Inter
 
     public function time()
     {
-        $fixture = new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\TimeFixture(
-            new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore(
+        $fixture = new TimeFixture(
+            new JsonDataStore(
                 ENGINEBLOCK_FOLDER_ROOT . static::FIXTURE_FILE
             )
         );

--- a/library/EngineBlock/TimeProvider/Fixture.php
+++ b/library/EngineBlock/TimeProvider/Fixture.php
@@ -16,8 +16,8 @@ class EngineBlock_TimeProvider_Fixture implements EngineBlock_TimeProvider_Inter
 
     public function time()
     {
-        $fixture = new \OpenConext\Component\EngineBlockFixtures\TimeFixture(
-            new \OpenConext\Component\EngineBlockFixtures\DataStore\JsonDataStore(
+        $fixture = new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\TimeFixture(
+            new \OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore(
                 ENGINEBLOCK_FOLDER_ROOT . static::FIXTURE_FILE
             )
         );

--- a/src/OpenConext/EngineBlock/Driver/File/FileHandler.php
+++ b/src/OpenConext/EngineBlock/Driver/File/FileHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenConext\EngineBlock\Driver\File;
+
+interface FileHandler
+{
+    /**
+     * @param mixed  $data     the data to write
+     * @param string $filePath the path to the file to write to
+     * @return void
+     */
+    public function writeTo($data, $filePath);
+
+    /**
+     * @param string $filePath the path to the file to read the contents of
+     * @return mixed
+     */
+    public function readFrom($filePath);
+}

--- a/src/OpenConext/EngineBlock/Driver/File/FileHandler.php
+++ b/src/OpenConext/EngineBlock/Driver/File/FileHandler.php
@@ -16,4 +16,10 @@ interface FileHandler
      * @return mixed
      */
     public function readFrom($filePath);
+
+    /**
+     * @param string $filePath the path to the file to remove
+     * @return void
+     */
+    public function remove($filePath);
 }

--- a/src/OpenConext/EngineBlock/Driver/File/FileStorageDriver.php
+++ b/src/OpenConext/EngineBlock/Driver/File/FileStorageDriver.php
@@ -10,7 +10,7 @@ final class FileStorageDriver implements StorageDriver
     /**
      * @var FileHandler
      */
-    private $fileAccessor;
+    private $fileHandler;
 
     /**
      * @var string
@@ -18,26 +18,26 @@ final class FileStorageDriver implements StorageDriver
     private $filePath;
 
     /**
-     * @param FileHandler $fileAccessor
+     * @param FileHandler $fileHandler
      * @param string      $filePath
      */
-    public function __construct(FileHandler $fileAccessor, $filePath)
+    public function __construct(FileHandler $fileHandler, $filePath)
     {
         Assertion::nonEmptyString($filePath, 'filePath');
 
-        $this->fileAccessor = $fileAccessor;
-        $this->filePath = $filePath;
+        $this->fileHandler = $fileHandler;
+        $this->filePath    = $filePath;
     }
 
     public function save($data)
     {
         Assertion::string($data, 'Data to save must be a string, "%s" given');
 
-        $this->fileAccessor->writeTo($data, $this->filePath);
+        $this->fileHandler->writeTo($data, $this->filePath);
     }
 
     public function load()
     {
-        return $this->fileAccessor->readFrom($this->filePath);
+        return $this->fileHandler->readFrom($this->filePath);
     }
 }

--- a/src/OpenConext/EngineBlock/Driver/File/FileStorageDriver.php
+++ b/src/OpenConext/EngineBlock/Driver/File/FileStorageDriver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OpenConext\EngineBlock\Driver\File;
+
+use OpenConext\EngineBlock\Assert\Assertion;
+use OpenConext\EngineBlock\Driver\StorageDriver;
+
+final class FileStorageDriver implements StorageDriver
+{
+    /**
+     * @var FileHandler
+     */
+    private $fileAccessor;
+
+    /**
+     * @var string
+     */
+    private $filePath;
+
+    /**
+     * @param FileHandler $fileAccessor
+     * @param string      $filePath
+     */
+    public function __construct(FileHandler $fileAccessor, $filePath)
+    {
+        Assertion::nonEmptyString($filePath, 'filePath');
+
+        $this->fileAccessor = $fileAccessor;
+        $this->filePath = $filePath;
+    }
+
+    public function save($data)
+    {
+        Assertion::string($data, 'Data to save must be a string, "%s" given');
+
+        $this->fileAccessor->writeTo($data, $this->filePath);
+    }
+
+    public function load()
+    {
+        return $this->fileAccessor->readFrom($this->filePath);
+    }
+}

--- a/src/OpenConext/EngineBlock/Driver/File/FilesystemAdapter.php
+++ b/src/OpenConext/EngineBlock/Driver/File/FilesystemAdapter.php
@@ -51,4 +51,14 @@ final class FilesystemAdapter implements FileHandler
 
         return $data;
     }
+
+    public function remove($filePath)
+    {
+        try {
+            $this->filesystem->remove($filePath);
+        } catch (IOException $exception) {
+            $newMessage = sprintf('Could not remove file "%s", "%s"', $filePath, $exception->getMessage());
+            throw new RuntimeException($newMessage, null, $exception);
+        }
+    }
 }

--- a/src/OpenConext/EngineBlock/Driver/File/FilesystemAdapter.php
+++ b/src/OpenConext/EngineBlock/Driver/File/FilesystemAdapter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace OpenConext\EngineBlock\Driver\File;
+
+use OpenConext\EngineBlock\Assert\Assertion;
+use OpenConext\EngineBlock\Exception\RuntimeException;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class FilesystemAdapter implements FileHandler
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    public function writeTo($data, $filePath)
+    {
+        Assertion::string($data, 'Can only write string data to file, "%s" given');
+        Assertion::nonEmptyString($filePath, 'filePath');
+
+        try {
+            $this->filesystem->dumpFile($filePath, $data);
+        } catch (IOException $exception) {
+            $newMessage = sprintf('Could not write data to file "%s": "%s"', $filePath, $exception->getMessage());
+            throw new RuntimeException($newMessage, null, $exception);
+        }
+    }
+
+    public function readFrom($filePath)
+    {
+        Assertion::nonEmptyString($filePath, 'filePath');
+
+        if (!$this->filesystem->exists($filePath)) {
+            throw new RuntimeException(sprintf('Cannot read from file "%s" as it does not exist', $filePath));
+        }
+
+        if (!is_readable($filePath)) {
+            throw new RuntimeException(sprintf('Cannot read from file "%s" as it is not readable', $filePath));
+        }
+
+        $data = file_get_contents($filePath);
+        if ($data === false) {
+            throw new RuntimeException(sprintf('Could not read data from file "%s"', $filePath));
+        }
+
+        return $data;
+    }
+}

--- a/src/OpenConext/EngineBlock/Driver/StorageDriver.php
+++ b/src/OpenConext/EngineBlock/Driver/StorageDriver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenConext\EngineBlock\Driver;
+
+interface StorageDriver
+{
+    /**
+     * @param $data
+     * @return boolean whether or not the data was saved succesfully
+     * @throws \OpenConext\EngineBlock\Exception\Exception
+     */
+    public function save($data);
+
+    /**
+     * @return mixed
+     * @throws \OpenConext\EngineBlock\Exception\Exception
+     */
+    public function load();
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Command/DumpServiceRegistryCommand.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Command/DumpServiceRegistryCommand.php
@@ -2,7 +2,7 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Command;
 
-use OpenConext\Component\EngineBlockFixtures\DataStore\JsonDataStore;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -2,9 +2,8 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
-use Behat\Mink\Element\NodeElement;
+use EngineBlock_Saml2_IdGenerator;
 use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture;
-use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 use OpenConext\EngineBlockFunctionalTestingBundle\Parser\LogChunkParser;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\EntityRegistry;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
@@ -125,7 +124,7 @@ class EngineBlockContext extends AbstractSubContext
         $this->engineBlock->overrideHostname($hostname);
 
         $frame = $this->engineBlock->getIdsToUse(IdFixture::FRAME_REQUEST);
-        $frame->set(IdFrame::ID_USAGE_SAML2_REQUEST, $authnRequest->getId());
+        $frame->set(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_REQUEST, $authnRequest->getId());
     }
 
     /**
@@ -140,12 +139,12 @@ class EngineBlockContext extends AbstractSubContext
 
         $this->engineBlock->getIdsToUse(IdFixture::FRAME_RESPONSE)
         // EB will generate internal responses, for now just let it give all Responses the same id
-            ->set(IdFrame::ID_USAGE_SAML2_RESPONSE, $response->getId())
-            ->set(IdFrame::ID_USAGE_SAML2_ASSERTION, $responseAssertions[0]->getId())
-            ->set(IdFrame::ID_USAGE_SAML2_RESPONSE, $response->getId())
-            ->set(IdFrame::ID_USAGE_SAML2_ASSERTION, $responseAssertions[0]->getId())
-            ->set(IdFrame::ID_USAGE_SAML2_RESPONSE, $response->getId())
-            ->set(IdFrame::ID_USAGE_SAML2_ASSERTION, $responseAssertions[0]->getId());
+            ->set(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_RESPONSE, $response->getId())
+            ->set(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_ASSERTION, $responseAssertions[0]->getId())
+            ->set(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_RESPONSE, $response->getId())
+            ->set(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_ASSERTION, $responseAssertions[0]->getId())
+            ->set(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_RESPONSE, $response->getId())
+            ->set(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_ASSERTION, $responseAssertions[0]->getId());
     }
 
     /**

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -3,13 +3,13 @@
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
 use Behat\Mink\Element\NodeElement;
-use OpenConext\Component\EngineBlockFixtures\IdFixture;
-use OpenConext\Component\EngineBlockFixtures\IdFrame;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 use OpenConext\EngineBlockFunctionalTestingBundle\Parser\LogChunkParser;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\EntityRegistry;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Service\EngineBlock;
-use OpenConext\Component\EngineBlockFixtures\ServiceRegistryFixture;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\ServiceRegistryFixture;
 
 class EngineBlockContext extends AbstractSubContext
 {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -8,7 +8,7 @@ use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockServiceProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Saml2\EncryptedAssertion;
 use OpenConext\EngineBlockFunctionalTestingBundle\Service\EngineBlock;
-use OpenConext\Component\EngineBlockFixtures\ServiceRegistryFixture;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\ServiceRegistryFixture;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProviderFactory;
 
 /**

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -3,9 +3,9 @@
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
 use Behat\Gherkin\Node\PyStringNode;
+use EngineBlock_Saml2_IdGenerator;
 use OpenConext\EngineBlockFunctionalTestingBundle\Parser\LogChunkParser;
 use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture;
-use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\EntityRegistry;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockServiceProvider;
@@ -155,7 +155,7 @@ class MockSpContext extends AbstractSubContext
             $requestIssuer = $unsolicitedRequest['saml:Issuer']['__v'];
 
             $frame = $this->engineBlock->getIdsToUse(IdFixture::FRAME_REQUEST);
-            $frame->set(IdFrame::ID_USAGE_SAML2_REQUEST, $unsolicitedRequest['_ID']);
+            $frame->set(EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_REQUEST, $unsolicitedRequest['_ID']);
         } else {
             // If not, then parse an AuthnRequest out of the log file
             $authnRequest = $logReader->getMessage(LogChunkParser::MESSAGE_TYPE_AUTHN_REQUEST);

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -4,14 +4,14 @@ namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
 use Behat\Gherkin\Node\PyStringNode;
 use OpenConext\EngineBlockFunctionalTestingBundle\Parser\LogChunkParser;
-use OpenConext\Component\EngineBlockFixtures\IdFixture;
-use OpenConext\Component\EngineBlockFixtures\IdFrame;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\EntityRegistry;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockServiceProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Service\EngineBlock;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockServiceProviderFactory;
-use OpenConext\Component\EngineBlockFixtures\ServiceRegistryFixture;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\ServiceRegistryFixture;
 
 /**
  * Class MockSpContext

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore;
+
+abstract class AbstractDataStore
+{
+    protected $filePath;
+
+    public function __construct($filePath)
+    {
+        $this->filePath = $filePath;
+    }
+
+    protected function verifyFilePath()
+    {
+        if (is_writeable($this->filePath)) {
+            return;
+        }
+
+        $directory = dirname($this->filePath);
+        if (!file_exists($directory)) {
+            $createdDirectory = mkdir($directory, 0777, true);
+            if (!$createdDirectory) {
+                throw new \RuntimeException('Unable to create directory: ' . $directory);
+            }
+        }
+
+        if (!file_exists($this->filePath)) {
+            $touched = touch($this->filePath);
+            chmod($this->filePath, 0666);
+            if (!$touched) {
+                throw new \RuntimeException('Unable to create file: ' . $this->filePath);
+            }
+        }
+    }
+
+    public function load($default = array())
+    {
+        $this->verifyFilePath();
+
+        $fileContents = file_get_contents($this->filePath);
+        if ($fileContents === false) {
+            throw new \RuntimeException('Unable to load data from: ' . $this->filePath);
+        }
+        if (empty($fileContents)) {
+            return $default;
+        }
+
+        $data = $this->decode($fileContents);
+        if ($data === false) {
+            throw new \RuntimeException('Unable to decode data from: ' . $this->filePath);
+        }
+
+        return $data;
+    }
+
+    public function save($data)
+    {
+        $this->verifyFilePath();
+
+        file_put_contents($this->filePath, $this->encode($data));
+    }
+
+    abstract protected function encode($data);
+
+    abstract protected function decode($data);
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/FileFlags.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/FileFlags.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore;
+
+class FileFlags
+{
+    protected $dir;
+
+    public function __construct($dir)
+    {
+        $this->dir = $dir;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortMethodName)
+     */
+    public function on($name, $value)
+    {
+        $this->verifyDir();
+
+        file_put_contents($this->dir . DIRECTORY_SEPARATOR . $name, $value);
+    }
+
+    public function off($name)
+    {
+        $this->verifyDir();
+
+        $file = $this->dir . DIRECTORY_SEPARATOR . $name;
+        if (!file_exists($file)) {
+            return;
+        }
+
+        unlink($file);
+    }
+
+    protected function verifyDir()
+    {
+        if (is_writeable($this->dir)) {
+            return;
+        }
+
+        if (!file_exists($this->dir)) {
+            $madeDir = mkdir($this->dir, 0755, true);
+            if (!$madeDir) {
+                throw new \RuntimeException('Unable to create directory: ' . $this->dir);
+            }
+        }
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/JsonDataStore.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/JsonDataStore.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore;
+
+class JsonDataStore extends AbstractDataStore
+{
+    protected function encode($data)
+    {
+        return json_encode($data);
+    }
+
+    protected function decode($data)
+    {
+        return json_decode($data, true);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/SerializedDataStore.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/SerializedDataStore.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore;
+
+class SerializedDataStore extends AbstractDataStore
+{
+    protected function encode($data)
+    {
+        return serialize($data);
+    }
+
+    protected function decode($data)
+    {
+        return unserialize($data);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/IdFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/IdFixture.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
+
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\AbstractDataStore;
+
+/**
+ * Ids
+ * @package OpenConext\EngineBlockFunctionalTestingBundle\Fixtures
+ */
+class IdFixture
+{
+    const FRAME_REQUEST = 'request';
+    const FRAME_RESPONSE = 'response';
+
+    protected $dataStore;
+
+    /**
+     * @var IdFrame[]
+     */
+    protected $frames;
+
+    /**
+     * @param AbstractDataStore $dataStore
+     */
+    public function __construct(AbstractDataStore $dataStore)
+    {
+        $this->dataStore = $dataStore;
+    }
+
+    private function loadFrames()
+    {
+        if (isset($this->frames)) {
+            return;
+        }
+
+        $this->frames = $this->dataStore->load();
+    }
+
+    /**
+     * Get the top frame off the queue for use.
+     */
+    public function shiftFrame()
+    {
+        $this->loadFrames();
+
+        if (empty($this->frames)) {
+            throw new \RuntimeException('No more IdFrames?');
+        }
+        return array_shift($this->frames);
+    }
+
+    public function hasFrame($frameName)
+    {
+        $this->loadFrames();
+
+        return isset($this->frames[$frameName]);
+    }
+
+    public function getFrame($frameName)
+    {
+        $this->loadFrames();
+
+        if (!isset($this->frames[$frameName])) {
+            throw new \RuntimeException("No frame with given name '$frameName'");
+        }
+        return $this->frames[$frameName];
+    }
+
+    /**
+     * Queue up another set of ids to use.
+     *
+     * @param $frameName
+     * @param IdFrame $frame
+     * @return $this
+     */
+    public function addFrame($frameName, IdFrame $frame)
+    {
+        $this->loadFrames();
+
+        $this->frames[$frameName] = $frame;
+        return $this;
+    }
+
+    /**
+     * Remove all frames.
+     */
+    public function clear()
+    {
+        if (!isset($this->frames)) {
+            return $this;
+        }
+
+        $this->loadFrames();
+
+        $this->frames = array();
+        return $this;
+    }
+
+    /**
+     * On destroy write out the current state.
+     */
+    public function __destruct()
+    {
+        if (!isset($this->frames)) {
+            return;
+        }
+
+        $this->dataStore->save($this->frames);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/IdFrame.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/IdFrame.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
+
+/**
+ * A 'frame' of ids, as in a set of ids for use in a single step of the EngineBlock flow.
+ * @package OpenConext\EngineBlockFunctionalTestingBundle\Fixtures
+ */
+class IdFrame
+{
+    const ID_USAGE_SAML2_RESPONSE   = 'saml2-response';
+    const ID_USAGE_SAML2_REQUEST    = 'saml2-request';
+    const ID_USAGE_SAML2_ASSERTION  = 'saml2-assertion';
+    const ID_USAGE_SAML2_METADATA   = 'saml2-metadata';
+    const ID_USAGE_OTHER            = 'other';
+
+    protected $ids;
+
+    /**
+     * @param array $ids
+     */
+    public function __construct($ids = array())
+    {
+        $this->ids = $ids;
+    }
+
+    /**
+     * @param $usage
+     * @param $id
+     * @return $this
+     */
+    public function set($usage, $id)
+    {
+        $this->ids[$usage][] = $id;
+        return $this;
+    }
+
+    /**
+     * @param $usage
+     * @return mixed
+     * @throws \RuntimeException
+     */
+    public function get($usage)
+    {
+        $id = array_shift($this->ids[$usage]);
+        if (!$id) {
+            throw new \RuntimeException(
+                'Current frame has no id set for ' . $usage . ', available ids: ' . print_r($this->ids, true)
+            );
+        }
+        return $id;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAll()
+    {
+        return $this->ids;
+    }
+
+    /**
+     * @param $usage
+     * @return bool
+     */
+    public function has($usage)
+    {
+        return isset($this->ids[$usage]);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/IdFrame.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/IdFrame.php
@@ -2,18 +2,13 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
 
+use RuntimeException;
+
 /**
  * A 'frame' of ids, as in a set of ids for use in a single step of the EngineBlock flow.
- * @package OpenConext\EngineBlockFunctionalTestingBundle\Fixtures
  */
 class IdFrame
 {
-    const ID_USAGE_SAML2_RESPONSE   = 'saml2-response';
-    const ID_USAGE_SAML2_REQUEST    = 'saml2-request';
-    const ID_USAGE_SAML2_ASSERTION  = 'saml2-assertion';
-    const ID_USAGE_SAML2_METADATA   = 'saml2-metadata';
-    const ID_USAGE_OTHER            = 'other';
-
     protected $ids;
 
     /**
@@ -32,22 +27,24 @@ class IdFrame
     public function set($usage, $id)
     {
         $this->ids[$usage][] = $id;
+
         return $this;
     }
 
     /**
      * @param $usage
      * @return mixed
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public function get($usage)
     {
         $id = array_shift($this->ids[$usage]);
         if (!$id) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'Current frame has no id set for ' . $usage . ', available ids: ' . print_r($this->ids, true)
             );
         }
+
         return $id;
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
+
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\AbstractDataStore;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\FileFlags;
+use SAML2_Const;
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class ServiceRegistryFixture
+{
+    const TYPE_SP = 1;
+    const TYPE_IDP = 2;
+
+    protected $fixture;
+    protected $fileFlags;
+    protected $directory;
+    protected $data;
+
+    public function __construct(AbstractDataStore $dataStore, FileFlags $fileFlags, $directory)
+    {
+        $this->fixture = $dataStore;
+        $this->fileFlags = $fileFlags;
+        $this->directory = $directory;
+
+        $this->data = $dataStore->load();
+    }
+
+    public function reset()
+    {
+        $this->data = array();
+        $files = glob($this->directory . 'arp-*');
+        foreach ($files as $file) {
+            unlink($file);
+        }
+        return $this;
+    }
+
+    public function registerSp($name, $entityId, $acsLocation, $certData = '')
+    {
+        $this->data[$entityId] = array(
+            'workflowState' => 'prodaccepted',
+            'entityId'      => $entityId,
+            'name:en' => $name,
+            'name:nl' => $name,
+            'displayName:en' => $name,
+            'displayName:nl' => $name,
+            'AssertionConsumerService:0:Binding'  => SAML2_Const::BINDING_HTTP_POST,
+            'AssertionConsumerService:0:Location' => $acsLocation,
+        );
+        if (!empty($certData)) {
+            $this->data[$entityId]['certData'] = $certData;
+        }
+        return $this;
+    }
+
+    public function registerIdp($name, $entityId, $ssoLocation, $certData = '')
+    {
+        $this->data[$entityId] = array(
+            'workflowState' => 'prodaccepted',
+            'entityId'      => $entityId,
+            'name:en' => $name,
+            'name:nl' => $name,
+            'displayName:en' => $name,
+            'displayName:nl' => $name,
+            'SingleSignOnService:0:Binding'  => SAML2_Const::BINDING_HTTP_POST,
+            'SingleSignOnService:0:Location' => $ssoLocation,
+            'SingleSignOnService:1:Binding'  => SAML2_Const::BINDING_HTTP_REDIRECT,
+            'SingleSignOnService:1:Location' => $ssoLocation,
+        );
+        if (!empty($certData)) {
+            $this->data[$entityId]['certData'] = $certData;
+        }
+        return $this;
+    }
+
+    public function move($fromEntityId, $toEntityId)
+    {
+        $this->data[$toEntityId] = $this->data[$fromEntityId];
+        $this->remove($fromEntityId);
+
+        $this->data[$toEntityId]['entityId'] = $toEntityId;
+
+        return $this;
+    }
+
+    public function remove($entityId)
+    {
+        unset($this->data[$entityId]);
+        return $this;
+    }
+
+    public function setEntitySsoLocation($entityId, $ssoLocation)
+    {
+        $this->data[$entityId]['SingleSignOnService:0:Location'] = $ssoLocation;
+        return $this;
+    }
+
+    public function setEntityAcsLocation($entityId, $acsLocation)
+    {
+        $this->data[$entityId]['AssertionConsumerService:0:Location'] = $acsLocation;
+        return $this;
+    }
+
+    public function setEntityNoConsent($entityId)
+    {
+        $this->data[$entityId]['coin:no_consent_required'] = true;
+        return $this;
+    }
+
+    public function setEntityWantsSignature($entityId)
+    {
+        $this->data[$entityId]['redirect.sign'] = true;
+        return $this;
+    }
+
+    public function setEntityTrustedProxy($entityId)
+    {
+        $this->data[$entityId]['coin:trusted_proxy'] = true;
+        return $this;
+    }
+
+    public function setEntityManipulation($entityId, $manipulation)
+    {
+        $this->data[$entityId]['manipulation'] = $manipulation;
+        return $this;
+    }
+
+    public function setEntityNameIdFormatUnspecified($entityId)
+    {
+        $this->data[$entityId]['NameIDFormat'] = SAML2_Const::NAMEID_UNSPECIFIED;
+        return $this;
+    }
+
+    public function addSpsFromJsonExport($spsConfigExportUrl)
+    {
+        $this->addEntitiesFromJsonConfigExport($spsConfigExportUrl);
+        return $this;
+    }
+
+    public function addIdpsFromJsonExport($idpsConfigExportUrl)
+    {
+        $this->addEntitiesFromJsonConfigExport($idpsConfigExportUrl);
+        return $this;
+    }
+
+    /**
+     * @param $configExportUrl
+     * @param int $type
+     * @SuppressWarnings(PMD)
+     */
+    protected function addEntitiesFromJsonConfigExport($configExportUrl, $type = self::TYPE_SP)
+    {
+        echo "Downloading ServiceRegistry configuration from: '{$configExportUrl}'..." . PHP_EOL;
+        $data = file_get_contents($configExportUrl);
+        if (!$data) {
+            throw new \RuntimeException('Unable to get data from: ' . $configExportUrl);
+        }
+        $entities = json_decode($data, true);
+        if ($entities === false) {
+            throw new \RuntimeException('Unable to decode json: ' . $data);
+        }
+
+        foreach ($entities as $entity) {
+            $entity = $this->flattenArray($entity);
+            $entity['workflowState'] = 'prodaccepted';
+
+            $entityId = $entity['entityid'];
+
+            $this->data[$entityId] = $entity;
+
+            if (!empty($entity['allowedEntities'])) {
+                $this->whitelist($entityId);
+
+                foreach ($entity['allowedEntities'] as $allowedEntityId) {
+                    if ($type === self::TYPE_SP) {
+                        $this->allow($entityId, $allowedEntityId);
+                    } else {
+                        $this->allow($allowedEntityId, $entityId);
+                    }
+                }
+            }
+
+            if (!empty($entity['blockedEntities'])) {
+                $this->blacklist($entityId);
+                foreach ($entity['blockedEntities'] as $blockedEntityId) {
+                    $this->block($entityId, $blockedEntityId);
+                    if ($type === self::TYPE_SP) {
+                        $this->block($entityId, $blockedEntityId);
+                    } else {
+                        $this->block($blockedEntityId, $entityId);
+                    }
+                }
+            }
+        }
+    }
+
+    protected function flattenArray(array $array, array $newArray = array(), $prefix = false)
+    {
+        foreach ($array as $name => $value) {
+            if (is_array($value)) {
+                $newArray = $this->flattenArray($value, $newArray, $prefix . $name . ':');
+            } else {
+                $newArray[$prefix . $name] = $value;
+            }
+        }
+        return $newArray;
+    }
+
+    public function blacklist($entityId)
+    {
+        $this->fileFlags->off('whitelisted-' . md5($entityId), $entityId);
+        return $this;
+    }
+
+    public function whitelist($entityId)
+    {
+        $this->fileFlags->on('whitelisted-' . md5($entityId), $entityId);
+        return $this;
+    }
+
+    public function allow($spEntityId, $idpEntityId)
+    {
+        $this->fileFlags->off('connection-forbidden-' . md5($spEntityId) . '-' . md5($idpEntityId));
+        $this->fileFlags->on(
+            'connection-allowed-' . md5($spEntityId) . '-' . md5($idpEntityId),
+            $spEntityId . ' - ' . $idpEntityId
+        );
+        return $this;
+    }
+
+    public function block($spEntityId, $idpEntityId)
+    {
+        $this->fileFlags->off('connection-allowed-' . md5($spEntityId) . '-' . md5($idpEntityId));
+        $this->fileFlags->on(
+            'connection-forbidden-' . md5($spEntityId) . '-' . md5($idpEntityId),
+            $spEntityId . ' - ' . $idpEntityId
+        );
+        return $this;
+    }
+
+    public function allowNoAttributeValues($entityId)
+    {
+        $this->data[$entityId]['arp'] = array();
+
+        return $this;
+    }
+
+    public function allowAttributeValue($entityId, $arpAttribute, $attributeValue)
+    {
+        if (!isset($this->data[$entityId]['arp'])) {
+            $this->data[$entityId]['arp'] = array();
+        }
+
+        // Save allowed value
+        if (!isset($this->data[$entityId]['arp'][$arpAttribute])) {
+            $this->data[$entityId]['arp'][$arpAttribute] = array();
+        }
+        $this->data[$entityId]['arp'][$arpAttribute][] = $attributeValue;
+
+        return $this;
+    }
+
+    public function setWorkflowState($entityId, $workflowState)
+    {
+        $this->data[$entityId]['workflowState'] = $workflowState;
+
+        return $this;
+    }
+
+    public function save()
+    {
+        $this->fixture->save($this->data);
+    }
+
+    public function __destruct()
+    {
+        $this->save();
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/SuperGlobalsFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/SuperGlobalsFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
+
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore;
+
+class SuperGlobalsFixture
+{
+    const SERVER = 'SERVER';
+
+    protected $fixture;
+    protected $data = array();
+
+    public function __construct(JsonDataStore $fixture)
+    {
+        $this->fixture = $fixture;
+        $this->data = $this->fixture->load();
+    }
+
+    public function getAll()
+    {
+        return $this->data;
+    }
+
+    public function get($superGlobal)
+    {
+        return $this->data[$superGlobal];
+    }
+
+    public function set($superGlobal, $name, $value)
+    {
+        if (!isset($this->data[$superGlobal])) {
+            $this->data[$superGlobal] = array();
+        }
+
+        $this->data[$superGlobal][$name] = $value;
+    }
+
+    public function __destruct()
+    {
+        $this->fixture->save($this->data);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/TimeFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/TimeFixture.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
+
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore;
+
+class TimeFixture
+{
+    protected $fixture;
+    protected $time;
+
+    public function __construct(JsonDataStore $fixture)
+    {
+        $this->fixture = $fixture;
+
+        $this->load();
+    }
+
+    protected function load()
+    {
+        $time = $this->fixture->load(false);
+        if ($time === false) {
+            return;
+        }
+
+        $this->time = $time;
+    }
+
+    public function get()
+    {
+        if (!isset($this->time)) {
+            return time();
+        }
+
+        return (int) $this->time;
+    }
+
+    public function set($time)
+    {
+        $this->time = (string) (int) $time;
+    }
+
+    public function __destruct()
+    {
+        if (!isset($this->time)) {
+            return;
+        }
+
+        $this->fixture->save($this->time);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/EntityRegistry.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/EntityRegistry.php
@@ -2,7 +2,7 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Mock;
 
-use OpenConext\Component\EngineBlockFixtures\DataStore\SerializedDataStore;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\SerializedDataStore;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
 class EntityRegistry extends ParameterBag

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/mocks.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/mocks.yml
@@ -19,9 +19,9 @@ services:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Saml2\ResponseFactory
 
     engineblock.mock_entities.data_store.mock_idps:
-        class: OpenConext\Component\EngineBlockFixtures\DataStore\SerializedDataStore
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\SerializedDataStore
         arguments: ['%idp_fixture_file%']
 
     engineblock.mock_entities.data_store.mock_sps:
-        class: OpenConext\Component\EngineBlockFixtures\DataStore\SerializedDataStore
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\SerializedDataStore
         arguments: ['%sp_fixture_file%']

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
@@ -48,43 +48,43 @@ services:
 
     #region Fixtures
     engineblock.functional_testing.fixture.service_registry:
-        class: OpenConext\Component\EngineBlockFixtures\ServiceRegistryFixture
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\ServiceRegistryFixture
         arguments:
             - '@engineblock.functional_testing.data_store.service_registry'
             - '@engineblock.functional_testing.data_store.service_registry_flags'
             - '%engineblock.functional_testing.service_registry_data_store.dir%'
 
     engineblock.functional_testing.fixture.id:
-        class: OpenConext\Component\EngineBlockFixtures\IdFixture
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture
         arguments: ['@engineblock.functional_testing.data_store.id']
 
     engineblock.functional_testing.fixture.time:
-        class: OpenConext\Component\EngineBlockFixtures\TimeFixture
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\TimeFixture
         arguments: ['@engineblock.functional_testing.data_store.time']
 
     engineblock.functional_testing.fixture.super_globals:
-        class: OpenConext\Component\EngineBlockFixtures\SuperGlobalsFixture
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\SuperGlobalsFixture
         arguments: ['@engineblock.functional_testing.data_store.super_globals']
     #endregion Fixtures
 
     #region Data Stores
     engineblock.functional_testing.data_store.service_registry:
-        class: OpenConext\Component\EngineBlockFixtures\DataStore\JsonDataStore
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore
         arguments: ['%engineblock.functional_testing.service_registry_data_store.file%']
 
     engineblock.functional_testing.data_store.service_registry_flags:
-        class: OpenConext\Component\EngineBlockFixtures\DataStore\FileFlags
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\FileFlags
         arguments: ['%engineblock.functional_testing.service_registry_data_store.dir%']
 
     engineblock.functional_testing.data_store.id:
-        class: OpenConext\Component\EngineBlockFixtures\DataStore\SerializedDataStore
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\SerializedDataStore
         arguments: ['%engineblock.functional_testing.id_data_store.file%']
 
     engineblock.functional_testing.data_store.time:
-        class: OpenConext\Component\EngineBlockFixtures\DataStore\JsonDataStore
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore
         arguments: ['%engineblock.functional_testing.time_data_store.file%']
 
     engineblock.functional_testing.data_store.super_globals:
-        class: OpenConext\Component\EngineBlockFixtures\DataStore\JsonDataStore
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore
         arguments: ['%engineblock.functional_testing.super_globals_data_store.file%']
     #endregion Data Stores

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Service/EngineBlock.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Service/EngineBlock.php
@@ -2,10 +2,10 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Service;
 
-use OpenConext\Component\EngineBlockFixtures\IdFixture;
-use OpenConext\Component\EngineBlockFixtures\IdFrame;
-use OpenConext\Component\EngineBlockFixtures\SuperGlobalsFixture;
-use OpenConext\Component\EngineBlockFixtures\TimeFixture;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFrame;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\SuperGlobalsFixture;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\TimeFixture;
 
 /**
  * Class EngineBlock

--- a/tests/OpenConext/EngineBlock/Driver/File/FileStorageDriverTest.php
+++ b/tests/OpenConext/EngineBlock/Driver/File/FileStorageDriverTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace OpenConext\EngineBlock\Driver\File;
+
+use Mockery as m;
+use PHPUnit_Framework_TestCase as UnitTest;
+
+class FileStorageDriverTest extends UnitTest
+{
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notStringOrEmptyString
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidArgumentException
+     *
+     * @param mixed $notStringOrEmptyString
+     */
+    public function filepath_must_be_a_non_empty_string($notStringOrEmptyString)
+    {
+        new FileStorageDriver(m::mock('OpenConext\EngineBlock\Driver\File\FileHandler'), $notStringOrEmptyString);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notString
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidArgumentException
+     *
+     * @param mixed $notString
+     */
+    public function data_to_save_must_be_a_string($notString)
+    {
+        $storage = new FileStorageDriver(m::mock('OpenConext\EngineBlock\Driver\File\FileHandler'), '/some/path');
+
+        $storage->save($notString);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     */
+    public function data_is_written_unmodified_to_file()
+    {
+        $data     = 'FooBarBaz';
+        $filePath = '/some/file/path';
+
+        $fileHandlerMock = m::mock('OpenConext\EngineBlock\Driver\File\FileHandler');
+        $fileHandlerMock->shouldReceive('writeTo')->withArgs(array($data, $filePath));
+
+        $storage = new FileStorageDriver($fileHandlerMock, $filePath);
+        $storage->save($data);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     */
+    public function data_is_read_from_file_and_returned_unmodified()
+    {
+        $data = 'FooBarBaz';
+        $filePath = '/some/file/path';
+
+        $fileHandlerMock = m::mock('OpenConext\EngineBlock\Driver\File\FileHandler');
+        $fileHandlerMock->shouldReceive('readFrom')->withArgs(array($filePath))->andReturn($data);
+
+        $storage = new FileStorageDriver($fileHandlerMock, $filePath);
+        $read = $storage->load();
+
+        $this->assertEquals($data, $read);
+    }
+}

--- a/tests/OpenConext/EngineBlock/Driver/File/FilesystemAdapterTest.php
+++ b/tests/OpenConext/EngineBlock/Driver/File/FilesystemAdapterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace OpenConext\EngineBlock\Driver\File;
+
+use Exception;
+use Mockery as m;
+use PHPUnit_Framework_TestCase as UnitTest;
+
+class FilesystemAdapterTest extends UnitTest
+{
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notString
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidArgumentException
+     *
+     * @param mixed $nonString
+     */
+    public function data_to_write_to_file_must_be_a_string($nonString)
+    {
+        $filesystemAdapter = new FilesystemAdapter(m::mock('\Symfony\Component\Filesystem\Filesystem'));
+
+        $filesystemAdapter->writeTo($nonString, '/some/path');
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notStringOrEmptyString
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidArgumentException
+     *
+     * @param mixed $nonStringOrEmtpyString
+     */
+    public function in_order_to_write_given_filepath_must_be_a_string($nonStringOrEmtpyString)
+    {
+        $filesystemAdapter = new FilesystemAdapter(m::mock('\Symfony\Component\Filesystem\Filesystem'));
+
+        $filesystemAdapter->writeTo('data-to-write', $nonStringOrEmtpyString);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     */
+    public function an_exception_thrown_by_filesystem_when_writing_is_converted_to_an_engineblock_exception()
+    {
+        $filesystemMock = m::mock('\Symfony\Component\Filesystem\Filesystem');
+        $filesystemMock->shouldReceive('dumpFile')->andThrow('Symfony\Component\Filesystem\Exception\IOException');
+
+        $filesystemAdapter = new FilesystemAdapter($filesystemMock);
+
+        try {
+            $filesystemAdapter->writeTo('data-to-write', '/some/path');
+        } catch (Exception $exception) {
+            $this->assertInstanceOf('\OpenConext\EngineBlock\Exception\RuntimeException', $exception);
+            $this->assertInstanceOf('Symfony\Component\Filesystem\Exception\IOException', $exception->getPrevious());
+        }
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     *
+     * @expectedException \OpenConext\EngineBlock\Exception\RuntimeException
+     */
+    public function attempting_to_read_data_from_a_non_existent_file_fails()
+    {
+        $filesystemMock = m::mock('\Symfony\Component\Filesystem\Filesystem');
+        $filesystemMock->shouldReceive('exists')->andReturn(false);
+
+        $filesystemAdapter = new FilesystemAdapter($filesystemMock);
+
+        $filesystemAdapter->readFrom('/does/not/exist');
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     *
+     * @expectedException \OpenConext\EngineBlock\Exception\RuntimeException
+     */
+    public function attempting_to_read_data_from_a_file_that_is_not_readable_fails()
+    {
+        $filesystemMock = m::mock('\Symfony\Component\Filesystem\Filesystem');
+        $filesystemMock->shouldReceive('exists')->andReturn(true);
+
+        $filesystemAdapter = new FilesystemAdapter($filesystemMock);
+
+        $filesystemAdapter->readFrom('/this/is/not/readable');
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Driver
+     *
+     * @expectedException \OpenConext\EngineBlock\Exception\RuntimeException
+     */
+    public function data_is_returned_without_modification()
+    {
+        $data = json_encode(array('foo' => array('bar' => 'quuz', 'baz' => 1.24)));
+
+        $resource = fopen('php://memory', 'w');
+        fwrite($resource, $data);
+
+        $filesystemMock = m::mock('\Symfony\Component\Filesystem\Filesystem');
+        $filesystemMock->shouldReceive('exists')->andReturn(true);
+
+        $filesystemAdapter = new FilesystemAdapter($filesystemMock);
+        $read = $filesystemAdapter->readFrom('php://memory');
+
+        fclose($resource);
+
+        $this->assertEquals($data, $read);
+    }
+}

--- a/tests/OpenConext/EngineBlock/Service/FeaturesServiceTest.php
+++ b/tests/OpenConext/EngineBlock/Service/FeaturesServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace OpenConext\EngineBlock\Service;
+
+use PHPUnit_Framework_TestCase as UnitTest;
+
+class FeaturesServiceTest extends UnitTest
+{
+    /**
+     * @test
+     * @group EngineBlock
+     * @group FeatureToggle
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notBoolean
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidArgumentException
+     *
+     * @param mixed $notBoolean
+     */
+    public function metadata_push_enabled_is_required_to_be_a_boolean($notBoolean)
+    {
+        new FeaturesService($notBoolean, true, true);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group FeatureToggle
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notBoolean
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidArgumentException
+     *
+     * @param mixed $notBoolean
+     */
+    public function consent_listing_enabled_is_required_to_be_a_boolean($notBoolean)
+    {
+        new FeaturesService(true, $notBoolean, true);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group FeatureToggle
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notBoolean
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidArgumentException
+     *
+     * @param mixed $notBoolean
+     */
+    public function metadata_api_enabled_is_required_to_be_a_boolean($notBoolean)
+    {
+        new FeaturesService(true, true, $notBoolean);
+    }
+
+    /**
+     * @test
+     * @group        EngineBlock
+     * @group        FeatureToggle
+     */
+    public function features_can_be_configured_independently()
+    {
+        $service = new FeaturesService(true, false, true);
+
+        $this->assertTrue($service->metadataPushIsEnabled());
+        $this->assertFalse($service->consentListingIsEnabled());
+        $this->assertTrue($service->metadataApiIsEnabled());
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -18,11 +18,10 @@
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">../src</directory>
             <directory suffix=".php">../library</directory>
-            <file>/path/to/file</file>
         </whitelist>
     </filter>
 
     <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
     </listeners>
 </phpunit>


### PR DESCRIPTION
Removes reliance on [external library][1] that is critical for the functional tests.

- [X] embed fixture code
- [ ] ~~replace file handling with file driver~~ don't fix it if it aint broken, low prio target.
- [X] Ensure IdFrame constants are part of EngineBlock as they are used throughout
- [ ] ~~Simplify datastores~~ don't fix it if it aint broken, low prio target.

More information with regards to the skipped elements can be found [here][2]

[1]: https://github.com/OpenConext/OpenConext-engineblock-fixtures
[2]: https://www.pivotaltracker.com/story/show/113823321