### PR TITLE
Fix for when phpsettings are missing in engineblock.ini

### DIFF
--- a/library/EngineBlock/Application/Bootstrapper.php
+++ b/library/EngineBlock/Application/Bootstrapper.php
@@ -136,8 +136,10 @@ class EngineBlock_Application_Bootstrapper
 
     protected function _bootstrapPhpSettings()
     {
-        $settings = $this->_application->getConfiguration()->phpSettings->toArray();
-        $this->_setIniSettings($settings);
+        $settings = $this->_application->getConfiguration()->phpSettings;
+        if (!is_null($settings)) {
+            $this->_setIniSettings($settings->toArray());
+        }
     }
 
     protected function _setIniSettings($settings, $prefix = '')


### PR DESCRIPTION
I ran into a nasty error when I left out the phpsettings from engineblock.ini (since they were already the default in my php.ini)

 PHP Fatal error:  Call to a member function toArray() on null in /apps/OpenConext/engineblock/OpenConext-engineblock-5.1.0/library/EngineBlock/Application/Bootstrapper.php on line 139