### PR TITLE
AttributerAggregationClient bugfix

### DIFF
--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/AttributeAggregationClientTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/AttributeAggregationClientTest.php
@@ -56,7 +56,7 @@ class AttributeAggregationClientTest extends TestCase
 
         $guzzle = new Client(['handler' => $mockHandler]);
 
-        $client = new AttributeAggregationClient(new HttpClient($guzzle));
+        $client = new AttributeAggregationClient(new HttpClient($guzzle), 'https://attr.at/api');
         $response = $client->aggregate($request);
 
         $this->assertInstanceOf(Response::class, $response);


### PR DESCRIPTION
The test of the AttributerAggregationClient was not yet fixed to include the use of the second paarameter.

This fix should be merged to `master` and the `display-unconnected-idps-wayf` branches.