### PR TITLE
Bugfix: debug page causes invalid authentication state

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -70,6 +70,8 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         if ($receivedRequest->isDebugRequest()) {
             $_SESSION['debugIdpResponse'] = $receivedResponse;
 
+            // Authentication state needs to be registered here as the debug flow differs from the regular flow,
+            // yet the procedures for both are completed when consuming the assertion in the ServiceProviderController
             $identityProvider = new Entity(new EntityId($idp->entityId), EntityType::IdP());
             $authenticationState = $this->_session->get('authentication_state');
             $authenticationState->authenticatedAt($identityProvider);

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -69,7 +69,15 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
 
         if ($receivedRequest->isDebugRequest()) {
             $_SESSION['debugIdpResponse'] = $receivedResponse;
-            $this->_server->redirect($this->_server->getUrl('debugSingleSignOnService'), 'Show original Response from IDP');
+
+            $identityProvider = new Entity(new EntityId($idp->entityId), EntityType::IdP());
+            $authenticationState = $this->_session->get('authentication_state');
+            $authenticationState->authenticatedAt($identityProvider);
+
+            $this->_server->redirect(
+                $this->_server->getUrl('debugSingleSignOnService'),
+                'Show original Response from IDP'
+            );
             return;
         }
 

--- a/src/OpenConext/EngineBlockBundle/Controller/DebugController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/DebugController.php
@@ -5,17 +5,29 @@ namespace OpenConext\EngineBlockBundle\Controller;
 use EngineBlock_ApplicationSingleton;
 use EngineBlock_Corto_Adapter;
 use OpenConext\EngineBlockBridge\ResponseFactory;
+use OpenConext\Value\Saml\Entity;
+use OpenConext\Value\Saml\EntityId;
+use OpenConext\Value\Saml\EntityType;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-class DebugController
+class DebugController implements AuthenticationLoopThrottlingController
 {
     /**
      * @var EngineBlock_ApplicationSingleton
      */
     private $engineBlockApplicationSingleton;
 
-    public function __construct(EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton)
-    {
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    public function __construct(
+        EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton,
+        SessionInterface $session
+    ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
+        $this->session = $session;
     }
 
     /**
@@ -26,6 +38,9 @@ class DebugController
         $proxyServer = new EngineBlock_Corto_Adapter();
 
         $proxyServer->debugSingleSignOn();
+
+        $authenticationState = $this->session->get('authentication_state');
+        $authenticationState->startAuthenticationOnBehalfOf(new Entity(new EntityId('debug_sp'), EntityType::SP()));
 
         return ResponseFactory::fromEngineBlockResponse($this->engineBlockApplicationSingleton->getHttpResponse());
     }

--- a/src/OpenConext/EngineBlockBundle/Controller/DebugController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/DebugController.php
@@ -39,6 +39,8 @@ class DebugController implements AuthenticationLoopThrottlingController
 
         $proxyServer->debugSingleSignOn();
 
+        // Authentication state needs to be registered here as the debug flow differs from the regular flow,
+        // yet the procedures for both are completed when consuming the assertion in the ServiceProviderController
         $authenticationState = $this->session->get('authentication_state');
         $authenticationState->startAuthenticationOnBehalfOf(new Entity(new EntityId('debug_sp'), EntityType::SP()));
 

--- a/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
@@ -43,6 +43,7 @@ services:
         class: OpenConext\EngineBlockBundle\Controller\DebugController
         arguments:
             - "@engineblock.compat.application"
+            - "@session"
 
     engineblock.controller.authentication.wayf:
         class: OpenConext\EngineBlockBundle\Controller\WayfController


### PR DESCRIPTION
This PR solves #380.

Issues were caused by debug requests not registering authentication states correctly. 