### PR TITLE
Revert SAML2 version bump back to 1.7.2 (5.0.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "openconext/stoker-metadata": "~0.1",
         "openid/php-openid": "dev-master#ee669c6a9d4d95b58ecd9b6945627276807694fb as 2.2.2",
         "pimple/pimple": "~2.1",
-        "simplesamlphp/saml2": "1.10.3 as 0.8.1",
+        "simplesamlphp/saml2": "1.7.2 as 0.8.1",
         "simplesamlphp/simplesamlphp": "~1.13",
         "sybio/image-workshop": "~2.0.7",
         "zendframework/zendframework1":"~1.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f9e9f0f584fa6b7633c1e818e938e827",
-    "content-hash": "bd63f2d609738066b26de713952b49c2",
+    "hash": "758cdc4453d1139664066eb89026796a",
+    "content-hash": "f858b2af397b6b9687380d32a8e27f00",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1566,30 +1566,22 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
                 "shasum": ""
             },
-            "require": {
-                "php": ">=5.3.0"
-            },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                "psr-0": {
+                    "Psr\\Log\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1603,13 +1595,12 @@
                 }
             ],
             "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2012-12-21 11:40:51"
         },
         {
             "name": "ramsey/uuid",
@@ -1902,16 +1893,16 @@
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v1.10.3",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "3f268c25ca5e9748652834faad04525746227ef7"
+                "reference": "6b91b49fbb22d3a5691e94b6d0057b6ab03ee46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/3f268c25ca5e9748652834faad04525746227ef7",
-                "reference": "3f268c25ca5e9748652834faad04525746227ef7",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/6b91b49fbb22d3a5691e94b6d0057b6ab03ee46f",
+                "reference": "6b91b49fbb22d3a5691e94b6d0057b6ab03ee46f",
                 "shasum": ""
             },
             "require": {
@@ -1947,7 +1938,7 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2016-12-02 12:15:53"
+            "time": "2016-01-11 16:04:45"
         },
         {
             "name": "simplesamlphp/simplesamlphp",
@@ -3556,7 +3547,7 @@
                     "name": "Manuel Pichler",
                     "email": "github@manuel-pichler.de",
                     "homepage": "https://github.com/manuelpichler",
-                    "role": "Project founder"
+                    "role": "Project Founder"
                 },
                 {
                     "name": "Other contributors",
@@ -4566,7 +4557,7 @@
         {
             "alias": "0.8.1",
             "alias_normalized": "0.8.1.0",
-            "version": "1.10.3.0",
+            "version": "1.7.2.0",
             "package": "simplesamlphp/saml2"
         }
     ],


### PR DESCRIPTION
This reverts the work done by cherry pick: 1602773ee1ac529da96c101aaef968dc6e83c36d.
The PR, backporting the SAML2 bump from master (https://github.com/OpenConext/OpenConext-engineblock/pull/362), related to that fix: https://github.com/OpenConext/OpenConext-engineblock/pull/364

This is reversion is necessary because the SAML2 version bump contains a change in the way AllowCreate is to be set in SAML2: https://github.com/simplesamlphp/saml2/commit/aecda70e72970c8d66af1d18d5b762a8df5731ed.

**Security notice**
This will cause EB 5.0.x to lack an important security update. This should be fixed ASAP.

**Note**
This should also be fixed on master, but the version bump that introduced this change was [already present in 5.1](https://github.com/OpenConext/OpenConext-engineblock/commit/0ce17afbe3fd137cddcc4dd52d3e2a97fa23cd6f), so we cannot simply revert back to 1.7.2. We should probably test and fix our integration with SAML2.

PR #371 (master) tackles this problem for future releases.