### PR TITLE
Closes an XSS vulnerability in the locale switcher

### DIFF
--- a/app/Resources/views/layouts/scripts/default.phtml
+++ b/app/Resources/views/layouts/scripts/default.phtml
@@ -59,7 +59,7 @@
         <?php if (strtoupper($_SERVER['REQUEST_METHOD']) === 'POST'): ?>
           <form method="post" action="">
             <?php foreach ($_POST as $key => $value): ?>
-              <input type="hidden" name="<?= EngineBlock_View::htmlSpecialCharsText($key) ?>" value="<?= EngineBlock_View::htmlSpecialCharsText($value) ?>">
+              <input type="hidden" name="<?= EngineBlock_View::htmlSpecialCharsAttributeValue($key) ?>" value="<?= EngineBlock_View::htmlSpecialCharsAttributeValue($value) ?>">
             <?php endforeach ?>
             <ul class="comp-language">
               <li>

--- a/theme/material/templates/layouts/scripts/default.phtml
+++ b/theme/material/templates/layouts/scripts/default.phtml
@@ -58,7 +58,7 @@
         <?php if (strtoupper($_SERVER['REQUEST_METHOD']) === 'POST'): ?>
           <form method="post" action="">
             <?php foreach ($_POST as $key => $value): ?>
-              <input type="hidden" name="<?= EngineBlock_View::htmlSpecialCharsText($key) ?>" value="<?= EngineBlock_View::htmlSpecialCharsText($value) ?>">
+              <input type="hidden" name="<?= EngineBlock_View::htmlSpecialCharsAttributeValue($key) ?>" value="<?= EngineBlock_View::htmlSpecialCharsAttributeValue($value) ?>">
             <?php endforeach ?>
             <ul class="comp-language">
               <li>


### PR DESCRIPTION
As reported:

> Sending a POST request to several EB URLs with a crafted `sp-entity-id`
or `lang` parameter allows for cross site scripting via the resulting
language switch.
>
> Examples:
POST `/authentication/idp/metadata/key:20140505`  with parameters
`[sp-entity-id=509" src="http://www.example.com/exploit509.js]`.
> POST `/authentication/idp/` with parameters `[lang=509"
src="http://www.example.com/exploit509.js]`

Credits to Nessus for identifying the issue.

Issue was caused by incorrectly escaping variables.