### PR TITLE
Remove legacy 'selectedIdp' cookie.

### DIFF
--- a/app/Resources/views/modules/Authentication/View/Proxy/discover.phtml
+++ b/app/Resources/views/modules/Authentication/View/Proxy/discover.phtml
@@ -10,7 +10,6 @@ use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;
  * @var array $idpList
  * @var string $action
  * @var string $ID
- * @var string $preselectedIdp
  */
 
 /**

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -360,7 +360,6 @@ class EngineBlock_Corto_Adapter
         $proxyServer->setConfigs(array(
             'debug' => $application->getConfigurationValue('debug', false),
             'ConsentStoreValues' => $this->_getConsentConfigurationValue('storeValues', true),
-            'rememberIdp' => '+3 months',
             'metadataValidUntilSeconds' => 86400, // This sets the time (in seconds) the entity metadata is valid.
         ));
 

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -373,7 +373,6 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         $output = $this->_server->renderTemplate(
             'discover',
             array(
-                'preselectedIdp'                      => $this->_server->getCookie('selectedIdp'),
                 'action'                              => $action,
                 'cutoffPointForShowingUnfilteredIdps' => EngineBlock_ApplicationSingleton::getInstance()
                     ->getDiContainer()

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -335,12 +335,6 @@ class EngineBlock_Corto_ProxyServer
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $spRequest,
         $idpEntityId
     ) {
-        $cookieExpiresStamp = null;
-        if (isset($this->_configs['rememberIdp'])) {
-            $cookieExpiresStamp = strtotime($this->_configs['rememberIdp']);
-        }
-        $this->setCookie('selectedIdp', $idpEntityId, $cookieExpiresStamp);
-
         $originalId = $spRequest->getId();
 
         $identityProvider = $this->getRepository()->fetchIdentityProviderByEntityId($idpEntityId);

--- a/theme/material/templates/modules/Authentication/View/Proxy/discover.phtml
+++ b/theme/material/templates/modules/Authentication/View/Proxy/discover.phtml
@@ -9,7 +9,6 @@ use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;
  * @var array $idpList
  * @var string $action
  * @var string $ID
- * @var string $preselectedIdp
  */
 
 /**


### PR DESCRIPTION
This has been supplanted by 'selectedidps' (with `s`) introduced in EB 4.5.
However, the old cookie was not removed at that time.