### PR TITLE
Fix missing port breakage in LDAP library

### DIFF
--- a/database/patch/patch-0010.php
+++ b/database/patch/patch-0010.php
@@ -14,6 +14,7 @@ $ldapConfig = EngineBlock_ApplicationSingleton::getInstance()->getConfiguration(
 
 $ldapOptions = array(
     'host'                 => $ldapConfig->host,
+    'port'                 => $ldapConfig->port,
     'useSsl'               => $ldapConfig->useSsl,
     'username'             => $ldapConfig->userName,
     'password'             => $ldapConfig->password,

--- a/docs/example.engineblock.ini
+++ b/docs/example.engineblock.ini
@@ -14,6 +14,7 @@ debug = true
 email.idpDebugging.to.address = example@example.edu
 
 ldap.host = ldap.demo.openconext.org
+ldap.port = 389
 ldap.userName = "cn=engine,dc=openconext,dc=nl"
 ldap.password = "EXAMPLE LDAP PASSWORD"
 

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -340,6 +340,7 @@ class EngineBlock_Application_DiContainer extends Pimple implements ContainerInt
 
             $ldapOptions = array(
                 'host' => $ldapConfig->host,
+                'port' => $ldapConfig->port,
                 'useSsl' => $ldapConfig->useSsl,
                 'username' => $ldapConfig->userName,
                 'password' => $ldapConfig->password,


### PR DESCRIPTION
Zend_Ldap breaks on some implementations if ldap port is missing.