### PR TITLE
Drop usage date and only update consent once

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,12 @@
 # UPGRADE NOTES
 
+## 5.x -> 5.2
+
+### Consent API
+Engineblock's Consent API, which is used by [OpenConext-Profile][op-pro]
+ no longer exposes the most recent date of consent given (last use on).
+ Instead, it offers only the first consent given (consent given on).
+
 ## 4.x -> 5.0
 
 ### General

--- a/database/DoctrineMigrations/Version20161209145942.php
+++ b/database/DoctrineMigrations/Version20161209145942.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20161209145942 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // Make sure consent_date is not updated every time a row is updated
+        $this->addSql('ALTER TABLE consent CHANGE consent_date consent_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE consent CHANGE consent_date consent_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;');
+
+    }
+}

--- a/database/DoctrineMigrations/Version20161209152354.php
+++ b/database/DoctrineMigrations/Version20161209152354.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20161209152354 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE consent DROP COLUMN usage_date');
+
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE consent ADD COLUMN usage_date TIMESTAMP DEFAULT \'0000-00-00 00:00:00\' AFTER consent_date');
+    }
+}

--- a/library/EngineBlock/Corto/Model/Consent.php
+++ b/library/EngineBlock/Corto/Model/Consent.php
@@ -120,9 +120,9 @@ class EngineBlock_Corto_Model_Consent
             return false;
         }
 
-        $query = "INSERT INTO consent (usage_date, hashed_user_id, service_id, attribute, consent_type)
-                  VALUES (NOW(), ?, ?, ?, ?)
-                  ON DUPLICATE KEY UPDATE usage_date=VALUES(usage_date), attribute=VALUES(attribute), consent_type=VALUES(consent_type)";
+        $query = "INSERT INTO consent (hashed_user_id, service_id, attribute, consent_type)
+                  VALUES (?, ?, ?, ?)
+                  ON DUPLICATE KEY UPDATE attribute=VALUES(attribute), consent_type=VALUES(consent_type)";
         $parameters = array(
             sha1($this->_getConsentUid()),
             $serviceProvider->entityId,
@@ -177,14 +177,6 @@ class EngineBlock_Corto_Model_Consent
                 // No stored consent found
                 return false;
             }
-
-            // Update usage date
-            $statement = $dbh->prepare("UPDATE LOW_PRIORITY {$this->_tableName} SET usage_date = NOW() WHERE hashed_user_id = ? AND service_id = ? AND consent_type = ?");
-            $statement->execute(array(
-                $hashedUserId,
-                $serviceProvider->entityId,
-                $consentType
-            ));
 
             return true;
         } catch (PDOException $e) {

--- a/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
@@ -79,8 +79,9 @@ class EngineBlock_Corto_Module_Service_ProcessConsent
 
         $attributes = $response->getAssertion()->getAttributes();
         $consentRepository = $this->_consentFactory->create($this->_server, $response, $attributes);
-        $consentRepository->giveExplicitConsentFor($destinationMetadata);
-        if ($consentRepository->countTotalConsent() === 1) {
+
+        if (!$consentRepository->explicitConsentWasGivenFor($serviceProvider)) {
+            $consentRepository->giveExplicitConsentFor($destinationMetadata);
             $this->_sendIntroductionMail($attributes);
         }
 

--- a/src/OpenConext/EngineBlock/Authentication/Dto/Consent.php
+++ b/src/OpenConext/EngineBlock/Authentication/Dto/Consent.php
@@ -67,7 +67,6 @@ final class Consent
         return [
             'service_provider' => $serviceProvider,
             'consent_given_on' => $this->consent->getDateConsentWasGivenOn()->format(DateTime::ATOM),
-            'last_used_on'     => $this->consent->getDateLastUsedOn()->format(DateTime::ATOM),
             'consent_type'     => $this->consent->getConsentType()->jsonSerialize(),
         ];
     }

--- a/src/OpenConext/EngineBlock/Authentication/Model/Consent.php
+++ b/src/OpenConext/EngineBlock/Authentication/Model/Consent.php
@@ -28,11 +28,6 @@ final class Consent
     private $consentGivenOn;
 
     /**
-     * @var DateTime
-     */
-    private $lastUsedOn;
-
-    /**
      * @var ConsentType
      */
     private $consentType;
@@ -41,14 +36,12 @@ final class Consent
      * @param string $userId
      * @param string $serviceProviderEntityId
      * @param DateTime $consentGivenOn
-     * @param DateTime $lastUsedOn
      * @param ConsentType $consentType
      */
     public function __construct(
         $userId,
         $serviceProviderEntityId,
         DateTime $consentGivenOn,
-        DateTime $lastUsedOn,
         ConsentType $consentType
     ) {
         Assertion::nonEmptyString($userId, 'userId');
@@ -57,7 +50,6 @@ final class Consent
         $this->userId                  = $userId;
         $this->serviceProviderEntityId = $serviceProviderEntityId;
         $this->consentGivenOn          = $consentGivenOn;
-        $this->lastUsedOn              = $lastUsedOn;
         $this->consentType             = $consentType;
     }
 
@@ -77,14 +69,6 @@ final class Consent
     public function getDateConsentWasGivenOn()
     {
         return clone $this->consentGivenOn;
-    }
-
-    /**
-     * @return DateTime
-     */
-    public function getDateLastUsedOn()
-    {
-        return clone $this->lastUsedOn;
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Authentication/Repository/ConsentRepository.php
+++ b/src/OpenConext/EngineBlock/Authentication/Repository/ConsentRepository.php
@@ -35,7 +35,6 @@ final class ConsentRepository
             SELECT
                 service_id
             ,   consent_date
-            ,   usage_date
             ,   consent_type
             FROM
                 consent
@@ -52,7 +51,6 @@ final class ConsentRepository
                     $userId,
                     $row['service_id'],
                     new DateTime($row['consent_date']),
-                    new DateTime($row['usage_date']),
                     new ConsentType($row['consent_type'])
                 );
             },


### PR DESCRIPTION
[130002585](https://www.pivotaltracker.com/story/show/130002585)
OpenConext/OpenConext-engineblock#316

This PR prevents consent_date from updating upon each consent and removes the tracking of the last date on which consent has been given. The usage_date column has been removed from the consent table.

This impacts Profile, as a consumer of the Consent API, see: OpenConext/OpenConext-profile#73