### PR TITLE
Pass $response by reference to the filter commands.

### DIFF
--- a/library/EngineBlock/Corto/Filter/Abstract.php
+++ b/library/EngineBlock/Corto/Filter/Abstract.php
@@ -30,7 +30,7 @@ abstract class EngineBlock_Corto_Filter_Abstract
      * @throws Exception
      */
     public function filter(
-        EngineBlock_Saml2_ResponseAnnotationDecorator $response,
+        EngineBlock_Saml2_ResponseAnnotationDecorator &$response,
         array &$responseAttributes,
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request,
         ServiceProvider $serviceProvider,


### PR DESCRIPTION
This explains the buggy behaviour described in #303 and restores that behaviour in PHP 5.4 and up.