### PR TITLE
Add new style database-configuration to docs

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -146,9 +146,9 @@ ldap.baseDn             = "dc=surfconext,dc=nl"
 ;;;;;;;;;;;; DATABASE SETTINGS ;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-database.host = db.demo.openconext.org
+database.host = "localhost"
 database.port = 3306
-database.password = ""
+database.password = "secret"
 database.user = "engineblock"
 database.dbname = "engineblock"
 

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -146,23 +146,11 @@ ldap.baseDn             = "dc=surfconext,dc=nl"
 ;;;;;;;;;;;; DATABASE SETTINGS ;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; Database masters are servers that can used for reading & writing
-; Database slaves are servers that can used only for reading
-; Define your servers on database.servername
-; then add them to the proper pool, like database.masters[] = "servername"
-; For DSN syntax, see PDO documentation
-; http://www.php.net/manual/en/pdo.construct.php
-database.master1.dsn = ""
-database.master1.user = "engineblock"
-database.master1.password = ""
-;database.master1.use_persistent = true
-;database.masters[] = "master1"
-
-database.slave1.dsn = ""
-database.slave1.user = "engineblock"
-database.slave1.password = ""
-;database.slave1.use_persistent = true
-;database.slaves[] = "slave1"
+database.host = db.demo.openconext.org
+database.port = 3306
+database.password = ""
+database.user = "engineblock"
+database.dbname = "engineblock"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; SERVICEREGISTRY SETTINGS ;;;;;;;;;;

--- a/docs/example.engineblock.ini
+++ b/docs/example.engineblock.ini
@@ -5,11 +5,11 @@ auth.simplesamlphp.idp.location = https://engine.demo.openconext.org/authenticat
 
 cookie.lang.domain = .demo.openconext.org
 
-database.master1.dsn = "mysql:host=db.demo.opnenconext.org;dbname=engineblock"
-database.master1.password = "EXAMPLE PASSWORD"
-database.master1.user = "engineblock"
-database.masters[] = master1
-database.slaves[] = master1
+database.host = db.demo.openconext.org
+database.port = 3306
+database.password = "EXAMPLE DATABASE PASSWORD"
+database.user = "engineblock"
+database.dbname = "engineblock"
 
 debug = true
 


### PR DESCRIPTION
The example engineblock.ini file contains database-configuration the old style.
When using this file as an example for a manual install, you run into all kinds of database-related errors (like: hostname cannot be null).
This PR should prevent putting manual installers on the wrong track.