### PR TITLE
Make DROP TABLE migrations more robust to when a table is already gone.

### DIFF
--- a/database/DoctrineMigrations/Version20161123131704.php
+++ b/database/DoctrineMigrations/Version20161123131704.php
@@ -18,8 +18,8 @@ class Version20161123131704 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
 
         // Remove the virtual organisation tables as the functionality has been removed
-        $this->addSql('DROP TABLE virtual_organisation');
-        $this->addSql('DROP TABLE virtual_organisation_group');
+        $this->addSql('DROP TABLE IF NOT EXISTS virtual_organisation');
+        $this->addSql('DROP TABLE IF NOT EXISTS virtual_organisation_group');
         $this->addSql('DROP TABLE virtual_organisation_idp');
 
         // Remove the implicit_vo_id from the sso_provider_roles

--- a/database/DoctrineMigrations/Version20170331145533.php
+++ b/database/DoctrineMigrations/Version20170331145533.php
@@ -11,7 +11,7 @@ class Version20170331145533 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('DROP TABLE log_logins');
+        $this->addSql('DROP TABLE IF NOT EXISTS log_logins');
     }
 
     public function down(Schema $schema)


### PR DESCRIPTION
It's simple: if it's for some reason already away, the goal has been accomplished, no need to fail.