### PR TITLE
Re-enable EPPN subjecIdField choice

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
+++ b/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
@@ -25,7 +25,13 @@ class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_F
     public function execute()
     {
         $userDirectory = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getUserDirectory();
-        $user = $userDirectory->identifyUser($this->_responseAttributes);
+
+        $subjectIdField = EngineBlock_ApplicationSingleton::getInstance()->getConfigurationValue(
+            'subjectIdAttribute',
+           'uid+sho' 
+        );
+
+        $user = $userDirectory->identifyUser($this->_responseAttributes, $subjectIdField);
 
         $collabPersonIdValue = $user->getCollabPersonId()->getCollabPersonId();
         $this->setCollabPersonId($collabPersonIdValue);

--- a/library/EngineBlock/Corto/Filter/Command/ValidateRequiredAttributes.php
+++ b/library/EngineBlock/Corto/Filter/Command/ValidateRequiredAttributes.php
@@ -5,6 +5,7 @@ use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
 class EngineBlock_Corto_Filter_Command_ValidateRequiredAttributes extends EngineBlock_Corto_Filter_Command_Abstract
 {
     const URN_MACE_TERENA_SCHACHOMEORG = 'urn:mace:terena.org:attribute-def:schacHomeOrganization';
+    const URN_MACE_DIR_UID = 'urn:mace:dir:attribute-def:uid';
 
     /**
      * This command may modify the response attributes
@@ -28,6 +29,17 @@ class EngineBlock_Corto_Filter_Command_ValidateRequiredAttributes extends Engine
                 $this->_identityProvider->schacHomeOrganization
             );
             $excluded[] = static::URN_MACE_TERENA_SCHACHOMEORG;
+        }
+
+        $subjectIdField = EngineBlock_ApplicationSingleton::getInstance()->getConfigurationValue(
+            'subjectIdAttribute',
+           'uid+sho'
+        );
+
+       // If engineblock is configured to use eppn as subjectIdField, sho and uid should not be mandatory
+       if ($subjectIdField == 'eppn') {
+          $excluded[] = static::URN_MACE_TERENA_SCHACHOMEORG;
+          $excluded[] = static::URN_MACE_DIR_UID;
         }
 
         $validationResult = EngineBlock_ApplicationSingleton::getInstance()


### PR DESCRIPTION
valid values for subjectIdField are "uid+sho" for old uid & schacHomeOrganisation behaviour, and new eppn for EdupersonPrincipalName behaviour. eppn can't be enabled when feature ldap_integration is enabled.