### PR TITLE
Remove backups when replacing includes for zend framework

### DIFF
--- a/bin/composer/zend-framework-post-install.sh
+++ b/bin/composer/zend-framework-post-install.sh
@@ -12,5 +12,11 @@ ROOT_DIR="$(cd -P "$(dirname $0)/../../" && pwd)"
 cd $ROOT_DIR
 
 cd vendor/zendframework
+
+# BSD's "-i" requires an extension for backups.
+# To prevent ".php-e" files we explicitly use ".bak" and remove the backups when we're done
+# See: http://stackoverflow.com/a/4247319
 find . -name '*.php' -print0  | \
-xargs -0 sed -E -i -e "s#(include|require)_once[^;]*\.php['\"][)]?;##g"
+xargs -0 sed -E -i '.bak' -e "s#(include|require)_once[^;]*\.php['\"][)]?;##g"
+find . -name '*.php.bak' -print0  | \
+xargs -0 rm -f


### PR DESCRIPTION
We are explicitly creating backups in order to be sure this works on every system (or most systems)

This is backported from master: https://github.com/OpenConext/OpenConext-engineblock/pull/372