### PR TITLE
Prefix functional testing routes to prevent matching conflicts

### DIFF
--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -14,8 +14,9 @@ _errors:
     resource: "@TwigBundle/Resources/config/routing/errors.xml"
     prefix:   /_error
 
-_functional_testing:
-    resource: routing_test.yml
-
 _main:
     resource: routing.yml
+
+_functional_testing:
+    prefix:   functional-testing
+    resource: @OpenConextEngineBlockFunctionalTestingBundle/Resources/config/routing.yml

--- a/app/config/routing_test.yml
+++ b/app/config/routing_test.yml
@@ -1,5 +1,6 @@
-functional_tests:
-    resource: @OpenConextEngineBlockFunctionalTestingBundle/Resources/config/routing.yml
-
 _main:
     resource: routing.yml
+
+functional_tests:
+    prefix:   functional-testing
+    resource: @OpenConextEngineBlockFunctionalTestingBundle/Resources/config/routing.yml

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Bindings.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Bindings.feature
@@ -18,7 +18,7 @@ Feature:
       And I pass through the IdP
       And I give my consent
       And I pass through EngineBlock
-     Then the url should match "Dummy%20SP/acs"
+     Then the url should match "functional-testing/Dummy%20SP/acs"
 
   Scenario: EngineBlock accepts AuthnRequests using HTTP-Redirect binding
     Given the SP uses the HTTP Redirect Binding
@@ -27,7 +27,7 @@ Feature:
       And I pass through the IdP
       And I give my consent
       And I pass through EngineBlock
-     Then the url should match "Dummy%20SP/acs"
+     Then the url should match "functional-testing/Dummy%20SP/acs"
 
   Scenario: EngineBlock accepts Signed AuthnRequests using HTTP-POST binding
     Given the SP uses the HTTP POST Binding
@@ -38,4 +38,4 @@ Feature:
       And I pass through the IdP
       And I give my consent
       And I pass through EngineBlock
-     Then the url should match "Dummy%20SP/acs"
+     Then the url should match "functional-testing/Dummy%20SP/acs"


### PR DESCRIPTION
The mock IdP route was defined in such a way that
it matched with the metadata route of engineblock itself.
By changing the defition order (first defined is first tried
for match) as well as prefixing the Functional Test URLs this
conflict is resolved.