### PR TITLE
Use APCu for forward compatibility with PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_script:
   - phpenv config-add .travis.php.ini
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then printf "\n" | pecl uninstall apcu; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then printf "\n" | pecl install apcu-4.0.10; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then sed -i 's,apc,array,' ~/build/OpenConext/OpenConext-engineblock/app/config/config.yml; fi
   - sudo ln -s "$(pwd)"/ci/travis/files/ /etc/openconext
   - mkdir -p /tmp/engineblock/cache/test
   - mkdir -p /tmp/engineblock/logs/test


### PR DESCRIPTION
This is the change made by arothuis in PR: https://github.com/OpenConext/OpenConext-engineblock/pull/399

The solution was to use array cache in php7 until the current Doctrine version supports php7's memory cache mechanism.