### PR TITLE
Document that PHP LDAP module is not optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See the [UPGRADING.md](UPGRADING.md) file
 * Linux
 * Apache
 * PHP 5.6:
-    - ldap (optional)
+    - ldap
     - libxml
     - mcrypt
 * MySQL > 5.x with settings:


### PR DESCRIPTION
Even when not using LDAP, current code still needs PHP LDAP module present, in order to pass a check for this module.