### PR TITLE
Fix engineblock fixtures dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "incenteev/composer-parameter-handler": "~2.0",
         "openconext/saml-value-object": "^1.1",
         "symfony/monolog-bundle": "~2.4",
-        "beberlei/assert": "^2.4"
+        "beberlei/assert": "^2.4",
+        "openconext/engineblock-fixtures": "^0.5.2"
     },
     "require-dev": {
         "phake/phake": "2.1",
@@ -43,7 +44,6 @@
         "behat/mink-extension": "~1.3",
         "behat/mink-goutte-driver": "~1.0",
         "behat/symfony2-extension": "~1.1",
-        "openconext/engineblock-fixtures": "^0.5.2",
         "phpmd/phpmd": "^2.3",
         "squizlabs/php_codesniffer": "^2.5",
         "sebastian/phpcpd": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "212d915b8298422e36f7c95c2fd91fb0",
-    "content-hash": "e6aa7a8cc9d897a725e94dd6664f6df0",
+    "hash": "0492cdf951f05e8691f085d765b8d8e8",
+    "content-hash": "9d9efb21acc214a823f4c82407cd16e5",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -906,6 +906,36 @@
             "description": "Minify is a PHP5 app that helps you follow several rules for client-side performance. It combines multiple CSS or Javascript files, removes unnecessary whitespace and comments, and serves them with gzip encoding and optimal client-side cache headers",
             "homepage": "http://code.google.com/p/minify/",
             "time": "2014-10-30 22:58:02"
+        },
+        {
+            "name": "openconext/engineblock-fixtures",
+            "version": "0.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OpenConext/OpenConext-engineblock-fixtures.git",
+                "reference": "a990f6cead9067a21662ec4bb2ba2e76d4f95498"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OpenConext/OpenConext-engineblock-fixtures/zipball/a990f6cead9067a21662ec4bb2ba2e76d4f95498",
+                "reference": "a990f6cead9067a21662ec4bb2ba2e76d4f95498",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OpenConext\\Component\\EngineBlockFixtures\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "OpenConext Component for EngineBlock Fixtures",
+            "time": "2016-01-19 10:03:57"
         },
         {
             "name": "openconext/engineblock-metadata",
@@ -2646,36 +2676,6 @@
             "time": "2015-04-02 19:54:00"
         },
         {
-            "name": "openconext/engineblock-fixtures",
-            "version": "0.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/OpenConext/OpenConext-engineblock-fixtures.git",
-                "reference": "a990f6cead9067a21662ec4bb2ba2e76d4f95498"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/OpenConext-engineblock-fixtures/zipball/a990f6cead9067a21662ec4bb2ba2e76d4f95498",
-                "reference": "a990f6cead9067a21662ec4bb2ba2e76d4f95498",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "OpenConext\\Component\\EngineBlockFixtures\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "OpenConext Component for EngineBlock Fixtures",
-            "time": "2016-01-19 10:03:57"
-        },
-        {
             "name": "pdepend/pdepend",
             "version": "2.2.2",
             "source": {
@@ -2856,7 +2856,7 @@
                     "name": "Manuel Pichler",
                     "email": "github@manuel-pichler.de",
                     "homepage": "https://github.com/manuelpichler",
-                    "role": "Project Founder"
+                    "role": "Project founder"
                 },
                 {
                     "name": "Other contributors",


### PR DESCRIPTION
As Engineblock uses parts of EngineBlockFixtures in non-test code,
it should not be a development-only dependency and it should be
shipped on release.

This dependency should be fixed in the future; production code
typically should not depend on EngineBlockFixtures.