### PR TITLE
Remove hardcoded Strict-Transport-Security header.

### DIFF
--- a/library/EngineBlock/Application/Bootstrapper.php
+++ b/library/EngineBlock/Application/Bootstrapper.php
@@ -123,7 +123,6 @@ class EngineBlock_Application_Bootstrapper
         $this->_application->setHttpRequest($httpRequest);
 
         $response = new EngineBlock_Http_Response();
-        $response->setHeader('Strict-Transport-Security', 'max-age=15768000; includeSubDomains');
         // workaround, P3P is needed to support iframes like iframe gadgets in portals
         $response->setHeader('P3P', self::P3P_HEADER);
         $this->_application->setHttpResponse($response);


### PR DESCRIPTION
We want to control this per application in the webserver, which seems a more appropriate place to handle this kind of configuration. Its settings are not easily changed when it's hardcoded.