### PR TITLE
Backport LDAP/CollabPersonId fix and SAML2 version number to 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ branches:
   only:
     - 5.x-dev
     - master
+    - release/5.0
 
 addons:
   hosts:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "openconext/stoker-metadata": "~0.1",
         "openid/php-openid": "dev-master#ee669c6a9d4d95b58ecd9b6945627276807694fb as 2.2.2",
         "pimple/pimple": "~2.1",
-        "simplesamlphp/saml2": "1.7.2 as 0.8.1",
+        "simplesamlphp/saml2": "1.10.3 as 0.8.1",
         "simplesamlphp/simplesamlphp": "~1.13",
         "sybio/image-workshop": "~2.0.7",
         "zendframework/zendframework1":"~1.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "758cdc4453d1139664066eb89026796a",
-    "content-hash": "f858b2af397b6b9687380d32a8e27f00",
+    "hash": "f9e9f0f584fa6b7633c1e818e938e827",
+    "content-hash": "bd63f2d609738066b26de713952b49c2",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1566,22 +1566,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1595,12 +1603,13 @@
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "ramsey/uuid",
@@ -1893,16 +1902,16 @@
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v1.7.2",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "6b91b49fbb22d3a5691e94b6d0057b6ab03ee46f"
+                "reference": "3f268c25ca5e9748652834faad04525746227ef7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/6b91b49fbb22d3a5691e94b6d0057b6ab03ee46f",
-                "reference": "6b91b49fbb22d3a5691e94b6d0057b6ab03ee46f",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/3f268c25ca5e9748652834faad04525746227ef7",
+                "reference": "3f268c25ca5e9748652834faad04525746227ef7",
                 "shasum": ""
             },
             "require": {
@@ -1938,7 +1947,7 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2016-01-11 16:04:45"
+            "time": "2016-12-02 12:15:53"
         },
         {
             "name": "simplesamlphp/simplesamlphp",
@@ -3547,7 +3556,7 @@
                     "name": "Manuel Pichler",
                     "email": "github@manuel-pichler.de",
                     "homepage": "https://github.com/manuelpichler",
-                    "role": "Project Founder"
+                    "role": "Project founder"
                 },
                 {
                     "name": "Other contributors",
@@ -4557,7 +4566,7 @@
         {
             "alias": "0.8.1",
             "alias_normalized": "0.8.1.0",
-            "version": "1.7.2.0",
+            "version": "1.10.3.0",
             "package": "simplesamlphp/saml2"
         }
     ],

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -281,4 +281,9 @@ class EngineBlock_Application_DiContainer extends Pimple implements ContainerInt
     {
         return $this[self::ATTRIBUTE_VALIDATOR];
     }
+
+    public function getFunctionalTestingFeatureConfiguration()
+    {
+        return $this->container->get('engineblock.functional_testing.fixture.features');
+    }
 }

--- a/library/EngineBlock/Application/FunctionalTestDiContainer.php
+++ b/library/EngineBlock/Application/FunctionalTestDiContainer.php
@@ -38,4 +38,8 @@ class EngineBlock_Application_FunctionalTestDiContainer extends EngineBlock_Appl
         return new FakeUserDirectory(new Filesystem());
     }
 
+    public function getFeatureConfiguration()
+    {
+        return $this->getFunctionalTestingFeatureConfiguration();
+    }
 }

--- a/library/EngineBlock/User.php
+++ b/library/EngineBlock/User.php
@@ -90,7 +90,7 @@ class EngineBlock_User
             ));
         }
 
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($this->getUid()),
             new SchacHomeOrganization($this->_attributes[SchacHomeOrganization::URN_MACE][0])
         );

--- a/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
@@ -22,21 +22,6 @@ final class CollabPersonId
     private $collabPersonId;
 
     /**
-     * @param Uid                   $uid
-     * @param SchacHomeOrganization $schacHomeOrganization
-     * @return CollabPersonId
-     */
-    public static function generateFrom(Uid $uid, SchacHomeOrganization $schacHomeOrganization)
-    {
-        $collabPersonId = implode(
-            ':',
-            [self::URN_NAMESPACE, $schacHomeOrganization->getSchacHomeOrganization(), $uid->getUid()]
-        );
-
-        return new self($collabPersonId);
-    }
-
-    /**
      * This method solely exists for compatibility between EB versions and existing SPs.
      * Replacing the @-sign for underscores in collabPersonIds was part of the LDAP module.
      *

--- a/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
@@ -72,7 +72,11 @@ final class CollabPersonId
             self::URN_NAMESPACE,
             sprintf('a CollabPersonId must start with the "%s" namespace', self::URN_NAMESPACE)
         );
-        Assertion::maxLength($collabPersonId, self::MAX_LENGTH, 'CollabPersonId length may not exceed 400 characters');
+        Assertion::maxLength(
+            $collabPersonId,
+            self::MAX_LENGTH,
+            sprintf('CollabPersonId length may not exceed %d characters', self::MAX_LENGTH)
+        );
 
         $this->collabPersonId = $collabPersonId;
     }

--- a/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
@@ -37,6 +37,31 @@ final class CollabPersonId
     }
 
     /**
+     * This method solely exists for compatibility between EB versions and existing SPs.
+     * Replacing the @-sign for underscores in collabPersonIds was part of the LDAP module.
+     *
+     * See: https://www.pivotaltracker.com/story/show/134915765 and
+     * https://github.com/OpenConext/OpenConext-engineblock/commit/e6631acd4c4299329c5c34899de2f3a464975a5a
+     *
+     * @param Uid $uid
+     * @param SchacHomeOrganization $schacHomeOrganization
+     * @return CollabPersonId
+     */
+    public static function generateWithReplacedAtSignFrom(Uid $uid, SchacHomeOrganization $schacHomeOrganization)
+    {
+        $collabPersonId = implode(
+            ':',
+            [
+                self::URN_NAMESPACE,
+                $schacHomeOrganization->getSchacHomeOrganization(),
+                str_replace('@', '_', $uid->getUid()),
+            ]
+        );
+
+        return new self($collabPersonId);
+    }
+
+    /**
      * @param string $collabPersonId
      */
     public function __construct($collabPersonId)

--- a/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
+++ b/src/OpenConext/EngineBlock/Authentication/Value/CollabPersonId.php
@@ -22,7 +22,7 @@ final class CollabPersonId
     private $collabPersonId;
 
     /**
-     * This method solely exists for compatibility between EB versions and existing SPs.
+     * This method provides compatibility between EB versions and existing SPs.
      * Replacing the @-sign for underscores in collabPersonIds was part of the LDAP module.
      *
      * See: https://www.pivotaltracker.com/story/show/134915765 and

--- a/src/OpenConext/EngineBlockBridge/Authentication/Repository/UserDirectoryAdapter.php
+++ b/src/OpenConext/EngineBlockBridge/Authentication/Repository/UserDirectoryAdapter.php
@@ -85,7 +85,7 @@ class UserDirectoryAdapter
             $schacHomeOrganization = $attributes[SchacHomeOrganization::URN_MACE][0];
 
             $collabPersonUuid      = CollabPersonUuid::generate();
-            $collabPersonId        = CollabPersonId::generateFrom(
+            $collabPersonId        = CollabPersonId::generateWithReplacedAtSignFrom(
                 new Uid($uid),
                 new SchacHomeOrganization($schacHomeOrganization)
             );
@@ -109,7 +109,7 @@ class UserDirectoryAdapter
      */
     public function registerUser($uid, $schacHomeOrganization)
     {
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($uid),
             new SchacHomeOrganization($schacHomeOrganization)
         );

--- a/src/OpenConext/EngineBlockBundle/Configuration/FeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/FeatureConfiguration.php
@@ -5,7 +5,7 @@ namespace OpenConext\EngineBlockBundle\Configuration;
 use OpenConext\EngineBlock\Assert\Assertion;
 use OpenConext\EngineBlock\Exception\LogicException;
 
-class FeatureConfiguration
+class FeatureConfiguration implements FeatureConfigurationInterface
 {
     /**
      * @var Feature[]
@@ -23,10 +23,6 @@ class FeatureConfiguration
         $this->features = $features;
     }
 
-    /**
-     * @param string $featureKey
-     * @return bool
-     */
     public function hasFeature($featureKey)
     {
         Assertion::nonEmptyString($featureKey, 'featureKey');
@@ -34,10 +30,6 @@ class FeatureConfiguration
         return array_key_exists($featureKey, $this->features);
     }
 
-    /**
-     * @param string $featureKey
-     * @return bool
-     */
     public function isEnabled($featureKey)
     {
         if (!$this->hasFeature($featureKey)) {

--- a/src/OpenConext/EngineBlockBundle/Configuration/FeatureConfigurationInterface.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/FeatureConfigurationInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace OpenConext\EngineBlockBundle\Configuration;
+
+interface FeatureConfigurationInterface
+{
+    /**
+     * @param string $featureKey
+     * @return bool
+     */
+    public function hasFeature($featureKey);
+
+    /**
+     * @param string $featureKey
+     * @return bool
+     */
+    public function isEnabled($featureKey);
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -3,6 +3,7 @@
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
 use EngineBlock_Saml2_IdGenerator;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingFeatureConfiguration;
 use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\IdFixture;
 use OpenConext\EngineBlockFunctionalTestingBundle\Parser\LogChunkParser;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\EntityRegistry;
@@ -46,12 +47,23 @@ class EngineBlockContext extends AbstractSubContext
     protected $spsConfigUrl;
 
     /**
+     * @var FunctionalTestingFeatureConfiguration
+     */
+    private $features;
+
+    /**
+     * @var boolean
+     */
+    private $usingFeatures = false;
+
+    /**
      * @param ServiceRegistryFixture $serviceRegistry
-     * @param EngineBlock            $engineBlock
-     * @param EntityRegistry         $mockSpRegistry
-     * @param EntityRegistry         $mockIdpRegistry
-     * @param string                 $spsConfigUrl
-     * @param string                 $idpsConfigUrl
+     * @param EngineBlock $engineBlock
+     * @param EntityRegistry $mockSpRegistry
+     * @param EntityRegistry $mockIdpRegistry
+     * @param string $spsConfigUrl
+     * @param string $idpsConfigUrl
+     * @param FunctionalTestingFeatureConfiguration $features
      */
     public function __construct(
         ServiceRegistryFixture $serviceRegistry,
@@ -59,7 +71,8 @@ class EngineBlockContext extends AbstractSubContext
         EntityRegistry $mockSpRegistry,
         EntityRegistry $mockIdpRegistry,
         $spsConfigUrl,
-        $idpsConfigUrl
+        $idpsConfigUrl,
+        FunctionalTestingFeatureConfiguration $features
     ) {
         $this->serviceRegistryFixture = $serviceRegistry;
         $this->engineBlock = $engineBlock;
@@ -67,6 +80,7 @@ class EngineBlockContext extends AbstractSubContext
         $this->mockIdpRegistry = $mockIdpRegistry;
         $this->spsConfigUrl = $spsConfigUrl;
         $this->idpsConfigUrl = $idpsConfigUrl;
+        $this->features = $features;
     }
 
     /**
@@ -248,5 +262,33 @@ class EngineBlockContext extends AbstractSubContext
     public function iLogoutAtEngineBlock()
     {
         $this->getMainContext()->getMinkContext()->visit($this->engineBlock->logoutLocation());
+    }
+
+    /**
+     * @Given /^feature "([^"]*)" is enabled$/
+     */
+    public function featureIsEnabled($feature)
+    {
+        $this->usingFeatures = true;
+        $this->features->save($feature, true);
+    }
+
+    /**
+     * @Given /^feature "([^"]*)" is disabled$/
+     */
+    public function featureIsDisabled($feature)
+    {
+        $this->usingFeatures = true;
+        $this->features->save($feature, false);
+    }
+
+    /**
+     * @AfterScenario
+     */
+    public function cleanUpFeatures()
+    {
+        if ($this->usingFeatures) {
+            $this->features->clean();
+        }
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -280,4 +280,20 @@ class MockIdpContext extends AbstractSubContext
         $mink = $this->getMainContext()->getMinkContext();
         $mink->pressButton('GO');
     }
+
+    /**
+     * @Given /^the IdP "([^"]*)" sends attribute "([^"]*)" with value "([^"]*)"$/
+     * @param string $idpName
+     * @param string $attributeName
+     * @param string $attributeValue
+     */
+    public function theIdPSendsAttributeWithValue($idpName, $attributeName, $attributeValue)
+    {
+        /** @var MockIdentityProvider $mockIdp */
+        $mockIdp = $this->mockIdpRegistry->get($idpName);
+
+        $mockIdp->setAttribute($attributeName, [$attributeValue]);
+
+        $this->mockIdpRegistry->save();
+    }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Encryption.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Encryption.feature
@@ -38,3 +38,28 @@ Feature:
       And I pass through EngineBlock
       And I pass through the IdP
      Then I should see "Invalid Identity Provider response"
+
+  @WIP
+  Scenario: EngineBlock rejects encrypted responses if the feature "eb.encrypted_assertions" is not enabled
+    Given the SP uses the HTTP POST Binding
+      And the IdP encrypts it's assertions with the public key in "/etc/openconext/engineblock.crt"
+      And feature "eb.encrypted_assertions" is disabled
+     When I log in at "Dummy SP"
+      And I pass through the SP
+      And I pass through EngineBlock
+      And I pass through the IdP
+     Then the url should match "authentication/feedback/received-invalid-response"
+      And I should see "Invalid Identity Provider response"
+
+  @WIP
+  Scenario: EngineBlock rejects encrypted responses without outer signature if the feature "eb.encrypted_assertions_require_outer_signatures" is enabled
+    Given the SP uses the HTTP POST Binding
+      And the IdP encrypts it's assertions with the public key in "/etc/openconext/engineblock.crt"
+      And feature "eb.encrypted_assertions" is enabled
+      And feature "eb.encrypted_assertions_require_outer_signature" is enabled
+     When I log in at "Dummy SP"
+      And I pass through the SP
+      And I pass through EngineBlock
+      And I pass through the IdP
+     Then the url should match "authentication/feedback/received-invalid-response"
+      And I should see "Invalid Identity Provider response"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Encryption.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Encryption.feature
@@ -38,28 +38,3 @@ Feature:
       And I pass through EngineBlock
       And I pass through the IdP
      Then I should see "Invalid Identity Provider response"
-
-  @WIP
-  Scenario: EngineBlock rejects encrypted responses if the feature "eb.encrypted_assertions" is not enabled
-    Given the SP uses the HTTP POST Binding
-      And the IdP encrypts it's assertions with the public key in "/etc/openconext/engineblock.crt"
-      And feature "eb.encrypted_assertions" is disabled
-     When I log in at "Dummy SP"
-      And I pass through the SP
-      And I pass through EngineBlock
-      And I pass through the IdP
-     Then the url should match "authentication/feedback/received-invalid-response"
-      And I should see "Invalid Identity Provider response"
-
-  @WIP
-  Scenario: EngineBlock rejects encrypted responses without outer signature if the feature "eb.encrypted_assertions_require_outer_signatures" is enabled
-    Given the SP uses the HTTP POST Binding
-      And the IdP encrypts it's assertions with the public key in "/etc/openconext/engineblock.crt"
-      And feature "eb.encrypted_assertions" is enabled
-      And feature "eb.encrypted_assertions_require_outer_signature" is enabled
-     When I log in at "Dummy SP"
-      And I pass through the SP
-      And I pass through EngineBlock
-      And I pass through the IdP
-     Then the url should match "authentication/feedback/received-invalid-response"
-      And I should see "Invalid Identity Provider response"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/LdapCompatibility.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/LdapCompatibility.feature
@@ -10,7 +10,6 @@ Feature:
       And an Identity Provider named "Dummy IdP"
       And a Service Provider named "Dummy SP"
 
-  @WIP
   Scenario: a collabPersonId is constructed from a uid with its at-signs replaced by underscores when LDAP integration is disabled
     Given feature "eb.ldap_integration" is disabled
       And the IdP "Dummy IdP" sends attribute "urn:mace:dir:attribute-def:uid" with value "frits@example.test"
@@ -22,7 +21,6 @@ Feature:
      Then the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text() = "frits@example.test"]'
       And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:oid:1.3.6.1.4.1.1076.20.40.40.1"]/saml:AttributeValue[text() = "urn:collab:person:engine-test-stand.openconext.org:frits_example.test"]'
 
-  @WIP
   Scenario: a collabPersonId is constructed from a uid with its at-signs replaced by underscores when LDAP integration is enabled
     Given feature "eb.ldap_integration" is enabled
       And the IdP "Dummy IdP" sends attribute "urn:mace:dir:attribute-def:uid" with value "frits@example.test"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/LdapCompatibility.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/LdapCompatibility.feature
@@ -1,0 +1,35 @@
+Feature:
+  In order to maintain compatibility
+  As Engineblock
+  I want to keep LDAP-related modifications to attributes
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+      And no registered SPs
+      And no registered Idps
+      And an Identity Provider named "Dummy IdP"
+      And a Service Provider named "Dummy SP"
+
+  @WIP
+  Scenario: a collabPersonId is constructed from a uid with its at-signs replaced by underscores when LDAP integration is disabled
+    Given feature "eb.ldap_integration" is disabled
+      And the IdP "Dummy IdP" sends attribute "urn:mace:dir:attribute-def:uid" with value "frits@example.test"
+     When I log in at "Dummy SP"
+      And I pass through EngineBlock
+      And I pass through the IdP
+      And I give my consent
+      And I pass through EngineBlock
+     Then the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text() = "frits@example.test"]'
+      And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:oid:1.3.6.1.4.1.1076.20.40.40.1"]/saml:AttributeValue[text() = "urn:collab:person:engine-test-stand.openconext.org:frits_example.test"]'
+
+  @WIP
+  Scenario: a collabPersonId is constructed from a uid with its at-signs replaced by underscores when LDAP integration is enabled
+    Given feature "eb.ldap_integration" is enabled
+      And the IdP "Dummy IdP" sends attribute "urn:mace:dir:attribute-def:uid" with value "frits@example.test"
+     When I log in at "Dummy SP"
+      And I pass through EngineBlock
+      And I pass through the IdP
+      And I give my consent
+      And I pass through EngineBlock
+     Then the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text() = "frits@example.test"]'
+      And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:oid:1.3.6.1.4.1.1076.20.40.40.1"]/saml:AttributeValue[text() = "urn:collab:person:engine-test-stand.openconext.org:frits_example.test"]'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingFeatureConfiguration.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
+
+use OpenConext\EngineBlockBundle\Configuration\Feature;
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\AbstractDataStore;
+use RuntimeException;
+
+final class FunctionalTestingFeatureConfiguration implements FeatureConfigurationInterface
+{
+    /**
+     * @var FeatureConfiguration
+     */
+    private $featureConfiguration;
+
+    /**
+     * @var Feature[]
+     */
+    private $featureConfigurationFixture;
+
+    /**
+     * @var AbstractDataStore
+     */
+    private $dataStore;
+
+    public function __construct(FeatureConfiguration $featureConfiguration, AbstractDataStore $dataStore)
+    {
+        $this->featureConfiguration = $featureConfiguration;
+        $this->dataStore            = $dataStore;
+
+        $this->featureConfigurationFixture = $dataStore->load();
+    }
+
+    public function hasFeature($featureKey)
+    {
+        return $this->featureConfiguration->hasFeature($featureKey);
+    }
+
+    public function isEnabled($featureKey)
+    {
+        if (isset($this->featureConfigurationFixture[$featureKey])) {
+            return $this->featureConfigurationFixture[$featureKey];
+        }
+
+        return $this->featureConfiguration->isEnabled($featureKey);
+    }
+
+    public function save($featureKey, $value)
+    {
+        if (!$this->featureConfiguration->hasFeature($featureKey)) {
+            throw new RuntimeException(sprintf(
+                'Cannot save fixture for feature "%s": it is not configured in the actual feature configuration',
+                $featureKey
+            ));
+        }
+
+        $this->featureConfigurationFixture[$featureKey] = $value;
+        $this->dataStore->save($this->featureConfigurationFixture);
+    }
+
+    public function clean()
+    {
+        $this->featureConfigurationFixture = [];
+        $this->dataStore->save($this->featureConfigurationFixture);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/FakeUserDirectory.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/FakeUserDirectory.php
@@ -82,7 +82,7 @@ class FakeUserDirectory extends UserDirectoryAdapter
         $schacHomeOrganization = $attributes[SchacHomeOrganization::URN_MACE][0];
 
         $collabPersonUuid = CollabPersonUuid::generate();
-        $collabPersonId   = CollabPersonId::generateFrom(
+        $collabPersonId   = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($uid),
             new SchacHomeOrganization($schacHomeOrganization)
         );
@@ -97,7 +97,7 @@ class FakeUserDirectory extends UserDirectoryAdapter
 
     public function registerUser($uid, $schacHomeOrganization)
     {
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($uid),
             new SchacHomeOrganization($schacHomeOrganization)
         );

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
@@ -210,6 +210,22 @@ class MockIdentityProvider extends AbstractMockEntityRole
         $assertions[0]->setAttributes($newAttributes);
     }
 
+    public function setAttribute($attributeName, array $attributeValues)
+    {
+        $role = $this->getSsoRole();
+
+        /** @var Response $response */
+        $response = $role->Extensions['SAMLResponse'];
+        $assertions = $response->getAssertions();
+
+        $attributes = $assertions[0]->getAttributes();
+        $newAttributes = $attributes;
+
+        $newAttributes[$attributeName] = $attributeValues;
+
+        $assertions[0]->setAttributes($newAttributes);
+    }
+
     public function useResponseSigning()
     {
         $this->descriptor->Extensions['SignResponses'] = true;

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
@@ -4,6 +4,7 @@ parameters:
     engineblock.functional_testing.super_globals_data_store.file:    "%kernel.root_dir%/../tmp/eb-fixtures/superglobals.json"
     engineblock.functional_testing.service_registry_data_store.dir:  "%kernel.root_dir%/../tmp/eb-fixtures/janus/"
     engineblock.functional_testing.service_registry_data_store.file: "%kernel.root_dir%/../tmp/eb-fixtures/janus/entities"
+    engineblock.functional_testing.features_data_store.file:         "%kernel.root_dir%/../tmp/eb-fixtures/features.json"
 
 services:
     engineblock.functional_testing.service.engine_block:
@@ -27,6 +28,7 @@ services:
             - '@engineblock.mock_entities.idp_registry'
             - '%sps_config_url%'
             - '%idps_config_url%'
+            - '@engineblock.functional_testing.fixture.features'
 
     engineblock.functional_testing.behat_context.mock_idp:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Features\Context\MockIdpContext
@@ -66,6 +68,13 @@ services:
     engineblock.functional_testing.fixture.super_globals:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\SuperGlobalsFixture
         arguments: ['@engineblock.functional_testing.data_store.super_globals']
+
+    engineblock.functional_testing.fixture.features:
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingFeatureConfiguration
+        arguments:
+            - '@engineblock.features'
+            - '@engineblock.functional_testing.data_store.features'
+
     #endregion Fixtures
 
     #region Data Stores
@@ -88,4 +97,8 @@ services:
     engineblock.functional_testing.data_store.super_globals:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore
         arguments: ['%engineblock.functional_testing.super_globals_data_store.file%']
+
+    engineblock.functional_testing.data_store.features:
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore
+        arguments: ['%engineblock.functional_testing.features_data_store.file%']
     #endregion Data Stores

--- a/tests/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
+++ b/tests/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
@@ -30,6 +30,28 @@ class CollabPersonIdTest extends UnitTest
         );
     }
 
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Authentication
+     */
+    public function a_predictable_collab_person_id_is_generated_with_at_signs_replaced_with_underscores()
+    {
+        $schacHomeOrganizationValue = 'openconext.org';
+        $uidValue = 'homer@domain.invalid';
+
+        $schacHomeOrganization = new SchacHomeOrganization($schacHomeOrganizationValue);
+        $uid = new Uid($uidValue);
+
+        $collabPersonIdWithReplacedAtSign = CollabPersonId::generateWithReplacedAtSignFrom($uid, $schacHomeOrganization);
+
+        $expectedUidValue = 'homer_domain.invalid';
+
+        $this->assertEquals(
+            CollabPersonId::URN_NAMESPACE . ':' . $schacHomeOrganizationValue . ':' . $expectedUidValue,
+            $collabPersonIdWithReplacedAtSign->getCollabPersonId()
+        );
+    }
 
     /**
      * @test

--- a/tests/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
+++ b/tests/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
@@ -8,29 +8,6 @@ use PHPUnit_Framework_TestCase as UnitTest;
 class CollabPersonIdTest extends UnitTest
 {
     /**
-     * Smoke test that ensures that CollabPersonIds are generated in an reliable, known manner.
-     *
-     * @test
-     * @group EngineBlock
-     * @group Authentication
-     */
-    public function generate_returns_a_predictable_collab_person_id()
-    {
-        $schacHomeOrganizationValue = 'openconext.org';
-        $uidValue = 'homer@domain.invalid';
-
-        $schacHomeOrganization = new SchacHomeOrganization($schacHomeOrganizationValue);
-        $uid = new Uid($uidValue);
-
-        $collabPersonId = CollabPersonId::generateFrom($uid, $schacHomeOrganization);
-
-        $this->assertEquals(
-            CollabPersonId::URN_NAMESPACE . ':' . $schacHomeOrganizationValue . ':' . $uidValue,
-            $collabPersonId->getCollabPersonId()
-        );
-    }
-
-    /**
      * @test
      * @group EngineBlock
      * @group Authentication

--- a/tests/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
+++ b/tests/OpenConext/EngineBlock/Authentication/Value/CollabPersonIdTest.php
@@ -80,7 +80,7 @@ class CollabPersonIdTest extends UnitTest
      * @group EngineBlock
      * @group Authentication
      */
-    public function collab_person_id_must_not_be_longer_than_400_characters()
+    public function collab_person_id_must_not_be_longer_than_the_maximum_allowed_number_of_characters()
     {
         $namespaceLength = strlen(CollabPersonId::URN_NAMESPACE);
         $beneathLimit = CollabPersonId::URN_NAMESPACE . str_repeat('a', CollabPersonId::MAX_LENGTH - $namespaceLength - 1);

--- a/tests/OpenConext/EngineBlockBridge/Authentication/Repository/UserDirectoryAdapterTest.php
+++ b/tests/OpenConext/EngineBlockBridge/Authentication/Repository/UserDirectoryAdapterTest.php
@@ -282,7 +282,7 @@ class UserDirectoryAdapterTest extends UnitTest
     {
         $uid                   = 'homer@invalid.org';
         $schacHomeOrganization = 'OpenConext.org';
-        $expected              = CollabPersonId::generateFrom(
+        $expected              = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($uid),
             new SchacHomeOrganization($schacHomeOrganization)
         );
@@ -439,7 +439,7 @@ class UserDirectoryAdapterTest extends UnitTest
      */
     private function getCollabPersonId()
     {
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid($this->getHomerUid()),
             new SchacHomeOrganization($this->getOpenConextSho())
         );

--- a/tests/OpenConext/EngineBlockBundle/Doctrine/Type/CollabPersonIdTypeTest.php
+++ b/tests/OpenConext/EngineBlockBundle/Doctrine/Type/CollabPersonIdTypeTest.php
@@ -142,7 +142,7 @@ class CollabPersonIdTypeTest extends UnitTest
      */
     private function getCollabPersonId()
     {
-        $collabPersonId = CollabPersonId::generateFrom(
+        $collabPersonId = CollabPersonId::generateWithReplacedAtSignFrom(
             new Uid('homer@invalid.org'),
             new SchacHomeOrganization('OpenConext.org')
         );


### PR DESCRIPTION
[134915765](https://www.pivotaltracker.com/story/show/134915765)

This PR contains backports of a fix for [LDAP/CollabPersonId](https://github.com/OpenConext/OpenConext-engineblock/pull/360) [generation](https://github.com/OpenConext/OpenConext-engineblock/pull/363) and a dependency update for [SAML2 regarding security and EPTIs](https://github.com/OpenConext/OpenConext-engineblock/pull/362).