### PR TITLE
Uncomment mandatory settings

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -49,8 +49,8 @@ engineblock.feature.encrypted_assertions_require_outer_signature = 1
 ; wayf.cutoffPointForShowingUnfilteredIdps = 50
 
 ;; Settings for detecting whether the user is stuck in a authentication loop within his session
-;engineblock.timeFrameForAuthenticationLoopInSeconds = 60
-;engineblock.maximumAuthenticationProceduresAllowed  = 5
+engineblock.timeFrameForAuthenticationLoopInSeconds = 60
+engineblock.maximumAuthenticationProceduresAllowed  = 5
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; SAML2 SETTINGS ;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Without them defined at all, you always immediately get the 'stuck-in-authentication-loop' error, without even being redirected to the IdP you picked.
Probably because 0 >= null evaluates to true @ https://github.com/OpenConext/OpenConext-engineblock/blob/master/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationLoopGuard.php#L72

It probably needs a safe default in code as well...