### PR TITLE
Test session lost feedback page

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -153,7 +153,6 @@ Feature:
       And I should see "Service Provider:"
       And I should see "Identity Provider:"
 
-
   Scenario: An Identity Provider sends a response without a SHO
     Given the IdP does not send the attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization"
      When I log in at "Dummy SP"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -192,10 +192,18 @@ Feature:
       And I should see "Service Provider:"
 
   @WIP
-  Scenario: The session has been lost
+  Scenario: The session has been lost after passing through EngineBlock
     When I log in at "Dummy SP"
      And I pass through EngineBlock
      And I lose my session
+     And I pass through the IdP
+     And I should see "your session was lost"
+
+  @WIP
+  Scenario: The session has been lost after logging in at the SP
+    When I log in at "Dummy SP"
+     And I lose my session
+     And I pass through EngineBlock
      And I pass through the IdP
      And I should see "your session was lost"
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -191,6 +191,14 @@ Feature:
       And I should see "IP Address:"
       And I should see "Service Provider:"
 
+  @WIP
+  Scenario: The session has been lost
+    When I log in at "Dummy SP"
+     And I pass through EngineBlock
+     And I lose my session
+     And I pass through the IdP
+     And I should see "your session was lost"
+
 #
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a location
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a binding

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -291,4 +291,13 @@ class EngineBlockContext extends AbstractSubContext
             $this->features->clean();
         }
     }
+
+    /**
+     * @Given /^I lose my session$/
+     */
+    public function iLoseMySession()
+    {
+        $session = $this->getMainContext()->getMinkContext()->getSession();
+        $session->restart();
+    }
 }


### PR DESCRIPTION
This adds a functional test verifying that the correct error/feedback page is shown when the session is lost.

### Related
[127716565](https://www.pivotaltracker.com/story/show/127716565)
#295 