### PR TITLE
Correct and comment out DB settings in ini

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -146,11 +146,11 @@ ldap.baseDn             = "dc=surfconext,dc=nl"
 ;;;;;;;;;;;; DATABASE SETTINGS ;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-database.host = "localhost"
+database.host = localhost
 database.port = 3306
 database.password = "secret"
-database.user = "engineblock"
-database.dbname = "engineblock"
+database.user = "ebrw"
+database.dbname = eb
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; SERVICEREGISTRY SETTINGS ;;;;;;;;;;


### PR DESCRIPTION
This ini overrides the engineblock.ini written during provisioning.

The previous values were added to use the correct syntax, but used the some default values that conflicted with the default OpenConext-deploy development environment, see https://github.com/OpenConext/OpenConext-engineblock/pull/352 by @tvdijen 

This change is transparent about how it can be configured (and how it is configured in OpenConext-deploy).