### PR TITLE
New Metadata API & Metadata Storage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Also, the following documentation can be found in the [docs][docs] directory:
 1. [Release Procedure][docs-release]
 1. [EngineBlock Input and Output Command Chains][docs-filter]
 1. [Release notes for releases < 5.0.0][docs-release-notes]
+1. [Metadata Documentation][docs-metadata]
 
 [travis-build]: https://travis-ci.org/OpenConext/OpenConext-engineblock
 [license]: LICENSE-2.0.txt
@@ -216,3 +217,4 @@ Also, the following documentation can be found in the [docs][docs] directory:
 [docs-release]: https://github.com/OpenConext/OpenConext-engineblock/tree/master/docs/release_procedure.md
 [docs-filter]: https://github.com/OpenConext/OpenConext-engineblock/tree/master/docs/filter_commands.md
 [docs-release-notes]: https://github.com/OpenConext/OpenConext-engineblock/tree/master/docs/release_notes
+[docs-metadata]: https://github.com/OpenConext/OpenConext-engineblock/blob/feature/metadata-api/docs/Metadata/index.md

--- a/docs/Metadata/Metadata-Structure.md
+++ b/docs/Metadata/Metadata-Structure.md
@@ -1,0 +1,119 @@
+# Metadata
+
+Below an overview of the Metadata structure which will be used as internal representation of metadata.
+Where relevant, additional information is listed.
+
+## IdentityProvider
+
+```
+IdentityProvider
+├── Entity                                      > Entity Descriptor
+│   ├── EntityId
+│   └── EntityType                              > saml20-sp|saml20-idp
+├── IdentityProviderSamlConfiguration           > Saml Specific Configuration
+│   ├── EntitySamlConfiguration
+│   │   ├── NameIdFormat                        > preferred NameID format
+│   │   ├── NameIdFormatList                    > allowed NameID formats - used in Metadata
+│   │   │   └── NameIdFormat[]
+│   │   ├── CertificateList
+│   │   │   └── Certificate[]
+│   │   ├── SingleLogoutService                 > represented as Endpoint(Binding, location(, responselocation))
+│   │   ├── ResponseProcessingService           > represented as Endpoint(Binding, location(, responselocation))
+│   │   ├── ContactPersonList                   > Used in Metadata
+│   │   │   └── ContactPerson[]
+│   │   │       ├── ContactType
+│   │   │       ├── EmailAddressList
+│   │   │       │   └── EmailAddress[]
+│   │   │       ├── TelephoneNumberList
+│   │   │       │   └── TelephoneNumber[]
+│   │   │       ├── GivenName (optional)
+│   │   │       ├── Surname (optional)
+│   │   │       └── Company (optional)
+│   │   └── Organization                        > Used in Metadata
+│   │       ├── OrganizationNameList
+│   │       │   └── OrganizationName[]          > (name, language)
+│   │       ├── OrganizationDisplayNameList
+│   │       │   └── OrganizationDisplayName[]   > (displayname, language)
+│   │       └── OrganizationUrlList
+│   │           └── OrganizationUrl[]           > (url, language)
+│   ├── SingleSignOnServices
+│   │   └── Endpoint[]                          > (Binding, location(, responselocation)) 
+│   └── ShibbolethMetadataScopeList
+│       └── ShibbolethMetadataScope[]           > (scope, isRegexp)
+├── IdentityProviderConfiguration               > EngineBlock specific configuration for an IdentityProvider, used during login
+│   ├── EntityConfiguration
+│   │   ├── AttributeManipulationCode           > 
+│   │   ├── WorkflowState                       > testaccepted|prodaccepted | required, no default
+│   │   ├── requiresAdditionalLogging           > bool | default: false
+│   │   ├── disableScoping                      > bool | default: false
+│   │   └── requiresSignedRequests              > bool | default: false
+│   ├── ServiceProvidersWithoutConsent          > Represented as EntitySet(Entity[])
+│   │   └── Entity[]                            > (EntityId, EntityType)
+│   └── GuestQualifier                          > (All|Some|None) | not req., default: All
+└── IdentityProviderAttributes                  > Specific attributes for an IdentityProvider | all optional
+    ├── EntityAttributes
+    │   ├── LocalizedServiceName
+    │   │   └── LocalizedName[]                 > (name, locale)
+    │   ├── LocalizedDescription
+    │   │   └── LocalizedText[]                 > (text, locale)
+    │   └── Logo                                > (url, width, height)
+    ├── isHidden                                > bool, whether or not IdP shows up in metadata and WAYF | default: false
+    ├── enabledInWayf                           > bool, whether or not IdP shows up in WAYF (lower precedence than isHidden) | default: true
+    └── Keywords
+        └── LocalizedKeywords[]                 > (locale, string[])
+```
+
+## ServiceProvider
+
+```
+ServiceProvider
+├── Entity                                      > Entity Descriptor
+│   ├── EntityId
+│   └── EntityType                              > saml20-sp|saml20-idp
+├── ServiceProviderSamlConfiguration            > Saml Specific Configuration
+│   ├── EntitySamlConfiguration
+│   │   ├── NameIdFormat                        > preferred NameID format
+│   │   ├── NameIdFormatList                    > allowed NameID formats - used in Metadata
+│   │   │   └── NameIdFormat[]
+│   │   ├── CertificateList
+│   │   │   └── Certificate[]
+│   │   ├── SingleLogoutService                 > represented as Endpoint(Binding, location(, responselocation))
+│   │   ├── ResponseProcessingService           > represented as Endpoint(Binding, location(, responselocation))
+│   │   ├── ContactPersonList                   > Used in Metadata
+│   │   │   └── ContactPerson[]
+│   │   │       ├── ContactType
+│   │   │       ├── EmailAddressList
+│   │   │       │   └── EmailAddress[]
+│   │   │       ├── TelephoneNumberList
+│   │   │       │   └── TelephoneNumber[]
+│   │   │       ├── GivenName (optional)
+│   │   │       ├── Surname (optional)
+│   │   │       └── Company (optional)
+│   │   └── Organization                        > Used in Metadata
+│   │       ├── OrganizationNameList
+│   │       │   └── OrganizationName[]          > (name, language)
+│   │       ├── OrganizationDisplayNameList
+│   │       │   └── OrganizationDisplayName[]   > (displayname, language)
+│   │       └── OrganizationUrlList
+│   │           └── OrganizationUrl             > (url, language)
+│   ├── AssertionConsumerServices
+│   │   └── IndexedEndpoint[]                   > (Endpoint(Binding, location(, responselocation), index, isDefault) 
+├── ServiceProviderConfiguration                > EngineBlock specific configuration for a ServiceProvider, used during login
+│   ├── displayUnconnectedIdpsInWayf            > bool | default: false
+│   ├── isTrustedProxy                          > bool | default: false
+│   ├── isTransparentIssuer                     > bool | default: false
+│   ├── requiresConsent                         > bool | default: true
+│   ├── denormalizationShouldBeSkipped          > bool | default: false
+│   ├── requiresPolicyEnforcementDecision       > bool | default: false
+│   └── requiresAttributeAggregation            > bool | default: false
+└── ServiceProviderAttributes                   > Specific attributes for a ServiceProvider | all optional
+    ├── EntityAttributes
+    │   ├── LocalizedServiceName
+    │   │   └── LocalizedName[]                 > (name, locale)
+    │   ├── LocalizedDescription
+    │   │   └── LocalizedText[]                 > (text, locale)
+    │   └── Logo                                > (url, width, height)
+    ├── TermsOfServiceUrl                       > represented as LocalizedUri(uri, locale)
+    └── LocalizedSupportUrl
+        └── LocalizedUri[]                      > (uri, locale)
+```

--- a/docs/Metadata/Metadata-json.md
+++ b/docs/Metadata/Metadata-json.md
@@ -1,0 +1,136 @@
+# 
+
+Both:
+```
+{
+    'type': 'saml20-sp'|'saml20-idp'                    // assembleConnection
+    'state': 'prodaccepted'|'testaccepted'               // assembleCommon
+    'metadata': {
+        'name': [
+            'nl': (string)                              // assembleCommon
+            'en': (string)                              // assembleCommon
+        ],
+        'displayName': [
+            'nl': (string)                              // assembleCommon
+            'en': (string)                              // assembleCommon
+        ],
+        'description': [
+            'nl': (string)                              // assembleCommon
+            'en': (string)                              // assembleCommon
+        ],
+        'logo': [   
+            {
+                'url': (string)                         // assembleLogo
+                'width': opt.???                        // assembleLogo
+                'height': opt.???                       // assembleLogo
+            }
+        ],
+        'OrganizationName': [
+            'nl': (string|opt.),                        // assembleOrganization
+            'en': (string|opt.)                         // assembleOrganization
+        ],
+        'OrganizationDisplayName': [
+            'nl': (string|opt.),                        // assembleOrganization
+            'en': (string|opt.)                         // assembleOrganization
+        ],
+        'OrganizationURL': [
+            'nl': (string|opt.),                        // assembleOrganization
+            'en': (string|opt.)                         // assembleOrganization
+        ],
+        'keywords': [
+            'nl': (string)                              // assembleCommon
+            'en': (string)                              // assembleCommon
+        ],
+        'coin': {
+            'publish_in_edugain': (bool)                // assembleCommon // assemblePublishInEdugainDate
+            'disable_scoping': (bool)                   // assembleCommon
+            'additional_logging': (bool)                // assembleCommon
+        }
+        'certData': (string|opt.)                       // assembleCertificates
+        'certData2': (string|opt.)                      // assembleCertificates
+        'certData3': (string|opt.)                      // assembleCertificates
+        'contacts: [
+            {
+                'contactType': (string)                 // assembleContactPersons
+                'emailAddress': (string)                // assembleContactPersons
+                'givenName': (string)                   // assembleContactPersons
+                'surName': (string)                     // assembleContactPersons
+            }
+        ],
+        'NameIDFormat': (string)                        // assembleCommon
+        'NameIDFormats': [                              // assembleCommon
+            (string)                                    // assembleCommon
+        ],
+        'SingleLogoutService: [
+            {
+                'Location': (string)                    // assembleSingleLogoutServices
+                'Binding': (string)                     // assembleSingleLogoutServices
+            }
+        ],
+        'redirect': {
+            'sign': ???                                 // assembleCommon
+        },
+    },
+    'manipulation_code': (string)                       // assembleCommon
+}
+```
+
+SP:
+```
+{
+    'metadata' : {
+        'coin': {
+            'transparent_issuer': (bool)                // assembleSp
+            'trusted_proxy': (bool)                     // assembleSp
+            'implicit_vo_id': (bool)                    // assembleSp
+            'display_unconnected_idps_wayf': (bool)     // assembleSp
+            'eula': (string)                            // assembleSp
+            'do_no_add_attribute_aliases': (bool)       // assembleSp
+            'policy_enforcement_decision_required': (bool) // assembleSp
+        },
+        'AssertionConsumerService': [
+            {
+                'Location': (string)                    // assembleAssertionConsumerService
+                'Binding': (string)                     // assembleAssertionConsumerService
+                'Index': (int)                          // assembleAssertionConsumerService
+            }
+        ]
+    },
+    'arp_attributes': [                                 // assembleAttributeReleasePolicy
+        'attribute_name': [                             // assembleAttributeReleasePolicy
+            'allowed_value1',                           // assembleAttributeReleasePolicy
+            'allowed_value2'                            // assembleAttributeReleasePolicy
+        ],
+    ]
+}
+```
+
+IdP:
+```
+{
+    'metadata': {
+        'SingleSignOnService': [
+            {
+                'Location': (string),                   // assembleSingleSignOnServices
+                'Binding': (string)                     // assembleSingleSignOnServices
+            }
+        ],
+        'coin': {
+            'guest_qualifier': (string)                 // assembleIdp
+            'schacHomeOrganization': (string)           // assembleIdp
+            'hidden': (bool)                            // assembleIdp
+        },
+        'shibmd': {                                     // assembleShibMdScope
+            'scope': [                                  // assembleShibMdScope
+                'allowed': (string)                     // assembleShibMdScope
+                'regexp': (bool)                        // assembleShibMdScope
+            ]
+        }
+    },
+    'disable_consent_connections': [
+        {
+            'name': (string)                            // assembleSpEntityIdsWithoutConsent
+        }
+    ]
+}
+```

--- a/docs/Metadata/SamlEntity.md
+++ b/docs/Metadata/SamlEntity.md
@@ -1,0 +1,117 @@
+# SamlEntity
+
+Note: this document is best viewed in raw format.
+
+This document was used to identify, structure and "translate" the current inflexible metadata representation to the new
+ structure metadata representation. This links the existing database fields to the new ValueObjects.
+ 
+This document is to be considered deprecated, but for now is kept as it may be informative whilst the new metadata
+ structure has not been rolled out yet.
+
+## Entity Data Definition (EntityAttributes)
+
+- [X] id INT(11) PRIMARY KEY NOT NULL,                              **id**
+- [X]                                                               **SamlEntityUuid**
+- [X] entity_id VARCHAR(255) NOT NULL,                              **Entity\EntityId**
+- [X] type VARCHAR(255) NOT NULL,                                   **Entity\EntityType**
+
+## SAML compliance
+
+### SP (ServiceProviderSamlConfiguration)
+- [X] assertion_consumer_services LONGTEXT COMMENT '(DC2Type:array)',   _set<>_
+- [X] ^- AssertionConsumerServices  
+  Represented as: `assertion_consumer_services: a:1:{i:0;O:55:"OpenConext\Component\EngineBlockMetadata\IndexedService":4:{s:12:"serviceIndex";i:0;s:9:"isDefault";N;s:7:"binding";s:46:"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";s:8:"location";s:45:"https://nyenrode.shop.canon-bs.nl/extern/saml";}}`
+
+### [X] IdP (IdentityProviderSamlConfiguration)
+- [X] shib_md_scopes LONGTEXT COMMENT '(DC2Type:array)',                _list<string>_ **keep, already implemented**
+- [X] single_sign_on_services LONGTEXT COMMENT '(DC2Type:array)',       _list<>_
+- [X] ^- SingleSignOnServices  
+  Represented as: `a:2:{i:0;O:48:"OpenConext\Component\EngineBlockMetadata\Service":2:{s:7:"binding";s:50:"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";s:8:"location";s:37:"https://teamwerk.fed.vumc.nl/adfs/ls/";}i:1;O:48:"OpenConext\Component\EngineBlockMetadata\Service":2:{s:7:"binding";s:46:"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";s:8:"location";s:37:"https://teamwerk.fed.vumc.nl/adfs/ls/";}}`
+
+### [X] BOTH (EntitySamlConfiguration)
+- [X] certificates LONGTEXT NOT NULL COMMENT '(DC2Type:array)',         _list<string>_  **keep <SAML2 certs?>** <- custom classes with toSaml2Cert
+- [X] single_logout_service LONGTEXT COMMENT '(DC2Type:object)',        _Endpoint_
+- [X] response_processing_service_binding VARCHAR(255),                 _Endpoint_ (optional, seems to be used interal only?
+- [X] name_id_format VARCHAR(255),                                      _NameIdFormat_        **keep <preferred NameID format>**  
+- [X] name_id_formats LONGTEXT NOT NULL COMMENT '(DC2Type:array)',      _NameIdFormatList_  **keep <allowed NameID formats>**
+- [X] + ContactPersonList (below)
+- [X] + Organization (below) - optional field, may not exist
+
+#### Organization
+
+- [X] organization_nl_name LONGTEXT COMMENT '(DC2Type:object)',     **keep <is organization, if FQ>**
+- [X] organization_en_name LONGTEXT COMMENT '(DC2Type:object)',     **keep <is organization, if FQ>**
+- [X] display_name_nl VARCHAR(255) NOT NULL,                        **keep @DEPRECATE <used in WAYF> -> OrganisationDisplayName should be used instead**
+- [X] display_name_en VARCHAR(255) NOT NULL,                        **keep @DEPRECATE <used in WAYF> -> OrganisationDisplayName should be used instead**
+
+#### ContactPersonList
+
+- [X] contact_persons LONGTEXT NOT NULL COMMENT '(DC2Type:array)',
+
+---
+
+## Service Attribute Configuration (IdP/Sp)
+
+Mostly service attributes used for view (UI) related affairs 
+
+### IdP (IdentityProviderAttributes) (IdentityProviderVisibilitySettings)
+- [X] keywords_nl VARCHAR(255) NOT NULL,                            _string_    **keep <used for metadata AND WAYF>**
+- [X] keywords_en VARCHAR(255) NOT NULL,                            _string_    **keep <used for metadata AND WAYF>**
+- [X] hidden TINYINT(1),                                            **keep**     *****^ Add to***
+- [X] enabled_in_wayf TINYINT(1),                                   **keep**
+
+### SP (ServiceProviderAttributes)
+- [X] terms_of_service_url VARCHAR(255),                            _string_    **keep <used for CONSENT and consent API>**
+- [X] support_url_en VARCHAR(255),                                  _string_    **keep <used for consent API>**
+    - LocalizedUri
+- [X] support_url_nl VARCHAR(255),                                  _string_    **keep <used for consent API>**
+    - LocalizedUri
+- [X] ^- both captured in LocalizedSupportUrls
+
+### BOTH (EntityAttributes)
+- [X] description_nl VARCHAR(255) NOT NULL,                         _string_    **keep <used for metadata>**
+- [X] description_en VARCHAR(255) NOT NULL,                         _string_    **keep <used for metadata>**
+- [X] logo LONGTEXT NOT NULL COMMENT '(DC2Type:object)',            **keep**
+- [X] name_nl VARCHAR(255) NOT NULL,                                **keep <shown i.s.o. organizationDisplayName: "dienst">**
+    - LocalizedName
+- [X] name_en VARCHAR(255) NOT NULL,                                **keep <shown i.s.o. organizationDisplayName: "dienst">**
+    - LocalizedName
+- [X] ^- both captured in LocalizedServiceName
+
+---
+
+## Connections < To create
+
+- [X] allowed_idp_entity_ids LONGTEXT COMMENT '(DC2Type:array)',    **keep _EntitySet in ServiceProvider_**
+
+## Custom Configuration (EngineBlock)
+
+### SP (ServiceProviderConfiguration)
+- [X] display_unconnected_idps_wayf TINYINT(1),                     **keep**
+- [X] is_trusted_proxy TINYINT(1),                                  **keep**
+- [X] is_transparent_issuer TINYINT(1),                             **keep**
+- [X] is_consent_required TINYINT(1),                               **keep**
+- [X] skip_denormalization TINYINT(1),                              **keep**
+- [X] policy_enforcement_decision_required TINYINT(1),              **keep**
+- [X] attribute_aggregation_required TINYINT(1)                     **keep**
+- [X] attribute_release_policy LONGTEXT COMMENT '(DC2Type:array)',  **keep**
+
+### [X] IdP (IdentityProviderConfiguration) < TO CREATE
+
+- [X] sps_entity_ids_without_consent LONGTEXT COMMENT '(DC2Type:array)',    **keep _EntitySet_**
+- [X] guest_qualifier VARCHAR(255),
+
+### Both < (Entity Configuration)
+- [X] additional_logging TINYINT(1) NOT NULL,                       **keep**
+- [X] disable_scoping TINYINT(1) NOT NULL,                          **keep**
+- [X] requests_must_be_signed TINYINT(1) NOT NULL,                  **keep**
+- [X] manipulation LONGTEXT NOT NULL,                               **keep**    ******^ add to*****
+- [X] workflow_state VARCHAR(255) NOT NULL,                         **keep**
+
+## Deprecated Fields
+
+- [-] implicit_vo_id VARCHAR(255),                                  **@DEPRECATED vo auth stuff [REMOVE]**
+- [-] publish_in_edugain TINYINT(1) NOT NULL,                       **@DEPRECATED edugain metadata stuff [REMOVE]**
+- [-] publish_in_edu_gain_date DATE,                                **@DEPRECATED edugain metadata stuff [REMOVE]**
+- [-] schac_home_organization VARCHAR(255),                         **@DEPRECATED replaced with shibmd scope [REMOVE]** 
+- [-] requested_attributes LONGTEXT COMMENT '(DC2Type:array)',      **@DEPRECATED edugain metadata stuff [REMOVE]**

--- a/docs/Metadata/dev_connections_controller.patch
+++ b/docs/Metadata/dev_connections_controller.patch
@@ -1,0 +1,55 @@
+diff --git a/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php b/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
+index 551cde0..7ae0c99 100644
+--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
++++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
+@@ -3,6 +3,7 @@
+ namespace OpenConext\EngineBlockBundle\Controller\Api;
+ 
+ use EngineBlock_ApplicationSingleton;
++use OpenConext\EngineBlockBundle\Metadata\Service\MetadataConnectionsFactory;
+ use OpenConext\Component\EngineBlockMetadata\Entity\Assembler\JanusPushMetadataAssembler;
+ use OpenConext\Component\EngineBlockMetadata\MetadataRepository\DoctrineMetadataRepository;
+ use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
+@@ -47,6 +48,8 @@ class ConnectionsController
+ 
+     public function pushConnectionsAction(Request $request)
+     {
++        //file_put_contents('../pushed_connections.json', $request->getContent());
++
+         if (!$this->featureConfiguration->isEnabled('api.metadata_push')) {
+             return new JsonResponse(null, 404);
+         }
+@@ -57,20 +60,25 @@ class ConnectionsController
+ 
+         ini_set('memory_limit', '265M');
+ 
+-        $body = JsonRequestHelper::decodeContentOf($request);
++        $requestData = JsonRequestHelper::decodeContentOf($request);
+ 
+-        if (!is_object($body) || !isset($body->connections) && !is_object($body->connections)) {
++        if (!isset($requestData['connections']) || !is_array($requestData['connections'])) {
+             throw new BadApiRequestHttpException('Unrecognized structure for JSON');
+         }
+ 
+-        $assembler = new JanusPushMetadataAssembler();
+-        $roles     = $assembler->assemble($body->connections);
++        //file_put_contents('../pushed_connections.json', json_encode($requestData, JSON_PRETTY_PRINT));
+ 
+-        $diContainer = $this->engineBlockApplicationSingleton->getDiContainer();
+-        $doctrineRepository = DoctrineMetadataRepository::createFromConfig([], $diContainer);
++        $connections = MetadataConnectionsFactory::createConnectionsFrom($requestData['connections']);
+ 
+-        $result = $doctrineRepository->synchronize($roles);
++        //        $assembler = new JanusPushMetadataAssembler();
++        //        $roles     = $assembler->assemble($body->connections);
+ 
+-        return new JsonResponse($result);
++        //        $diContainer = $this->engineBlockApplicationSingleton->getDiContainer();
++        //        $doctrineRepository = DoctrineMetadataRepository::createFromConfig([], $diContainer);
++        //
++        //        $result = $doctrineRepository->synchronize($roles);
++        //
++        //        return new JsonResponse($result);
++        file_put_contents('../exported_connections', '<?php ' . PHP_EOL . var_export($connections, true) . ';');
+     }
+ }

--- a/docs/Metadata/index.md
+++ b/docs/Metadata/index.md
@@ -1,0 +1,16 @@
+# Metadata Documentation
+
+In this folder you can find several documents relating to the transformation of the internal EngineBlock Metadata 
+ representation and storage mechanism to a stricter representation and more flexible storage mechanism.
+
+The following documents are available:
+
+- [Metadata Structure][1], outlining the new metadata structure
+- [Metadata json][2], outlining the JSON as it is being sent by Janus. Leading for what mustr be supported.
+- [Questions and Findings][3], several open questions and remarks, things that deserve investigation
+- [SamlEntity][4], a (deprecated) document about the transformation of metadata representation and storage
+
+[1]: https://github.com/OpenConext/OpenConext-engineblock/blob/feature/metadata-api/docs/Metadata/Metadata-Structure.md
+[2]: https://github.com/OpenConext/OpenConext-engineblock/blob/feature/metadata-api/docs/Metadata/Metadata-json.md
+[3]: https://github.com/OpenConext/OpenConext-engineblock/blob/feature/metadata-api/docs/Metadata/questions-and-findings.md
+[4]: https://github.com/OpenConext/OpenConext-engineblock/blob/feature/metadata-api/docs/Metadata/SamlEntity.md

--- a/docs/Metadata/questions-and-findings.md
+++ b/docs/Metadata/questions-and-findings.md
@@ -1,0 +1,74 @@
+# Metadata Marshalling
+
+## NameIdFormat
+- Current dev metadata of https://engine.vm.openconext.org/authentication/idp/metadata does not contain NameIdFormat 
+- Prod metadata (4 cases): "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified", value object supports only SAML:1.1 unspecified
+
+## Email addresses
+- Prod metadata (47 cases): contact person email address contains "mailto:", value object does not support it
+    - Add to Value Object
+- Prod metadata (? cases): contact person email address contains empty string, value object does not support it
+    - How should we handle this?
+- Prod metadata (2 cases): contact person email address contains name instead of email, value object does not support it
+    - This should be fixed by clients
+
+## Logo
+- Prod metadata (2 cases), can be empty, value object does not support it
+
+## Binding
+- Prod metadata (100+ cases): "urn:oasis:names:tc:SAML:2.0:bindings:PAOS", value object does not support it
+- Prod metadata (1 case): "urn:oasis:names:tc:SAML:2.0:bindings:URI", value object does not support it
+- Prod metadata (2 cases): contains empty binding (in assertion consumer services and single logout service); supported? defaul?
+
+## Allowed NameIdFormats
+- Current dev metadata of Shibboleth does not have the `NameIdFormats` attribute. 
+    - NameIdFormats = opt. (empty list)
+
+## SingleLogoutService
+- Current dev metadata does not contain single logout service, should the attribute be optional?
+    - It might
+- Represented in JSON as an array, only one endpoint as an object? 
+    - Only 1
+
+## ShibMdScope
+- Current dev metadata does not contain shib md scopes, should they be optional?
+- Are there multiple shibmd scopes possible?
+
+## SingleSignOnService
+- Represented in json as an array, only one endpoint as an object? 
+    - Endpoints (multiple)
+
+## Attribute Manipulation Code
+- Non empty string, but required? What should the value be if non given?
+
+## AssertionConsumerServices
+- How to determine 'isDefault' in indexedEndpoints?
+- Can there be multiple AssertionConsumerServices endpoints without an index defined?
+- Can there be AssertionConsumerServices endpoints that have an index next to those that don't?
+
+## Endpoint (ACS, SLS, SSOS)
+- Can 'location' be empty in an endpoint?
+- Is 'ResponseLocation' ever used?
+
+## ServiceProviderConfiguration
+- denormalizationShouldBeSkipped: what metadata key is used
+- requiresAttributeAggregation: what metdata key is used
+
+## Logo
+- Width and height are optional in the metadata, value object does not support this
+
+## Disabled in WAYF
+- How is this represented in JSON?
+    - coin:publish_in_edugain?
+
+## SupportUrl (url)
+- Can turn up as empty string in the metadata; value object does not support this
+
+## ContactPerson values (surName, givenName, email adress in email address list, ...)
+- Can turn up as empty string in the metadata; value object does not support this
+
+## Description
+- Can turn up as empty string in the metadata; value object does not support this
+
+## ShibMdScope scope
+- Can turn up as empty string in the metadata; svalue object does not support this

--- a/src/OpenConext/EngineBlock/Exception/DomainException.php
+++ b/src/OpenConext/EngineBlock/Exception/DomainException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OpenConext\EngineBlock\Exception;
+
+use DomainException as CoreDomainException;
+
+final class DomainException extends CoreDomainException implements Exception
+{
+    /**
+     * We override the parent constructor to only allow the message parameter. A DomainException does not need a
+     * specific code nor should it be thrown as the result of a previous exception; it is always the result of a domain
+     * constraint violation.
+     *
+     * @param string $message
+     */
+    public function __construct($message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/Model/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Model/IdentityProvider.php
@@ -2,6 +2,10 @@
 
 namespace OpenConext\EngineBlock\Metadata\Model;
 
+use OpenConext\EngineBlock\Exception\DomainException;
+use OpenConext\EngineBlock\Metadata\Value\IdentityProviderAttributes;
+use OpenConext\EngineBlock\Metadata\Value\IdentityProviderConfiguration;
+use OpenConext\EngineBlock\Metadata\Value\IdentityProviderSamlConfiguration;
 use OpenConext\EngineBlock\Metadata\Value\SamlEntityUuid;
 use OpenConext\Value\Saml\Entity;
 use OpenConext\Value\Saml\EntityId;
@@ -13,14 +17,40 @@ final class IdentityProvider
      */
     private $entity;
 
-    public static function create(Entity $entity)
-    {
-        return new self($entity);
-    }
+    /**
+     * @var IdentityProviderSamlConfiguration
+     */
+    private $identityProviderSamlConfiguration;
 
-    private function __construct(Entity $entity)
-    {
+    /**
+     * @var IdentityProviderConfiguration
+     */
+    private $identityProviderConfiguration;
+
+    /**
+     * @var IdentityProviderAttributes
+     */
+    private $identityProviderAttributes;
+
+    public function __construct(
+        Entity $entity,
+        IdentityProviderSamlConfiguration $identityProviderSamlConfiguration,
+        IdentityProviderConfiguration $identityProviderConfiguration,
+        IdentityProviderAttributes $identityProviderAttributes
+    ) {
+        if (!$entity->isIdentityProvider()) {
+            $message = sprintf(
+                'Can only create an IdentityProvider model for an Entity that is an IdentityProvider, entity "%s"'
+                . ' is not an IdentityProvider',
+                (string) $entity
+            );
+            throw new DomainException($message);
+        }
+
         $this->entity = $entity;
+        $this->identityProviderSamlConfiguration = $identityProviderSamlConfiguration;
+        $this->identityProviderConfiguration = $identityProviderConfiguration;
+        $this->identityProviderAttributes = $identityProviderAttributes;
     }
 
     /**
@@ -29,6 +59,38 @@ final class IdentityProvider
     public function getEntityId()
     {
         return $this->entity->getEntityId();
+    }
+
+    /**
+     * @return Entity
+     */
+    public function getEntity()
+    {
+        return $this->entity;
+    }
+
+    /**
+     * @return IdentityProviderSamlConfiguration
+     */
+    public function getIdentityProviderSamlConfiguration()
+    {
+        return $this->identityProviderSamlConfiguration;
+    }
+
+    /**
+     * @return IdentityProviderConfiguration
+     */
+    public function getIdentityProviderConfiguration()
+    {
+        return $this->identityProviderConfiguration;
+    }
+
+    /**
+     * @return IdentityProviderAttributes
+     */
+    public function getIdentityProviderAttributes()
+    {
+        return $this->identityProviderAttributes;
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Model/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Model/ServiceProvider.php
@@ -3,6 +3,9 @@
 namespace OpenConext\EngineBlock\Metadata\Model;
 
 use OpenConext\EngineBlock\Metadata\Value\SamlEntityUuid;
+use OpenConext\EngineBlock\Metadata\Value\ServiceProviderAttributes;
+use OpenConext\EngineBlock\Metadata\Value\ServiceProviderConfiguration;
+use OpenConext\EngineBlock\Metadata\Value\ServiceProviderSamlConfiguration;
 use OpenConext\Value\Saml\Entity;
 use OpenConext\Value\Saml\EntityId;
 
@@ -13,14 +16,31 @@ final class ServiceProvider
      */
     private $entity;
 
-    public static function create(Entity $entity)
-    {
-        return new self($entity);
-    }
+    /**
+     * @var ServiceProviderSamlConfiguration
+     */
+    private $serviceProviderSamlConfiguration;
 
-    private function __construct(Entity $entity)
-    {
+    /**
+     * @var ServiceProviderConfiguration
+     */
+    private $serviceProviderConfiguration;
+
+    /**
+     * @var ServiceProviderAttributes
+     */
+    private $serviceProviderAttributes;
+
+    public function __construct(
+        Entity $entity,
+        ServiceProviderSamlConfiguration $serviceProviderSamlConfiguration,
+        ServiceProviderConfiguration $serviceProviderConfiguration,
+        ServiceProviderAttributes $serviceProviderAttributes
+    ) {
         $this->entity = $entity;
+        $this->serviceProviderSamlConfiguration = $serviceProviderSamlConfiguration;
+        $this->serviceProviderConfiguration = $serviceProviderConfiguration;
+        $this->serviceProviderAttributes = $serviceProviderAttributes;
     }
 
     /**
@@ -29,6 +49,38 @@ final class ServiceProvider
     public function getEntityId()
     {
         return $this->entity->getEntityId();
+    }
+
+    /**
+     * @return Entity
+     */
+    public function getEntity()
+    {
+        return $this->entity;
+    }
+
+    /**
+     * @return ServiceProviderSamlConfiguration
+     */
+    public function getServiceProviderSamlConfiguration()
+    {
+        return $this->serviceProviderSamlConfiguration;
+    }
+
+    /**
+     * @return ServiceProviderConfiguration
+     */
+    public function getServiceProviderConfiguration()
+    {
+        return $this->serviceProviderConfiguration;
+    }
+
+    /**
+     * @return ServiceProviderAttributes
+     */
+    public function getServiceProviderAttributes()
+    {
+        return $this->serviceProviderAttributes;
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Repository/MetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/Repository/MetadataRepository.php
@@ -4,47 +4,9 @@ namespace OpenConext\EngineBlock\Metadata\Repository;
 
 use OpenConext\Value\Saml\EntityId;
 
-class MetadataRepository
+interface MetadataRepository
 {
-    /**
-     * @var SamlEntityRepository
-     */
-    private $samlEntityRepository;
-
-    /**
-     * @var ConnectionRepository
-     */
-    private $connectionRepository;
-
-    public function __construct(
-        SamlEntityRepository $samlEntityRepository,
-        ConnectionRepository $connectionRepository
-    ) {
-        $this->samlEntityRepository = $samlEntityRepository;
-        $this->connectionRepository = $connectionRepository;
-    }
-
-    /**
-     *
-     */
-    public function getSamlEntityBy(EntityId $entityId)
-    {
-
-    }
-
-    /**
-     *
-     */
-    public function getServiceProviderBy(EntityId $entityId)
-    {
-
-    }
-
-    /**
-     *
-     */
-    public function getIdentityProviderBy(EntityId $entityId)
-    {
-
-    }
+    public function getSamlEntityBy(EntityId $entityId);
+    public function getServiceProviderBy(EntityId $entityId);
+    public function getIdentityProviderBy(EntityId $entityId);
 }

--- a/src/OpenConext/EngineBlock/Metadata/Value/EntitySamlConfiguration.php
+++ b/src/OpenConext/EngineBlock/Metadata/Value/EntitySamlConfiguration.php
@@ -48,6 +48,7 @@ final class EntitySamlConfiguration implements Serializable
      */
     private $organization;
 
+    // @codingStandardsIgnoreStart
     /**
      * @param NameIdFormat      $preferredNameIdFormat
      * @param NameIdFormatList  $allowedNameIdFormats
@@ -61,10 +62,10 @@ final class EntitySamlConfiguration implements Serializable
         NameIdFormat $preferredNameIdFormat,
         NameIdFormatList $allowedNameIdFormats,
         CertificateList $certificateList,
-        Endpoint $singleLogoutService,
-        Endpoint $responseProcessingService,
+        Endpoint $singleLogoutService = null,
+        Endpoint $responseProcessingService = null,
         ContactPersonList $contactPersons,
-        Organization $organization = null // <- verify
+        Organization $organization = null
     ) {
         $this->preferredNameIdFormat     = $preferredNameIdFormat;
         $this->allowedNameIdFormats      = $allowedNameIdFormats;
@@ -74,6 +75,7 @@ final class EntitySamlConfiguration implements Serializable
         $this->contactPersons            = $contactPersons;
         $this->organization              = $organization;
     }
+    // @codingStandardsIgnoreEnd
 
     /**
      * @return NameIdFormat
@@ -176,9 +178,9 @@ final class EntitySamlConfiguration implements Serializable
             'preferred_name_id_format' => $this->preferredNameIdFormat->serialize(),
             'allowed_name_id_formats' => $this->allowedNameIdFormats->serialize(),
             'certificate_list' => $this->certificateList->serialize(),
+            'contact_person_list' => $this->contactPersons->serialize(),
             'single_logout_service' => $this->singleLogoutService->serialize(),
             'response_processing_service' => $this->responseProcessingService->serialize(),
-            'contact_person_list' => $this->contactPersons->serialize(),
             'organization' => $this->organization ? $this->organization->serialize() : null
         ];
     }

--- a/src/OpenConext/EngineBlock/Metadata/Value/ServiceProviderAttributes.php
+++ b/src/OpenConext/EngineBlock/Metadata/Value/ServiceProviderAttributes.php
@@ -25,7 +25,7 @@ final class ServiceProviderAttributes implements Serializable
 
     public function __construct(
         EntityAttributes $entityAttributes,
-        LocalizedUri $termsOfServiceUrl,
+        Url $termsOfServiceUrl,
         LocalizedSupportUrl $localizedSupportUrl
     ) {
         $this->entityAttributes    = $entityAttributes;
@@ -91,7 +91,7 @@ final class ServiceProviderAttributes implements Serializable
 
         return new self(
             EntityAttributes::deserialize($data['entity_attributes']),
-            LocalizedUri::deserialize($data['terms_of_service_url']),
+            Url::deserialize($data['terms_of_service_url']),
             LocalizedSupportUrl::deserialize($data['support_urls'])
         );
     }

--- a/src/OpenConext/EngineBlock/Metadata/Value/Url.php
+++ b/src/OpenConext/EngineBlock/Metadata/Value/Url.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace OpenConext\EngineBlock\Metadata\Value;
+
+use OpenConext\EngineBlock\Assert\Assertion;
+use OpenConext\Value\Serializable;
+
+final class Url implements Serializable
+{
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @param string $url
+     */
+    public function __construct($url)
+    {
+        Assertion::nonEmptyString($url, 'url');
+
+        $this->url = $url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param Url $other
+     * @return bool
+     */
+    public function equals(Url $other)
+    {
+        return $this->url === $other->url;
+    }
+
+    public static function deserialize($data)
+    {
+        Assertion::isArray($data);
+        Assertion::keyExists($data, 'url');
+
+        return new self($data['url']);
+    }
+
+    public function serialize()
+    {
+        return array(
+            'url' => $this->url,
+        );
+    }
+
+    public function __toString()
+    {
+        return sprintf('Url(url=%)', $this->url);
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Http/Request/JsonRequestHelper.php
+++ b/src/OpenConext/EngineBlockBundle/Http/Request/JsonRequestHelper.php
@@ -18,13 +18,13 @@ final class JsonRequestHelper
 
     /**
      * @param Request $request
-     * @return int|string|array
+     * @return array
      * @throws BadRequestHttpException
      */
     public static function decodeContentOf(Request $request)
     {
         $contents = $request->getContent();
-        $data     = json_decode($contents);
+        $data     = json_decode($contents, true);
 
         if (json_last_error() === JSON_ERROR_NONE) {
             return $data;

--- a/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataConnectionsFactory.php
+++ b/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataConnectionsFactory.php
@@ -1,0 +1,731 @@
+<?php
+
+namespace OpenConext\EngineBlockBundle\Metadata\Service;
+
+use Exception;
+use OpenConext\EngineBlock\Metadata\Model\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Model\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Value\AssertionConsumerServices;
+use OpenConext\EngineBlock\Metadata\Value\AttributeManipulationCode;
+use OpenConext\EngineBlock\Metadata\Value\Common\LocalizedText;
+use OpenConext\EngineBlock\Metadata\Value\EntityAttributes;
+use OpenConext\EngineBlock\Metadata\Value\EntityConfiguration;
+use OpenConext\EngineBlock\Metadata\Value\EntitySamlConfiguration;
+use OpenConext\EngineBlock\Metadata\Value\GuestQualifier;
+use OpenConext\EngineBlock\Metadata\Value\IdentityProviderAttributes;
+use OpenConext\EngineBlock\Metadata\Value\IdentityProviderConfiguration;
+use OpenConext\EngineBlock\Metadata\Value\IdentityProviderSamlConfiguration;
+use OpenConext\EngineBlock\Metadata\Value\Keywords;
+use OpenConext\EngineBlock\Metadata\Value\LocalizedDescription;
+use OpenConext\EngineBlock\Metadata\Value\LocalizedKeywords;
+use OpenConext\EngineBlock\Metadata\Value\LocalizedServiceName;
+use OpenConext\EngineBlock\Metadata\Value\LocalizedSupportUrl;
+use OpenConext\EngineBlock\Metadata\Value\Logo;
+use OpenConext\EngineBlock\Metadata\Value\ServiceProviderAttributes;
+use OpenConext\EngineBlock\Metadata\Value\ServiceProviderConfiguration;
+use OpenConext\EngineBlock\Metadata\Value\ServiceProviderSamlConfiguration;
+use OpenConext\EngineBlock\Metadata\Value\SingleSignOnServices;
+use OpenConext\EngineBlock\Metadata\Value\Url;
+use OpenConext\EngineBlock\Metadata\Value\WorkflowState;
+use OpenConext\EngineBlock\Metadata\Value\X509\Certificate;
+use OpenConext\EngineBlock\Metadata\Value\X509\CertificateList;
+use OpenConext\Value\Saml\Entity;
+use OpenConext\Value\Saml\EntityId;
+use OpenConext\Value\Saml\EntitySet;
+use OpenConext\Value\Saml\EntityType;
+use OpenConext\Value\Saml\Metadata\Common\Binding;
+use OpenConext\Value\Saml\Metadata\Common\Endpoint;
+use OpenConext\Value\Saml\Metadata\Common\IndexedEndpoint;
+use OpenConext\Value\Saml\Metadata\Common\LocalizedName;
+use OpenConext\Value\Saml\Metadata\Common\LocalizedUri;
+use OpenConext\Value\Saml\Metadata\ContactPerson;
+use OpenConext\Value\Saml\Metadata\ContactPerson\Company;
+use OpenConext\Value\Saml\Metadata\ContactPerson\ContactType;
+use OpenConext\Value\Saml\Metadata\ContactPerson\EmailAddress;
+use OpenConext\Value\Saml\Metadata\ContactPerson\EmailAddressList;
+use OpenConext\Value\Saml\Metadata\ContactPerson\GivenName;
+use OpenConext\Value\Saml\Metadata\ContactPerson\Surname;
+use OpenConext\Value\Saml\Metadata\ContactPerson\TelephoneNumber;
+use OpenConext\Value\Saml\Metadata\ContactPerson\TelephoneNumberList;
+use OpenConext\Value\Saml\Metadata\ContactPersonList;
+use OpenConext\Value\Saml\Metadata\Organization;
+use OpenConext\Value\Saml\Metadata\Organization\OrganizationDisplayName;
+use OpenConext\Value\Saml\Metadata\Organization\OrganizationDisplayNameList;
+use OpenConext\Value\Saml\Metadata\Organization\OrganizationName;
+use OpenConext\Value\Saml\Metadata\Organization\OrganizationNameList;
+use OpenConext\Value\Saml\Metadata\Organization\OrganizationUrl;
+use OpenConext\Value\Saml\Metadata\Organization\OrganizationUrlList;
+use OpenConext\Value\Saml\Metadata\ShibbolethMetadataScope;
+use OpenConext\Value\Saml\Metadata\ShibbolethMetadataScopeList;
+use OpenConext\Value\Saml\NameIdFormat;
+use OpenConext\Value\Saml\NameIdFormatList;
+
+/**
+ * @SuppressWarnings(PHPMD) // we know it's complex...
+ */
+final class MetadataConnectionsFactory
+{
+    public static function createConnectionsFrom(array $connectionData)
+    {
+        $connections = [];
+
+        foreach ($connectionData as $connection) {
+            if (!isset($connection['type'])) {
+                throw new Exception('Invalid JSON structure: connection is missing a type');
+            }
+
+            if ($connection['type'] === EntityType::TYPE_IDP) {
+                $connections['identityProviders'][] = self::createIdentityProviderFrom($connection);
+                continue;
+            }
+
+            if ($connection['type'] === EntityType::TYPE_SP) {
+                $connections['serviceProviders'][] = self::createServiceProviderFrom($connection);
+            }
+        }
+
+        return $connections;
+    }
+
+    private static function createIdentityProviderFrom($connection)
+    {
+        // EntitySamlConfiguration: NameID format
+        if (!isset($connection['metadata']['NameIDFormat'])) {
+            // What to do with non set NameIDFormat?
+            $nameIdFormat = NameIdFormat::unspecified();
+        } else {
+            $nameIdFormat = new NameIdFormat($connection['metadata']['NameIDFormat']);
+        }
+
+        // EntitySamlConfiguration: Allowed NameID formats
+        if (isset($connection['metadata']['NameIDFormats'])) {
+            $allowedNameIdFormats = new NameIdFormatList(
+                array_map(
+                    function ($nameIdFormat) {
+                        return new NameIdFormat($nameIdFormat);
+                    },
+                    $connection['metadata']['NameIDFormats']
+                )
+            );
+        } else {
+            $allowedNameIdFormats = new NameIdFormatList([]);
+        }
+
+        // EntitySamlConfiguration: Certificates
+        $certificates = [];
+        if (isset($connection['metadata']['certdata1'])) {
+            $certificates[] = new Certificate($connection['metadata']['certdata1']);
+        }
+        if (isset($connection['metadata']['certdata2'])) {
+            $certificates[] = new Certificate($connection['metadata']['certdata2']);
+        }
+        if (isset($connection['metadata']['certdata3'])) {
+            $certificates[] = new Certificate($connection['metadata']['certdata3']);
+        }
+        $certificateList = new CertificateList($certificates);
+
+        // EntitySamlConfiguration: Single Logout Service
+        $singleLogoutService = null;
+        if (isset($connection['metadata']['SingleLogoutService'])) {
+            $singleLogoutResponseLocation = null;
+            if (isset($connection['metadata']['SingleLogoutService']['ResponseLocation'])) {
+                $singleLogoutResponseLocation = $connection['metadata']['SingleLogoutService']['ResponseLocation'];
+            }
+
+            $singleLogoutService = new Endpoint(
+                new Binding($connection['metadata']['SingleLogoutService']['Binding']),
+                $connection['metadata']['SingleLogoutService']['Location'],
+                $singleLogoutResponseLocation
+            );
+        }
+
+        // EntitySamlConfiguration: Response Processing Service
+        $responseProcessingService = null;
+        if (isset($connection['metadata']['ResponseProcessingService'])) {
+            $responseProcessingResponseLocation = null;
+            if (isset($connection['metadata']['ResponseProcessingService']['ResponseLocation'])) {
+                $responseProcessingResponseLocation = $connection['metadata']['ResponseProcessingService']['ResponseLocation'];
+            }
+
+            $responseProcessingService = new Endpoint(
+                new Binding($connection['metadata']['ResponseProcessingService']['Binding']),
+                $connection['metadata']['ResponseProcessingService']['Location'],
+                $responseProcessingResponseLocation
+            );
+        }
+
+        // EntitySamlConfiguration: Contact persons
+        $contactPersons = [];
+
+        foreach ($connection['metadata']['contacts'] as $contactPerson) {
+            $telephoneNumbers = [];
+            if (isset($contactPerson['telephoneNumber'])) {
+                $telephoneNumbers = [new TelephoneNumber($contactPerson['telephoneNumber'])];
+            }
+            $telephoneNumberList = new TelephoneNumberList($telephoneNumbers);
+
+            $surname = null;
+            if (isset($contactPerson['surName']) && trim($contactPerson['surName']) !== '') {
+                $surname = new Surname($contactPerson['surName']);
+            }
+
+            $givenName = null;
+            if (isset($contactPerson['givenName']) && trim($contactPerson['givenName']) !== '') {
+                $givenName = new GivenName($contactPerson['givenName']);
+            }
+
+            $company = null;
+            if (isset($contactPerson['company']) && trim($contactPerson['company']) !== '') {
+                $company = new Company($contactPerson['company']);
+            }
+
+            $emailAddresses = [];
+            // non empty string? optional? invalid?
+            if (isset($contactPerson['emailAddress']) && trim($contactPerson['emailAddress']) !== ''
+                && filter_var(trim($contactPerson['emailAddress']), FILTER_VALIDATE_EMAIL)
+            ) {
+                // strip mailto:
+                $emailAddress = trim($contactPerson['emailAddress']);
+                if (strpos($emailAddress, 'mailto:') !== false) {
+                    $emailAddress = substr($emailAddress, 7);
+                }
+
+                $emailAddresses[] = new EmailAddress($emailAddress);
+            }
+
+            $contactPersons[] = new ContactPerson(
+                new ContactType($contactPerson['contactType']),
+                new EmailAddressList($emailAddresses),
+                $telephoneNumberList,
+                $givenName,
+                $surname,
+                $company
+            );
+        }
+
+        $contactPersonList = new ContactPersonList($contactPersons);
+
+        // EntitySamlConfiguration: Organization
+        $organization = null;
+        if (isset($connection['metadata']['OrganizationName'])
+            && isset($connection['metadata']['OrganizationDisplayName'])
+            && isset($connection['metadata']['OrganizationURL'])
+        ) {
+            $organizationNames = [];
+            $organizationDisplayNames = [];
+            $organizationUrls = [];
+
+            if (isset($connection['metadata']['OrganizationName'])) {
+                foreach ($connection['metadata']['OrganizationName'] as $language => $organizationName) {
+                    $organizationNames[] = new OrganizationName($organizationName, $language);
+                }
+            }
+
+            if (isset($connection['metadata']['OrganizationDisplayName'])) {
+                foreach ($connection['metadata']['OrganizationDisplayName'] as $language => $organizationDisplayName) {
+                    $organizationDisplayNames[] = new OrganizationDisplayName($organizationDisplayName, $language);
+                }
+            }
+
+            if (isset($connection['metadata']['OrganizationURL'])) {
+                foreach ($connection['metadata']['OrganizationURL'] as $language => $organizationUrl) {
+                    $organizationUrls[] = new OrganizationUrl($organizationUrl, $language);
+                }
+            }
+
+            $organization = new Organization(
+                new OrganizationNameList($organizationNames),
+                new OrganizationDisplayNameList($organizationDisplayNames),
+                new OrganizationUrlList($organizationUrls)
+            );
+        }
+
+        // Single Sign On Services
+        $singleSignOnEndpoints = [];
+        if (isset($connection['metadata']['SingleSignOnService'])) {
+            foreach ($connection['metadata']['SingleSignOnService'] as $endpoint) {
+                // Optional?
+                $location = '(empty)';
+                if (isset($endpoint['Location'])) {
+                    $location = $endpoint['Location'];
+                }
+
+                $responseLocation = null;
+                if (isset($endpoint['ResponseLocation'])) {
+                    $responseLocation = $endpoint['ResponseLocation'];
+                }
+
+                $singleSignOnEndpoints[] = new Endpoint(
+                    new Binding($endpoint['Binding']),
+                    $location,
+                    $responseLocation
+                );
+            }
+        }
+
+        // ShibMdScopes
+        $shibMdScopes = [];
+
+        if (isset($connection['metadata']['shibmd'])) {
+            foreach ($connection['metadata']['shibmd'] as $shibMd) {
+
+                // optional?
+                $shibMdScope = '(empty)';
+                if (isset($shibMd['scope'])) {
+                    $shibMdScope = $shibMd['scope'];
+                }
+
+                $shibMdIsRegex = false;
+                if (isset($shibMd['isRegexp'])) {
+                    $shibMdIsRegex = $shibMd['isRegexp'];
+                }
+
+                $shibMdScopes[] = new ShibbolethMetadataScope($shibMdScope, $shibMdIsRegex);
+            }
+        }
+
+        // AttributeManipulationCode
+        $attributeManipulationCode = '//';
+        if (isset($connection['metadata']['manipulation_code'])) {
+            $attributeManipulationCode = $connection['metadata']['manipulation_code'];
+        }
+
+        // Requires additional logging
+        $requiresAdditionalLogging = false;
+        if (isset($connection['metadata']['coin']['additional_logging'])) {
+            $requiresAdditionalLogging = $connection['metadata']['coin']['additional_logging'];
+        }
+
+        // Disable scoping
+        $disableScoping = false;
+        if (isset($connection['metadata']['coin']['disable_scoping'])) {
+            $disableScoping = $connection['metadata']['coin']['disable_scoping'];
+        }
+
+        // Requires signed requests
+        $requiresSignedRequests = false;
+        if (isset($connection['metadata']['redirect']['sign'])) {
+            $requiresSignedRequests = $connection['metadata']['redirect']['sign'];
+        }
+
+        // Service providers without consent
+        $serviceProvidersWithoutConsent = [];
+        if (isset($connection['metadata']['disable_consent_connections'])) {
+            $serviceProvidersWithoutConsent = $connection['metadata']['disable_consent_connections'];
+        }
+
+        // Guest qualifier
+        if (isset($connection['metadata']['coin']['guest_qualifier'])) {
+            $guestQualifier = new GuestQualifier($connection['metadata']['coin']['guest_qualifier']);
+        } else {
+            $guestQualifier = GuestQualifier::all();
+        }
+
+        // Is Hidden
+        $isHidden = false;
+        if (isset($connection['metadata']['coin']['hidden'])) {
+            $isHidden = isset($connection['metadata']['coin']['hidden']);
+        }
+
+        // Enabled in WAYF
+        $isEnabledInWayf = true;
+        if (isset($connection['metadata']['coin']['publish_in_edugain'])) {
+            $isEnabledInWayf = isset($connection['metadata']['coin']['publish_in_edugain']);
+        }
+
+        // IdentityProviderAttributes: EntityAttributes: LocalizedServiceName
+        $localizedNames = [];
+        if (isset($connection['metadata']['name'])) {
+            foreach ($connection['metadata']['name'] as $language => $name) {
+                $localizedNames[] = new LocalizedName($name, $language);
+            }
+        }
+
+        // IdentityProviderAttributes: EntityAttributes: LocalizedDescription
+        $localizedTexts = [];
+        // optional?
+        if (isset($connection['metadata']['description'])) {
+            foreach ($connection['metadata']['description'] as $language => $text) {
+                // optional?
+                if (!empty($text)) {
+                    $localizedTexts[] = new LocalizedText($text, $language);
+                }
+            }
+        }
+
+        // IdentityProviderAttributes: Keywords
+        $localizedKeywords = [];
+        // optional?
+        if (isset($connection['metadata']['keywords'])) {
+            foreach ($connection['metadata']['keywords'] as $locale => $keywords) {
+                $localizedKeywords[] = new LocalizedKeywords($locale, [$keywords]);
+            }
+        }
+        $idpKeywords = new Keywords($localizedKeywords);
+
+        return new IdentityProvider(
+            new Entity(
+                new EntityId($connection['name']),
+                EntityType::IdP()
+            ),
+            new IdentityProviderSamlConfiguration(
+                new EntitySamlConfiguration(
+                    $nameIdFormat,
+                    $allowedNameIdFormats,
+                    $certificateList,
+                    $contactPersonList,
+                    $singleLogoutService,
+                    $responseProcessingService,
+                    $organization
+                ),
+                new SingleSignOnServices($singleSignOnEndpoints),
+                new ShibbolethMetadataScopeList($shibMdScopes)
+            ),
+            new IdentityProviderConfiguration(
+                new EntityConfiguration(
+                    new AttributeManipulationCode($attributeManipulationCode),
+                    new WorkflowState($connection['state']),
+                    $requiresAdditionalLogging,
+                    $disableScoping,
+                    $requiresSignedRequests
+                ),
+                new EntitySet($serviceProvidersWithoutConsent),
+                $guestQualifier
+            ),
+            new IdentityProviderAttributes(
+                new EntityAttributes(
+                    new LocalizedServiceName($localizedNames),
+                    new LocalizedDescription($localizedTexts),
+                    new Logo(
+                        $connection['metadata']['logo'][0]['url'],
+                        // width and height are optional, but not in the VO
+                        (int)$connection['metadata']['logo'][0]['width'],
+                        (int)$connection['metadata']['logo'][0]['height']
+                    )
+                ),
+                $isHidden,
+                $isEnabledInWayf,
+                $idpKeywords
+            )
+        );
+    }
+
+    private static function createServiceProviderFrom($connection)
+    {
+        // EntitySamlConfiguration: NameID format
+        if (!isset($connection['metadata']['NameIDFormat'])) {
+            // Should this happen?
+            $nameIdFormat = NameIdFormat::unspecified();
+        } else {
+            $nameIdFormat = new NameIdFormat($connection['metadata']['NameIDFormat']);
+        }
+
+        // EntitySamlConfiguration: Allowed NameID formats
+        if (isset($connection['metadata']['NameIDFormats'])) {
+            $allowedNameIdFormats = new NameIdFormatList(
+                array_map(
+                    function ($nameIdFormat) {
+                        return new NameIdFormat($nameIdFormat);
+                    },
+                    $connection['metadata']['NameIDFormats']
+                )
+            );
+        } else {
+            $allowedNameIdFormats = new NameIdFormatList([]);
+        }
+
+        // EntitySamlConfiguration: Certificates
+        $certificates = [];
+        if (isset($connection['metadata']['certdata1'])) {
+            $certificates[] = new Certificate($connection['metadata']['certdata1']);
+        }
+        if (isset($connection['metadata']['certdata2'])) {
+            $certificates[] = new Certificate($connection['metadata']['certdata2']);
+        }
+        if (isset($connection['metadata']['certdata3'])) {
+            $certificates[] = new Certificate($connection['metadata']['certdata3']);
+        }
+        $certificateList = new CertificateList($certificates);
+
+        // EntitySamlConfiguration: Single Logout Service
+        $singleLogoutService = null;
+        if (isset($connection['metadata']['SingleLogoutService'])) {
+            $singleLogoutResponseLocation = null;
+
+            if (isset($connection['metadata']['SingleLogoutService']['ResponseLocation'])) {
+                $singleLogoutResponseLocation = $connection['metadata']['SingleLogoutService']['ResponseLocation'];
+            }
+
+            // ! What to do here?
+            if (!isset($connection['metadata']['SingleLogoutService']['Binding'])) {
+                $connection['metadata']['SingleLogoutService']['Binding'] = Binding::HTTP_ARTIFACT;
+            }
+
+            // optional?
+            if (!isset($connection['metadata']['SingleLogoutService']['Location'])) {
+                $connection['metadata']['SingleLogoutService']['Location'] = '(empty)';
+            }
+
+            $singleLogoutService = new Endpoint(
+                new Binding($connection['metadata']['SingleLogoutService']['Binding']),
+                $connection['metadata']['SingleLogoutService']['Location'],
+                $singleLogoutResponseLocation
+            );
+        }
+
+        // EntitySamlConfiguration: Response Processing Service
+        $responseProcessingService = null;
+        if (isset($connection['metadata']['ResponseProcessingService'])) {
+            $responseProcessingResponseLocation = null;
+
+            if (isset($connection['metadata']['ResponseProcessingService']['ResponseLocation'])) {
+                $responseProcessingResponseLocation = $connection['metadata']['ResponseProcessingService']['ResponseLocation'];
+            }
+
+            $responseProcessingService = new Endpoint(
+                new Binding($connection['metadata']['ResponseProcessingService']['Binding']),
+                $connection['metadata']['ResponseProcessingService']['Location'],
+                $responseProcessingResponseLocation
+            );
+        }
+
+        // EntitySamlConfiguration: Contact persons
+        $contactPersons = [];
+
+        if (isset($connection['metadata']['contacts'])) {
+            foreach ($connection['metadata']['contacts'] as $contactPerson) {
+                $telephoneNumbers = [];
+                if (isset($contactPerson['telephoneNumber'])) {
+                    $telephoneNumbers = [new TelephoneNumber($contactPerson['telephoneNumber'])];
+                }
+                $telephoneNumberList = new TelephoneNumberList($telephoneNumbers);
+
+                $surname = null;
+                if (isset($contactPerson['surName']) && trim($contactPerson['surName']) !== '') {
+                    $surname = new Surname($contactPerson['surName']);
+                }
+
+                $givenName = null;
+                if (isset($contactPerson['givenName']) && trim($contactPerson['givenName']) !== '') {
+                    $givenName = new GivenName($contactPerson['givenName']);
+                }
+
+                $company = null;
+                if (isset($contactPerson['company']) && trim($contactPerson['company']) !== '') {
+                    $company = new Company($contactPerson['company']);
+                }
+
+                $emailAddresses = [];
+                // non empty string? optional?
+                if (isset($contactPerson['emailAddress']) && trim($contactPerson['emailAddress']) !== ''
+                    && filter_var(trim($contactPerson['emailAddress']), FILTER_VALIDATE_EMAIL)
+                ) {
+                    $emailAddress = trim($contactPerson['emailAddress']);
+                    if (strpos($emailAddress, 'mailto:') !== false) {
+                        $emailAddress = substr($emailAddress, 7);
+                    }
+
+                    $emailAddresses[] = new EmailAddress($emailAddress);
+                }
+
+                $contactPersons[] = new ContactPerson(
+                    new ContactType($contactPerson['contactType']),
+                    new EmailAddressList($emailAddresses),
+                    $telephoneNumberList,
+                    $givenName,
+                    $surname,
+                    $company
+                );
+            }
+        }
+
+        $contactPersonList = new ContactPersonList($contactPersons);
+
+        // EntitySamlConfiguration: Organization
+        $organization = null;
+        if (isset($connection['metadata']['OrganizationName'])
+            && isset($connection['metadata']['OrganizationDisplayName'])
+            && isset($connection['metadata']['OrganizationURL'])
+        ) {
+
+            $organizationNames        = [];
+            $organizationDisplayNames = [];
+            $organizationUrls         = [];
+            if (isset($connection['metadata']['OrganizationName'])) {
+                foreach ($connection['metadata']['OrganizationName'] as $language => $organizationName) {
+                    $organizationNames[] = new OrganizationName($organizationName, $language);
+                }
+            }
+
+            if (isset($connection['metadata']['OrganizationDisplayName'])) {
+                foreach ($connection['metadata']['OrganizationDisplayName'] as $language => $organizationDisplayName) {
+                    $organizationDisplayNames[] = new OrganizationDisplayName($organizationDisplayName, $language);
+                }
+            }
+
+            if (isset($connection['metadata']['OrganizationURL'])) {
+                foreach ($connection['metadata']['OrganizationURL'] as $language => $organizationUrl) {
+                    $organizationUrls[] = new OrganizationUrl($organizationUrl, $language);
+                }
+            }
+
+            $organization = new Organization(
+                new OrganizationNameList($organizationNames),
+                new OrganizationDisplayNameList($organizationDisplayNames),
+                new OrganizationUrlList($organizationUrls)
+            );
+        }
+
+        // AssertionConsumerServices: IndexedEndpoints
+        $indexedEndpoints = [];
+        foreach ($connection['metadata']['AssertionConsumerService'] as $key => $acs) {
+            // ! What to do here?
+            if (!isset($acs['Binding'])) {
+                $acs['Binding'] = Binding::HTTP_ARTIFACT;
+            }
+
+            // Optional?
+            $location = '(empty)';
+            if (isset($acs['Location'])) {
+                $location = $acs['Location'];
+            }
+
+            $responseLocation = null;
+            if (isset($acs['ResponseLocation'])) {
+                $responseLocation = $acs['ResponseLocation'];
+            }
+
+            $index = $key;
+            if (isset($acs['index'])) {
+                $index = $acs['index'];
+            }
+
+
+            $indexedEndpoints[] = new IndexedEndpoint(
+                new Endpoint(
+                    new Binding($acs['Binding']),
+                    $location,
+                    $responseLocation
+                ),
+                (int) $index
+            );
+        }
+
+        // ServiceProviderConfiguration
+        $displayUnconnectedIdpsInWayf = false;
+        if (isset($connection['metadata']['coin']['display_unconnected_idps_wayf'])) {
+            $displayUnconnectedIdpsInWayf = $connection['metadata']['coin']['display_unconnected_idps_wayf'];
+        }
+        $isTrustedProxy = false;
+        if (isset($connection['metadata']['coin']['trusted_proxy'])) {
+            $isTrustedProxy = $connection['metadata']['coin']['trusted_proxy'];
+        }
+        $isTransparentIssuer = false;
+        if (isset($connection['metadata']['coin']['transparent_issuer'])) {
+            $isTransparentIssuer = $connection['metadata']['coin']['transparent_issuer'];
+        }
+        $requiresConsent = true;
+        if (isset($connection['metadata']['coin']['no_consent_required'])) {
+            $requiresConsent = !$connection['metadata']['coin']['no_consent_required'];
+        }
+        $denormalizationShouldBeSkipped = false;
+        if (isset($connection['metadata']['coin']['do_not_add_attribute_aliases'])) {
+            $denormalizationShouldBeSkipped = $connection['metadata']['coin']['do_not_add_attribute_aliases'];
+        }
+        $requiresPolicyEnforcementDecision = false;
+        if (isset($connection['metadata']['coin']['policy_enforcement_decision_required'])) {
+            $requiresPolicyEnforcementDecision = $connection['metadata']['coin']['policy_enforcement_decision_required'];
+        }
+        $requiresAttributeAggregation = false;
+        if (isset($connection['metadata']['coin']['attribute_aggregation_required'])) {
+            $denormalizationShouldBeSkipped = $connection['metadata']['coin']['attribute_aggregation_required'];
+        }
+
+        // ServiceProviderAttributes: EntityAttributes: LocalizedServiceName
+        $localizedNames = [];
+        if (isset($connection['metadata']['name'])) {
+            foreach ($connection['metadata']['name'] as $language => $name) {
+                $localizedNames[] = new LocalizedName($name, $language);
+            }
+        }
+
+        // ServiceProviderAttributes: EntityAttributes: LocalizedDescription
+        $localizedTexts = [];
+        if (isset($connection['metadata']['description'])) {
+            foreach ($connection['metadata']['description'] as $language => $text) {
+                // optional?
+                if (!empty($text)) {
+                    $localizedTexts[] = new LocalizedText($text, $language);
+                }
+            }
+        }
+
+        // logo
+        $logo = new Logo('(empty)', 0, 0);
+        if (isset($connection['metadata']['logo'][0]['url'])) {
+            $logo = new Logo(
+                $connection['metadata']['logo'][0]['url'],
+                // width and height are optional, but not in the VO
+                (int)$connection['metadata']['logo'][0]['width'],
+                (int)$connection['metadata']['logo'][0]['height']
+            );
+        }
+
+        // ServiceProviderAttributes
+        if (isset($connection['metadata']['coin']['eula'])) {
+            $termsOfServiceUrl = new Url($connection['metadata']['coin']['eula']);
+        } else {
+            // Optional?
+            $termsOfServiceUrl = new Url('/');
+        }
+
+        $localizedUris = [];
+        if (isset($connection['metadata']['url'])) {
+            foreach ($connection['metadata']['url'] as $language => $uri) {
+                // Optional?
+                $localizedUris[] = empty($uri) ? new LocalizedUri('(empty)', $language) : new LocalizedUri(
+                    $uri,
+                    $language
+                );
+            }
+        }
+        $supportUrl = new LocalizedSupportUrl($localizedUris);
+
+        return new ServiceProvider(
+            new Entity(
+                new EntityId($connection['name']),
+                EntityType::SP()
+            ),
+            new ServiceProviderSamlConfiguration(
+                new EntitySamlConfiguration(
+                    $nameIdFormat,
+                    $allowedNameIdFormats,
+                    $certificateList,
+                    $contactPersonList,
+                    $singleLogoutService,
+                    $responseProcessingService,
+                    $organization
+                ),
+                new AssertionConsumerServices($indexedEndpoints)
+            ),
+            new ServiceProviderConfiguration(
+                $displayUnconnectedIdpsInWayf,
+                $isTrustedProxy,
+                $isTransparentIssuer,
+                $requiresConsent,
+                $denormalizationShouldBeSkipped,
+                $requiresPolicyEnforcementDecision,
+                $requiresAttributeAggregation
+            ),
+            new ServiceProviderAttributes(
+                new EntityAttributes(
+                    new LocalizedServiceName($localizedNames),
+                    new LocalizedDescription($localizedTexts),
+                    $logo
+                ),
+                $termsOfServiceUrl,
+                $supportUrl
+            )
+        );
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataMarshallingService.php
+++ b/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataMarshallingService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OpenConext\EngineBlockBundle\Metadata\Service;
+
+class MetadataMarshallingService
+{
+    public function unMarshall(array $data)
+    {
+        
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataService.php
+++ b/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OpenConext\EngineBlockBundle\Metadata\Service;
+
+use OpenConext\EngineBlockBundle\Metadata\Repository\InMemoryAllowedConnectionRepository;
+use OpenConext\EngineBlockBundle\Metadata\Repository\InMemorySamlServiceRepository;
+
+class MetadataService
+{
+    /**
+     * @var MetadataMarshallingService
+     */
+    private $metadataMarshallingService;
+
+    /**
+     * @var InMemorySamlServiceRepository
+     */
+    private $samlServiceRepository;
+
+    /**
+     * @var InMemoryAllowedConnectionRepository
+     */
+    private $allowedConnectionRepository;
+
+    public function __construct(
+        MetadataMarshallingService $metadataMarshallingService,
+        InMemorySamlServiceRepository $samlServiceRepository,
+        InMemoryAllowedConnectionRepository $allowedConnectionRepository
+    ) {
+        $this->metadataMarshallingService = $metadataMarshallingService;
+        $this->samlServiceRepository = $samlServiceRepository;
+        $this->allowedConnectionRepository = $allowedConnectionRepository;
+    }
+
+    public function applyNewConfiguration(array $metadataConfiguration)
+    {
+
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Value/ServiceProviderAttributesTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Value/ServiceProviderAttributesTest.php
@@ -24,7 +24,7 @@ class ServiceProviderAttributesTest extends UnitTest
                 new LocalizedDescription([new LocalizedText('OpenConext', 'en')]),
                 new Logo('https://domain.invalid/img.png', 150, 150)
             ),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             new LocalizedSupportUrl([])
         );
 
@@ -45,7 +45,7 @@ class ServiceProviderAttributesTest extends UnitTest
                 $localizedDescription,
                 new Logo('https://domain.invalid/img.png', 150, 150)
             ),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             new LocalizedSupportUrl([])
         );
 
@@ -66,7 +66,7 @@ class ServiceProviderAttributesTest extends UnitTest
                 new LocalizedDescription([new LocalizedText('OpenConext', 'en')]),
                 $logo
             ),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             new LocalizedSupportUrl([])
         );
 
@@ -80,7 +80,7 @@ class ServiceProviderAttributesTest extends UnitTest
      */
     public function terms_of_service_url_can_be_retrieved()
     {
-        $termsOfServiceUrl         = new LocalizedUri('http://domain.invalid/tos', 'en');
+        $termsOfServiceUrl         = new Url('http://domain.invalid/tos');
         $serviceProviderAttributes = new ServiceProviderAttributes(
             $this->getEntityAttributes(),
             $termsOfServiceUrl,
@@ -100,7 +100,7 @@ class ServiceProviderAttributesTest extends UnitTest
         $supportUrl                = new LocalizedSupportUrl([]);
         $serviceProviderAttributes = new ServiceProviderAttributes(
             $this->getEntityAttributes(),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             $supportUrl
         );
 
@@ -116,12 +116,12 @@ class ServiceProviderAttributesTest extends UnitTest
     {
         $base = new ServiceProviderAttributes(
             $this->getEntityAttributes(),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             new LocalizedSupportUrl([])
         );
         $same = new ServiceProviderAttributes(
             $this->getEntityAttributes(),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             new LocalizedSupportUrl([])
         );
         $differentEntityAttributes = new ServiceProviderAttributes(
@@ -130,17 +130,17 @@ class ServiceProviderAttributesTest extends UnitTest
                 new LocalizedDescription([]),
                 new Logo('https://domain.invalid/img.png', 150, 150)
             ),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             new LocalizedSupportUrl([])
         );
         $differentTermsOfService = new ServiceProviderAttributes(
             $this->getEntityAttributes(),
-            new LocalizedUri('http://somewhere.invalid/t-o-s', 'nl'),
+            new Url('http://somewhere.invalid/t-o-s', 'nl'),
             new LocalizedSupportUrl([])
         );
         $differentSupportUrl = new ServiceProviderAttributes(
             $this->getEntityAttributes(),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             new LocalizedSupportUrl([new LocalizedUri('http://domain.invalid/support', 'en')])
         );
 
@@ -159,7 +159,7 @@ class ServiceProviderAttributesTest extends UnitTest
     {
         $original = new ServiceProviderAttributes(
             $this->getEntityAttributes(),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos'),
             new LocalizedSupportUrl([])
         );
 
@@ -207,13 +207,13 @@ class ServiceProviderAttributesTest extends UnitTest
             'no matches' => [
                 [
                     'foo' => $this->getEntityAttributes()->serialize(),
-                    'bar' => (new LocalizedUri('uri', 'en'))->serialize(),
+                    'bar' => (new Url('https://en.domain.invalid/'))->serialize(),
                     'baz' => (new LocalizedSupportUrl([new LocalizedUri('uri', 'en')]))->serialize()
                 ]
             ],
             'no entity_attributes' => [
                 [
-                    'terms_of_service_url' => (new LocalizedUri('uri', 'en'))->serialize(),
+                    'terms_of_service_url' => (new Url('https://en.domain.invalid/'))->serialize(),
                     'support_urls'         => (new LocalizedSupportUrl([new LocalizedUri('uri', 'en')]))->serialize()
                 ]
             ],
@@ -226,7 +226,7 @@ class ServiceProviderAttributesTest extends UnitTest
             'no support_urls' => [
                 [
                     'entity_attributes'    => $this->getEntityAttributes()->serialize(),
-                    'terms_of_service_url' => (new LocalizedUri('uri', 'en'))->serialize(),
+                    'terms_of_service_url' => (new Url('https://en.domain.invalid/'))->serialize(),
                 ]
             ],
         ];
@@ -241,7 +241,7 @@ class ServiceProviderAttributesTest extends UnitTest
     {
         $serviceProviderAttributes = new ServiceProviderAttributes(
             $this->getEntityAttributes(),
-            new LocalizedUri('http://domain.invalid/tos', 'en'),
+            new Url('http://domain.invalid/tos', 'en'),
             new LocalizedSupportUrl([])
         );
 

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Value/UrlTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Value/UrlTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace OpenConext\EngineBlock\Metadata\Value;
+
+use OpenConext\Value\Exception\InvalidArgumentException;
+use PHPUnit_Framework_TestCase as UnitTest;
+
+class UrlTest extends UnitTest
+{
+    /**
+     * @test
+     * @group Metadata
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notStringOrEmptyString
+     * @expectedException InvalidArgumentException
+     *
+     * @param mixed $notStringOrEmptyString
+     */
+    public function url_must_be_a_non_empty_string($notStringOrEmptyString)
+    {
+        new Url($notStringOrEmptyString);
+    }
+
+    /**
+     * @test
+     * @group Metadata
+     */
+    public function uri_can_be_retrieved()
+    {
+        $uri = 'https://en.domain.invalid/';
+
+        $url = new Url($uri);
+
+        $this->assertEquals($uri, $url->getUrl());
+    }
+
+    /**
+     * @test
+     * @group Metadata
+     */
+    public function equality_is_verified_on_uri()
+    {
+        $base              = new Url('https://en.domain.invalid/');
+        $same              = new Url('https://en.domain.invalid/');
+        $differentUri      = new Url('https://nl.domain.invalid/');
+
+        $this->assertTrue($base->equals($same));
+        $this->assertFalse($base->equals($differentUri));
+    }
+
+    /**
+     * @test
+     * @group Metadata
+     */
+    public function deserializing_a_serialized_url_yields_an_equal_value_object()
+    {
+        $original = new Url('https://en.domain.invalid/');
+
+        $deserialized = Url::deserialize($original->serialize());
+
+        $this->assertTrue($original->equals($deserialized));
+    }
+
+    /**
+     * @test
+     * @group Metadata
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notArray
+     * @expectedException InvalidArgumentException
+     *
+     * @param mixed $notArray
+     */
+    public function deserialization_requires_data_to_be_an_array($notArray)
+    {
+        Url::deserialize($notArray);
+    }
+
+    /**
+     * @test
+     * @group Metadata
+     *
+     * @expectedException InvalidArgumentException
+     *
+     */
+    public function deserialization_requires_all_required_keys_to_be_present()
+    {
+        Url::deserialize(array('foo' => 'https://en.domain.invalid/'));
+    }
+
+    /**
+     * @test
+     * @group Metadata
+     */
+    public function a_localized_uri_can_be_cast_to_string()
+    {
+        $this->assertInternalType('string', (string) new Url('some:uri'));
+    }
+}


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/111132276

Todo:
- [ ] Update metadata documentation links in `README` and `docs/Metadata/index.md` to link to master branch rather than feature/metadata-api branch.

Development remarks:
A patch file is included in the PR, this is purely intended to be used for debugging during development by using a file rather than having to push json constantly. This should be removed from the PR when no longer of use. Furthermore it is recommended to request a dump from production Janus/SR metadata to ensure full compatibility with the current metadata.

Todo for the required feature:
- [ ] Resolve all open questions and remarks (see [questions and findings][qaf]). Take care that any changes to logic/default values regarding SAMLValueObjects must be made local in EngineBlock as the value objects are conforming to the SAML specification. Changes to logic/default values for all other value objects are local to EngineBlock by nature and can thus be changed.
- [ ] Ensure that an additional value object is added to the IdentityProvider and ServiceProvider objects that allow storing of arbitrary `key => value(s)` structures to allow flexible expansion of the configuration. Should the expansion become a part of mainstream application logic, a custom value object should be built for that.
- [ ] Create an entity and repositories to persist and hydrate the models. The value objects should be stored as json blobs. each entity should also store its UUID, EntityID and EntityType.
- [ ] Create a model and accompanying repository that allows the modelling and querying of Connections. A connection is an explicit allowed connection between a ServiceProvider and an IdentityProvider. If there is no limit on which IdPs can be used for an SP, the idea is not to store any connections to reduce load (meaning introduction of the rule: no connection means all connections are allowed)
- [ ] Parse the connections from the JSON and create connections between the correct metadata models.
- [ ] Create the entity and repository to persist and load connections.
- [ ] Create a service that allows the retrieval of metadata and connections (read only - reading should be used everywhere but in the the ConnectionsController, writing should only be used in the ConnectionsController
- [ ] Create a service that allows the updating of the metadata and connections (write only). For connections cheapest would be wipe and replace, for the metadata it should be checked, updates might be better, but are expensive in a cluster, therefor wipe/replace all might be best.
- [ ] Use the new services and storage to persist the metadata and connections in the new structure. This could be done in an intermediate release with a feature toggle so that temporarily both exists and the new structure is only used for writes, the old for both writes and reads. This allows for verification of compatibility with production data.
- [ ] Adapt all usages of metadata to the new metadata structures, effectively implementing the usage of the new metadata structures on the read side. If necessary/effective, bridge functionality can be created that allows transformation of the new structure to the old structure to minimize the required changes in the `library` (EB4) code. All new code must use the new structures.
- [ ] Remove any and all code that is no longer needed.


[qaf]: https://github.com/OpenConext/OpenConext-engineblock/blob/24f2f9b21edac9b12f54fff89e0ede195d95701d/docs/Metadata/questions-and-findings.md