### PR TITLE
Fix missing (mandatory) setting

### DIFF
--- a/docs/example.engineblock.ini
+++ b/docs/example.engineblock.ini
@@ -1,3 +1,5 @@
+base_domain = demo.openconext.org
+
 auth.simplesamlphp.idp.entityId = https://engine.demo.openconext.org/authentication/idp/metadata
 auth.simplesamlphp.idp.location = https://engine.demo.openconext.org/authentication/idp/single-sign-on
 


### PR DESCRIPTION
Without any value for the base_domain setting, the 'domain' parameter in app/config/ini_parameters.yml will render to 'null' when running bin/composer.phar
More info can be found in #342