### PR TITLE
Set AllowCreate correctly for SAML2

### DIFF
--- a/library/EngineBlock/Saml2/AuthnRequestFactory.php
+++ b/library/EngineBlock/Saml2/AuthnRequestFactory.php
@@ -9,7 +9,7 @@ class EngineBlock_Saml2_AuthnRequestFactory
         IdentityProvider $idpMetadata,
         EngineBlock_Corto_ProxyServer $server
     ) {
-        $nameIdPolicy = array('AllowCreate' => 'true');
+        $nameIdPolicy = array('AllowCreate' => true);
         /**
          * Name policy is not required, so it is only set if configured, SAML 2.0 spec
          * says only following values are allowed:

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AuthnRequest.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AuthnRequest.feature
@@ -15,4 +15,4 @@ Feature:
     When I log in at "Dummy-SP"
      And I pass through EngineBlock
      And I pass through the IdP
-    Then the response should contain "AllowCreate"
+    Then the AuthnRequest should match xpath '/samlp:AuthnRequest/samlp:NameIDPolicy[@AllowCreate="true" or @AllowCreate="1"]'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AuthnRequest.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AuthnRequest.feature
@@ -1,0 +1,18 @@
+@WIP
+Feature:
+  In order to maintain compatibility with certain IdPs
+  As Engineblock
+  I want to send correct AuthnRequests
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+      And no registered SPs
+      And no registered Idps
+      And an Identity Provider named "Dummy-IdP"
+      And a Service Provider named "Dummy-SP"
+
+  Scenario: The AuthnRequest contains the correct attributes
+    When I log in at "Dummy-SP"
+     And I pass through EngineBlock
+     And I pass through the IdP
+    Then the response should contain "AllowCreate"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -306,9 +306,9 @@ class EngineBlockContext extends AbstractSubContext
     }
 
     /**
-     * @Then /^the AuthnRequest should match xpath '([^']*)'$/
+     * @Then /^the AuthnRequest to submit should match xpath '([^']*)'$/
      */
-    public function theAuthnRequestShouldMatchXpath($xpath)
+    public function theAuthnRequestToSubmitShouldMatchXpath($xpath)
     {
         $session = $this->getMainContext()->getMinkContext()->getSession();
         $mink    = $session->getPage();

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
@@ -1,8 +1,8 @@
 @WIP
 Feature:
-  In order to maintain compatibility with certain IdPs
-  As Engineblock
-  I want to send correct AuthnRequests
+  In order to offer a predictable API to SPs and IdPs
+  As EngineBlock
+  I want to send them the correct AuthnRequests and Responses
 
   Background:
     Given an EngineBlock instance on "vm.openconext.org"
@@ -11,7 +11,7 @@ Feature:
       And an Identity Provider named "Dummy-IdP"
       And a Service Provider named "Dummy-SP"
 
-  Scenario: The AuthnRequest contains the correct attributes
+  Scenario: IdPs are allowed to create NameIDs
     When I log in at "Dummy-SP"
      And I pass through EngineBlock
      And I pass through the IdP

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
@@ -1,4 +1,3 @@
-@WIP
 Feature:
   In order to offer a predictable API to SPs and IdPs
   As EngineBlock

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
@@ -15,4 +15,4 @@ Feature:
     When I log in at "Dummy-SP"
      And I pass through EngineBlock
      And I pass through the IdP
-    Then the AuthnRequest should match xpath '/samlp:AuthnRequest/samlp:NameIDPolicy[@AllowCreate="true" or @AllowCreate="1"]'
+    Then the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:NameIDPolicy[@AllowCreate="true" or @AllowCreate="1"]'

--- a/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
@@ -20,10 +20,13 @@ class EngineBlock_Test_Corto_ProxyServerTest extends PHPUnit_Framework_TestCase
             $proxyServer
         );
 
-        $expectedNameIdPolicy = ['AllowCreate' => true];
-        $actualNameIdPolicy   = $enhancedRequest->getNameIdPolicy();
+        $nameIdPolicy = $enhancedRequest->getNameIdPolicy();
 
-        $this->assertSame($expectedNameIdPolicy, $actualNameIdPolicy);
+        $this->assertNotContains(
+            'Format',
+            array_keys($nameIdPolicy),
+            'The NameIDPolicy should not contain the key "Format"'
+        );
     }
 
     public function testNameIDFormatIsSetFromRemoteMetaData()

--- a/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
@@ -9,6 +9,10 @@ class EngineBlock_Test_Corto_ProxyServerTest extends PHPUnit_Framework_TestCase
 {
     public function testNameIDFormatIsNotSetByDefault()
     {
+        $expectedNameIdPolicy = [
+            'AllowCreate' => true
+        ];
+
         $proxyServer = $this->factoryProxyServer();
 
         $originalRequest = $this->factoryOriginalRequest();
@@ -20,7 +24,9 @@ class EngineBlock_Test_Corto_ProxyServerTest extends PHPUnit_Framework_TestCase
             $proxyServer
         );
 
-        $this->assertNotContains('Format', $enhancedRequest->getNameIdPolicy());
+        $actualNameIdPolicy = $enhancedRequest->getNameIdPolicy();
+
+        $this->assertSame($expectedNameIdPolicy, $actualNameIdPolicy);
     }
 
     public function testNameIDFormatIsSetFromRemoteMetaData()

--- a/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
@@ -32,6 +32,31 @@ class EngineBlock_Test_Corto_ProxyServerTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAllowCreateIsSet()
+    {
+        $proxyServer = $this->factoryProxyServer();
+
+        $originalRequest = $this->factoryOriginalRequest();
+        $identityProvider = $proxyServer->getRepository()->fetchIdentityProviderByEntityId('testIdp');
+        /** @var SAML2_AuthnRequest $enhancedRequest */
+        $enhancedRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest(
+            $originalRequest,
+            $identityProvider,
+            $proxyServer
+        );
+
+        $nameIdPolicy = $enhancedRequest->getNameIdPolicy();
+
+        $this->assertContains(
+            'AllowCreate',
+            array_keys($nameIdPolicy),
+            'The NameIDPolicy should contain the key "AllowCreate"',
+            false,
+            true,
+            true
+        );
+    }
+
     public function testNameIDFormatIsSetFromRemoteMetaData()
     {
         $proxyServer = $this->factoryProxyServer();

--- a/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
@@ -9,10 +9,6 @@ class EngineBlock_Test_Corto_ProxyServerTest extends PHPUnit_Framework_TestCase
 {
     public function testNameIDFormatIsNotSetByDefault()
     {
-        $expectedNameIdPolicy = [
-            'AllowCreate' => true
-        ];
-
         $proxyServer = $this->factoryProxyServer();
 
         $originalRequest = $this->factoryOriginalRequest();
@@ -24,7 +20,8 @@ class EngineBlock_Test_Corto_ProxyServerTest extends PHPUnit_Framework_TestCase
             $proxyServer
         );
 
-        $actualNameIdPolicy = $enhancedRequest->getNameIdPolicy();
+        $expectedNameIdPolicy = ['AllowCreate' => true];
+        $actualNameIdPolicy   = $enhancedRequest->getNameIdPolicy();
 
         $this->assertSame($expectedNameIdPolicy, $actualNameIdPolicy);
     }

--- a/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
@@ -25,7 +25,10 @@ class EngineBlock_Test_Corto_ProxyServerTest extends PHPUnit_Framework_TestCase
         $this->assertNotContains(
             'Format',
             array_keys($nameIdPolicy),
-            'The NameIDPolicy should not contain the key "Format"'
+            'The NameIDPolicy should not contain the key "Format"',
+            false,
+            true,
+            true
         );
     }
 


### PR DESCRIPTION
The SAML2 version bump contains a change in the way AllowCreate is to be set in SAML2: https://github.com/simplesamlphp/saml2/commit/aecda70e72970c8d66af1d18d5b762a8df5731ed.

We were setting this as a string and this caused AllowCreate not to be set anymore, while there are some IdPs out there that require it.
This PR aims to fix that.

In order to properly test this and future requirements regarding AuthnRequests, this PR also introduces infrastructure to be able to query the encoded AuthnRequest XML present in the HTTP response's body. 