### PR TITLE
Correct dumping trusted proxy ips configuration

### DIFF
--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -31,7 +31,7 @@ if (!is_array($trustedProxies)) {
 $ymlContent = array(
     'parameters' => array(
         'domain'                                                  => $config->get('base_domain'),
-        'trusted_proxies'                                         => $config->get('trustedProxyIps', array())->toArray(),
+        'trusted_proxies'                                         => $trustedProxies,
         'api.users.janus.username'                                => $config->get('engineApi.users.janus.username'),
         'api.users.janus.password'                                => $config->get('engineApi.users.janus.password'),
         'api.users.profile.username'                              => $config->get('engineApi.users.profile.username'),


### PR DESCRIPTION
This corrects the oversight when fixing the issue in #331, as reported by @tvdijen in the same PR.