### PR TITLE
Do not send referrer header on POST to SP.

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Proxy/form.phtml
+++ b/theme/material/templates/modules/Authentication/View/Proxy/form.phtml
@@ -24,6 +24,7 @@ $layout->title = $layout->title.' - '.$this->t('post_data');
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="robots" content="noindex, nofollow"/>
+    <meta name="referrer" content="no-referrer"/>
     <meta content="ie=edge,chrome=1" http-equiv="x-ua-compatible">
     <meta content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width" name="viewport">
     <meta content="translucent-black" name="apple-mobile-web-app-status-bar-style">


### PR DESCRIPTION
Some SP's claim their (e.g. Piwik) stats are 'polluted' by referrers from
engine.surfconext.nl when people have logged into the SP, which obscure
the 'real' external referrer for this user.

We might not have much to gain by sending this header. So we can avoid
doing so, helping these SP's at no cost to us (?).

NB: this only modifies the source theme, theme still needs to be compiled.