### PR TITLE
Add prepare-env composer command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,11 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
+        ],
+        "prepare-env": [
+            "bin/composer/dump-required-ini-params.sh",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache"
         ]
     },
     "autoload": {


### PR DESCRIPTION
This allows to build the correct configuration on all local envs
so that the application is in a bootable state based on the
correct configuration without having to ship the configuration in
a tarball.

can be invoked with `./bin/composer.phar prepare-env`