### PR TITLE
Merged ProxyServer loggers

### DIFF
--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -207,7 +207,7 @@ class EngineBlock_Corto_Adapter
                 );
             }
             else {
-                $this->_getSessionLog()->warning(
+                $this->_getLogger()->warning(
                     "Unable to apply RequesterID '$requesterId' to sub-scope the available IdPs as we don't know this SP!"
                 );
             }
@@ -352,7 +352,7 @@ class EngineBlock_Corto_Adapter
     protected function _configureProxyServer(EngineBlock_Corto_ProxyServer $proxyServer)
     {
 
-        $proxyServer->setLogger($this->_getSystemLog());
+        $proxyServer->setLogger($this->_getLogger());
 
         $application = EngineBlock_ApplicationSingleton::getInstance();
         $proxyServer->setHostName($application->getHostname());
@@ -377,15 +377,7 @@ class EngineBlock_Corto_Adapter
     /**
      * @return Psr\Log\LoggerInterface
      */
-    protected function _getSystemLog()
-    {
-        return EngineBlock_ApplicationSingleton::getLog();
-    }
-
-    /**
-     * @return Psr\Log\LoggerInterface
-     */
-    protected function _getSessionLog()
+    protected function _getLogger()
     {
         return EngineBlock_ApplicationSingleton::getLog();
     }
@@ -483,13 +475,13 @@ class EngineBlock_Corto_Adapter
         $keyPairs = array();
         foreach ($keysConfig as $keyId => $keyConfig) {
             if (!isset($keyConfig['privateFile'])) {
-                $this->_getSessionLog()->warning(
+                $this->_getLogger()->warning(
                     'Reference to private key file not found for key: ' . $keyId . ' skipping keypair.'
                 );
                 continue;
             }
             if (!isset($keyConfig['publicFile'])) {
-                $this->_getSessionLog()->warning('Reference to public key file not found for key: ' . $keyId);
+                $this->_getLogger()->warning('Reference to public key file not found for key: ' . $keyId);
                 continue;
             }
 

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -351,8 +351,8 @@ class EngineBlock_Corto_Adapter
 
     protected function _configureProxyServer(EngineBlock_Corto_ProxyServer $proxyServer)
     {
-        $proxyServer->setSystemLog($this->_getSystemLog());
-        $proxyServer->setSessionLogDefault($this->_getSessionLog());
+
+        $proxyServer->setLogger($this->_getSystemLog());
 
         $application = EngineBlock_ApplicationSingleton::getInstance();
         $proxyServer->setHostName($application->getHostname());

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -97,7 +97,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         }
 
         if ($sspRequest->isMessageConstructedWithSignature()) {
-            $log = $this->_server->getSessionLog();
+            $log = $this->_server->getLogger();
 
             $log->notice(sprintf(
                 'Received signed AuthnRequest from Issuer "%s" with signature method algorithm "%s"',
@@ -207,7 +207,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         }
 
         // Log the response we received for troubleshooting
-        $log = $this->_server->getSessionLog();
+        $log = $this->_server->getLogger();
         $log->info(
             'Received response',
             array('saml_response' => $sspResponse->toUnsignedXML()->ownerDocument->saveXML())
@@ -457,7 +457,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
             $action = $sspMessage->getDestination();
 
-            $log = $this->_server->getSessionLog();
+            $log = $this->_server->getLogger();
             $log->info('HTTP-Post: Sending Message', array('saml_message' => $xml));
 
             $output = $this->_server->renderTemplate(
@@ -540,7 +540,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             $this->_server->setRemoteIdpMd5($parameters['RemoteIdPMd5']);
         }
 
-        $log = $this->_server->getSessionLog();
+        $log = $this->_server->getLogger();
         $log->info("Using internal binding for destination $destinationLocation", array('url_params' => $parameters));
 
         $serviceName = $parameters['ServiceName'];

--- a/library/EngineBlock/Corto/Module/Service/ContinueToIdp.php
+++ b/library/EngineBlock/Corto/Module/Service/ContinueToIdp.php
@@ -28,7 +28,7 @@ class EngineBlock_Corto_Module_Service_ContinueToIdp extends EngineBlock_Corto_M
             );
         }
 
-        $authnRequestRepository = new EngineBlock_Saml2_AuthnRequestSessionRepository($this->_server->getSessionLog());
+        $authnRequestRepository = new EngineBlock_Saml2_AuthnRequestSessionRepository($this->_server->getLogger());
         $request = $authnRequestRepository->findRequestById($id);
 
         if (!$request) {

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -10,7 +10,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
     {
         $application = EngineBlock_ApplicationSingleton::getInstance();
 
-        $log = $this->_server->getSessionLog();
+        $log = $this->_server->getLogger();
 
         $response = $this->_displayDebugResponse($serviceName);
         if ($response) {
@@ -149,7 +149,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
      */
     protected function _getRequest($serviceName)
     {
-        $logger = $this->_server->getSessionLog();
+        $logger = $this->_server->getLogger();
         $logger->info('Getting request...');
 
         if ($serviceName === 'unsolicitedSingleSignOnService') {
@@ -200,7 +200,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         $protocolBinding = $request->getProtocolBinding();
 
         if ($acsUrl XOR $protocolBinding) {
-            $this->_server->getSessionLog()->error(
+            $this->_server->getLogger()->error(
                 "Incomplete ACS location found in request (missing URL or binding)"
             );
 
@@ -274,7 +274,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
     protected function _getScopedIdPs(
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request
     ) {
-        $log = $this->_server->getSessionLog();
+        $log = $this->_server->getLogger();
 
         /** @var SAML2_AuthnRequest $request */
         $scopedIdPs = $request->getIDPList();
@@ -330,7 +330,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
             return false;
         }
 
-        $this->_server->getSessionLog()->info("Cached response found from Idp");
+        $this->_server->getLogger()->info("Cached response found from Idp");
         // Note that we would like to repurpose the response,
         // but that's tricky as it is probably no longer valid (lifetime is usually something like 5 minutes)
         // so instead we scope the request to that Idp and trust the Idp to do the remembering.

--- a/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
@@ -14,8 +14,6 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends PHPUnit_Framework_TestC
     public function setup()
     {
         $proxyServer = Phake::mock('EngineBlock_Corto_ProxyServer');
-        $log = Phake::mock('Psr\Log\LoggerInterface');
-        Phake::when($proxyServer)->getSessionLog()->thenReturn($log);
         Phake::when($proxyServer)->getSigningCertificates()->thenReturn(new EngineBlock_X509_KeyPair(
             new EngineBlock_X509_Certificate(openssl_x509_read(file_get_contents(__DIR__ . '/test.pem.crt'))),
             new EngineBlock_X509_PrivateKey(__DIR__ . '/test.pem.key')


### PR DESCRIPTION
The two loggers (session and system) have been merged to a single
logger. The three fields have been merged into a new `_logger` field.
All usages in the EngineBlock module have been updated to use the new
logger.

Pivotal tracker: #143228773