### PR TITLE
Replace @-sign in collab person ids for compatibility

### DIFF
--- a/library/EngineBlock/User.php
+++ b/library/EngineBlock/User.php
@@ -90,7 +90,7 @@ class EngineBlock_User
             ));
         }
 
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($this->getUid()),
             new SchacHomeOrganization($this->_attributes[SchacHomeOrganization::URN_MACE][0])
         );

--- a/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
@@ -22,21 +22,6 @@ final class CollabPersonId
     private $collabPersonId;
 
     /**
-     * @param Uid                   $uid
-     * @param SchacHomeOrganization $schacHomeOrganization
-     * @return CollabPersonId
-     */
-    public static function generateFrom(Uid $uid, SchacHomeOrganization $schacHomeOrganization)
-    {
-        $collabPersonId = implode(
-            ':',
-            [self::URN_NAMESPACE, $schacHomeOrganization->getSchacHomeOrganization(), $uid->getUid()]
-        );
-
-        return new self($collabPersonId);
-    }
-
-    /**
      * This method solely exists for compatibility between EB versions and existing SPs.
      * Replacing the @-sign for underscores in collabPersonIds was part of the LDAP module.
      *

--- a/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
@@ -72,7 +72,11 @@ final class CollabPersonId
             self::URN_NAMESPACE,
             sprintf('a CollabPersonId must start with the "%s" namespace', self::URN_NAMESPACE)
         );
-        Assertion::maxLength($collabPersonId, self::MAX_LENGTH, 'CollabPersonId length may not exceed 400 characters');
+        Assertion::maxLength(
+            $collabPersonId,
+            self::MAX_LENGTH,
+            sprintf('CollabPersonId length may not exceed %d characters', self::MAX_LENGTH)
+        );
 
         $this->collabPersonId = $collabPersonId;
     }

--- a/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
@@ -37,6 +37,31 @@ final class CollabPersonId
     }
 
     /**
+     * This method solely exists for compatibility between EB versions and existing SPs.
+     * Replacing the @-sign for underscores in collabPersonIds was part of the LDAP module.
+     *
+     * See: https://www.pivotaltracker.com/story/show/134915765 and
+     * https://github.com/OpenConext/OpenConext-engineblock/commit/e6631acd4c4299329c5c34899de2f3a464975a5a
+     *
+     * @param Uid $uid
+     * @param SchacHomeOrganization $schacHomeOrganization
+     * @return CollabPersonId
+     */
+    public static function generateWithReplacedAtSignFrom(Uid $uid, SchacHomeOrganization $schacHomeOrganization)
+    {
+        $collabPersonId = implode(
+            ':',
+            [
+                self::URN_NAMESPACE,
+                $schacHomeOrganization->getSchacHomeOrganization(),
+                str_replace('@', '_', $uid->getUid()),
+            ]
+        );
+
+        return new self($collabPersonId);
+    }
+
+    /**
      * @param string $collabPersonId
      */
     public function __construct($collabPersonId)

--- a/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
@@ -22,7 +22,7 @@ final class CollabPersonId
     private $collabPersonId;
 
     /**
-     * This method solely exists for compatibility between EB versions and existing SPs.
+     * This method provides compatibility between EB versions and existing SPs.
      * Replacing the @-sign for underscores in collabPersonIds was part of the LDAP module.
      *
      * See: https://www.pivotaltracker.com/story/show/134915765 and

--- a/src/OpenConext/EngineBlockBridge/Authentication/Repository/UserDirectoryAdapter.php
+++ b/src/OpenConext/EngineBlockBridge/Authentication/Repository/UserDirectoryAdapter.php
@@ -85,7 +85,7 @@ class UserDirectoryAdapter
             $schacHomeOrganization = $attributes[SchacHomeOrganization::URN_MACE][0];
 
             $collabPersonUuid      = CollabPersonUuid::generate();
-            $collabPersonId        = CollabPersonId::generateFrom(
+            $collabPersonId        = CollabPersonId::generateWithReplacedAtSignFrom(
                 new Uid($uid),
                 new SchacHomeOrganization($schacHomeOrganization)
             );
@@ -109,7 +109,7 @@ class UserDirectoryAdapter
      */
     public function registerUser($uid, $schacHomeOrganization)
     {
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($uid),
             new SchacHomeOrganization($schacHomeOrganization)
         );

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
@@ -26,7 +26,7 @@ Feature:
     When I give my consent
      And I pass through EngineBlock
     Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
-     And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="nl:surf:test:something"]/saml:AttributeValue["arbitrary-value"]'
+     And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="nl:surf:test:something"]/saml:AttributeValue[text()="arbitrary-value"]'
 
   Scenario: The Service Provider can have the attributes manipulated
     Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
@@ -41,7 +41,7 @@ Feature:
     When I give my consent
      And I pass through EngineBlock
     Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
-     And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue["the-manipulated-value"]'
+     And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text()="the-manipulated-value"]'
 
   Scenario: The Service Provider can have the SubjectID manipulated
     Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulationWithAllManipulationsBeforeConsent.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulationWithAllManipulationsBeforeConsent.feature
@@ -27,7 +27,7 @@ Feature:
     When I give my consent
     And I pass through EngineBlock
     Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
-    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="nl:surf:test:something"]/saml:AttributeValue["arbitrary-value"]'
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="nl:surf:test:something"]/saml:AttributeValue[text()="arbitrary-value"]'
 
   Scenario: The Service Provider can have the attributes manipulated
     Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
@@ -42,7 +42,7 @@ Feature:
     When I give my consent
     And I pass through EngineBlock
     Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
-    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue["the-manipulated-value"]'
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text()="the-manipulated-value"]'
 
   Scenario: The Service Provider can have the SubjectID manipulated
     Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -191,7 +191,6 @@ Feature:
       And I should see "IP Address:"
       And I should see "Service Provider:"
 
-  @WIP
   Scenario: The session has been lost after passing through EngineBlock
     When I log in at "Dummy SP"
      And I pass through EngineBlock
@@ -199,7 +198,6 @@ Feature:
      And I pass through the IdP
      And I should see "your session was lost"
 
-  @WIP
   Scenario: The session has been lost after logging in at the SP
     When I log in at "Dummy SP"
      And I lose my session

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -305,4 +305,20 @@ class MockIdpContext extends AbstractSubContext
 
         $this->mockIdpRegistry->save();
     }
+
+    /**
+     * @Given /^the IdP "([^"]*)" sends attribute "([^"]*)" with value "([^"]*)"$/
+     * @param string $idpName
+     * @param string $attributeName
+     * @param string $attributeValue
+     */
+    public function theIdPSendsAttributeWithValue($idpName, $attributeName, $attributeValue)
+    {
+        /** @var MockIdentityProvider $mockIdp */
+        $mockIdp = $this->mockIdpRegistry->get($idpName);
+
+        $mockIdp->setAttribute($attributeName, [$attributeValue]);
+
+        $this->mockIdpRegistry->save();
+    }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/LdapCompatibility.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/LdapCompatibility.feature
@@ -1,0 +1,35 @@
+Feature:
+  In order to maintain compatibility
+  As Engineblock
+  I want to keep LDAP-related modifications to attributes
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+      And no registered SPs
+      And no registered Idps
+      And an Identity Provider named "Dummy IdP"
+      And a Service Provider named "Dummy SP"
+
+  @WIP
+  Scenario: a collabPersonId is constructed from a uid with its at-signs replaced by underscores when LDAP integration is disabled
+    Given feature "eb.ldap_integration" is disabled
+      And the IdP "Dummy IdP" sends attribute "urn:mace:dir:attribute-def:uid" with value "frits@example.test"
+     When I log in at "Dummy SP"
+      And I pass through EngineBlock
+      And I pass through the IdP
+      And I give my consent
+      And I pass through EngineBlock
+     Then the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text() = "frits@example.test"]'
+      And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:oid:1.3.6.1.4.1.1076.20.40.40.1"]/saml:AttributeValue[text() = "urn:collab:person:engine-test-stand.openconext.org:frits_example.test"]'
+
+  @WIP
+  Scenario: a collabPersonId is constructed from a uid with its at-signs replaced by underscores when LDAP integration is enabled
+    Given feature "eb.ldap_integration" is enabled
+      And the IdP "Dummy IdP" sends attribute "urn:mace:dir:attribute-def:uid" with value "frits@example.test"
+     When I log in at "Dummy SP"
+      And I pass through EngineBlock
+      And I pass through the IdP
+      And I give my consent
+      And I pass through EngineBlock
+     Then the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text() = "frits@example.test"]'
+      And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:oid:1.3.6.1.4.1.1076.20.40.40.1"]/saml:AttributeValue[text() = "urn:collab:person:engine-test-stand.openconext.org:frits_example.test"]'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/FakeUserDirectory.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/FakeUserDirectory.php
@@ -82,7 +82,7 @@ class FakeUserDirectory extends UserDirectoryAdapter
         $schacHomeOrganization = $attributes[SchacHomeOrganization::URN_MACE][0];
 
         $collabPersonUuid = CollabPersonUuid::generate();
-        $collabPersonId   = CollabPersonId::generateFrom(
+        $collabPersonId   = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($uid),
             new SchacHomeOrganization($schacHomeOrganization)
         );
@@ -97,7 +97,7 @@ class FakeUserDirectory extends UserDirectoryAdapter
 
     public function registerUser($uid, $schacHomeOrganization)
     {
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($uid),
             new SchacHomeOrganization($schacHomeOrganization)
         );

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
@@ -212,6 +212,22 @@ class MockIdentityProvider extends AbstractMockEntityRole
         $assertions[0]->setAttributes($newAttributes);
     }
 
+    public function setAttribute($attributeName, array $attributeValues)
+    {
+        $role = $this->getSsoRole();
+
+        /** @var Response $response */
+        $response = $role->Extensions['SAMLResponse'];
+        $assertions = $response->getAssertions();
+
+        $attributes = $assertions[0]->getAttributes();
+        $newAttributes = $attributes;
+
+        $newAttributes[$attributeName] = $attributeValues;
+
+        $assertions[0]->setAttributes($newAttributes);
+    }
+
     public function useResponseSigning()
     {
         $this->descriptor->Extensions['SignResponses'] = true;

--- a/tests/unit/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
@@ -30,6 +30,28 @@ class CollabPersonIdTest extends UnitTest
         );
     }
 
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Authentication
+     */
+    public function a_predictable_collab_person_id_is_generated_with_at_signs_replaced_with_underscores()
+    {
+        $schacHomeOrganizationValue = 'openconext.org';
+        $uidValue = 'homer@domain.invalid';
+
+        $schacHomeOrganization = new SchacHomeOrganization($schacHomeOrganizationValue);
+        $uid = new Uid($uidValue);
+
+        $collabPersonIdWithReplacedAtSign = CollabPersonId::generateWithReplacedAtSignFrom($uid, $schacHomeOrganization);
+
+        $expectedUidValue = 'homer_domain.invalid';
+
+        $this->assertEquals(
+            CollabPersonId::URN_NAMESPACE . ':' . $schacHomeOrganizationValue . ':' . $expectedUidValue,
+            $collabPersonIdWithReplacedAtSign->getCollabPersonId()
+        );
+    }
 
     /**
      * @test

--- a/tests/unit/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
@@ -8,29 +8,6 @@ use PHPUnit_Framework_TestCase as UnitTest;
 class CollabPersonIdTest extends UnitTest
 {
     /**
-     * Smoke test that ensures that CollabPersonIds are generated in an reliable, known manner.
-     *
-     * @test
-     * @group EngineBlock
-     * @group Authentication
-     */
-    public function generate_returns_a_predictable_collab_person_id()
-    {
-        $schacHomeOrganizationValue = 'openconext.org';
-        $uidValue = 'homer@domain.invalid';
-
-        $schacHomeOrganization = new SchacHomeOrganization($schacHomeOrganizationValue);
-        $uid = new Uid($uidValue);
-
-        $collabPersonId = CollabPersonId::generateFrom($uid, $schacHomeOrganization);
-
-        $this->assertEquals(
-            CollabPersonId::URN_NAMESPACE . ':' . $schacHomeOrganizationValue . ':' . $uidValue,
-            $collabPersonId->getCollabPersonId()
-        );
-    }
-
-    /**
      * @test
      * @group EngineBlock
      * @group Authentication

--- a/tests/unit/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
@@ -80,7 +80,7 @@ class CollabPersonIdTest extends UnitTest
      * @group EngineBlock
      * @group Authentication
      */
-    public function collab_person_id_must_not_be_longer_than_400_characters()
+    public function collab_person_id_must_not_be_longer_than_the_maximum_allowed_number_of_characters()
     {
         $namespaceLength = strlen(CollabPersonId::URN_NAMESPACE);
         $beneathLimit = CollabPersonId::URN_NAMESPACE . str_repeat('a', CollabPersonId::MAX_LENGTH - $namespaceLength - 1);

--- a/tests/unit/OpenConext/EngineBlockBridge/Authentication/Repository/UserDirectoryAdapterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/Authentication/Repository/UserDirectoryAdapterTest.php
@@ -282,7 +282,7 @@ class UserDirectoryAdapterTest extends UnitTest
     {
         $uid                   = 'homer@invalid.org';
         $schacHomeOrganization = 'OpenConext.org';
-        $expected              = CollabPersonId::generateFrom(
+        $expected              = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($uid),
             new SchacHomeOrganization($schacHomeOrganization)
         );
@@ -439,7 +439,7 @@ class UserDirectoryAdapterTest extends UnitTest
      */
     private function getCollabPersonId()
     {
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($this->getHomerUid()),
             new SchacHomeOrganization($this->getOpenConextSho())
         );

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/CollabPersonIdTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/CollabPersonIdTypeTest.php
@@ -142,7 +142,7 @@ class CollabPersonIdTypeTest extends UnitTest
      */
     private function getCollabPersonId()
     {
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid('homer@invalid.org'),
             new SchacHomeOrganization('OpenConext.org')
         );


### PR DESCRIPTION
[134915765](https://www.pivotaltracker.com/story/show/134915765)

In the past, at-signs were replaced by underscores because LDAP had trouble dealing with them. Recently, the way collabPersonIds are generated has changed, breaking compatibility with earlier versions of EB across the platform. In order to reinstate this, a method has been added to reinstate compatibility with all the collabPersonIds present in the platform already.

I have deliberately chosen to create another method for this to be explicit about the quirky implementation of collabPersonIds.

In the future, a way of migrating from old to new collabPersonIds should be devised. Then, we can use the original `CollabPersonId::generateFrom()` method.