### PR TITLE
Send a client ID to the PDP API endpoint

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -190,6 +190,7 @@ pdp.baseUrl = "https://pdp.surfconext.nl/decide/policy"
 ; PDP uses basic auth
 pdp.username = "pdp_admin"
 pdp.password = "secret"
+pdp.client_id = "EngineBlock"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; ATTRIBUTE AGGREGATION SETTINGS ;;;;;;;;;;;;;;;;;;;;;;

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -40,6 +40,7 @@ $ymlContent = array(
         'pdp.policy_decision_point_path'                          => $config->get('pdp.policy_decision_point_path'),
         'pdp.username'                                            => $config->get('pdp.username'),
         'pdp.password'                                            => $config->get('pdp.password'),
+        'pdp.client_id'                                           => $config->get('pdp.client_id'),
         'attribute_aggregation.base_url'                          => $config->get('attributeAggregation.baseUrl'),
         'attribute_aggregation.username'                          => $config->get('attributeAggregation.username'),
         'attribute_aggregation.password'                          => $config->get('attributeAggregation.password'),

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -324,6 +324,11 @@ class EngineBlock_Application_DiContainer extends Pimple implements ContainerInt
         return $this->container->get('engineblock.pdp.pdp_client');
     }
 
+    public function getPdpClientId()
+    {
+        return $this->container->getParameter('pdp.client_id');
+    }
+
     public function getFunctionalTestingPdpClient()
     {
         return $this->container->get('engineblock.functional_testing.fixture.pdp_client');

--- a/library/EngineBlock/Application/FunctionalTestDiContainer.php
+++ b/library/EngineBlock/Application/FunctionalTestDiContainer.php
@@ -53,6 +53,11 @@ class EngineBlock_Application_FunctionalTestDiContainer extends EngineBlock_Appl
         return $this->getFunctionalTestingPdpClient();
     }
 
+    public function getPdpClientId()
+    {
+        return 'Federation';
+    }
+
     /**
      * @return \OpenConext\EngineBlockBundle\AttributeAggregation\AttributeAggregationClientInterface
      */

--- a/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
+++ b/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
@@ -27,6 +27,7 @@ class EngineBlock_Corto_Filter_Command_EnforcePolicy extends EngineBlock_Corto_F
         $log->debug("Policy Enforcement Point: consulting Policy Decision Point");
 
         $pdpRequest = Request::from(
+            $this->getPdpClientId(),
             $this->_collabPersonId,
             $this->_identityProvider->entityId,
             $serviceProvider->entityId,
@@ -85,5 +86,13 @@ class EngineBlock_Corto_Filter_Command_EnforcePolicy extends EngineBlock_Corto_F
     private function getPdpClient()
     {
         return EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getPdpClient();
+    }
+
+    /**
+     * @return string
+     */
+    private function getPdpClientId()
+    {
+        return EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getPdpClientId();
     }
 }

--- a/library/EngineBlock/PolicyDecisionPoint/PepValidator.php
+++ b/library/EngineBlock/PolicyDecisionPoint/PepValidator.php
@@ -36,6 +36,9 @@ class EngineBlock_PolicyDecisionPoint_PepValidator
             }
         }
 
+        $clientIdAttribute = new Attribute;
+        $clientIdAttribute->attributeId = 'ClientID';
+        $clientIdAttribute->value = $this->getPdpClientId();
         $idpAttribute = new Attribute;
         $idpAttribute->attributeId = 'IDPentityID';
         $idpAttribute->value = $idp;
@@ -45,7 +48,7 @@ class EngineBlock_PolicyDecisionPoint_PepValidator
 
         $pdpRequest = new Request();
         $pdpRequest->accessSubject->attributes = $accessSubjectAttributes;
-        $pdpRequest->resource->attributes = [$idpAttribute, $spAttribute];
+        $pdpRequest->resource->attributes = [$clientIdAttribute, $idpAttribute, $spAttribute];
 
         $pdpClient = $this->getPdpClient();
 
@@ -78,6 +81,11 @@ class EngineBlock_PolicyDecisionPoint_PepValidator
     private function getPdpClient()
     {
         return EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getPdpClient();
+    }
+
+    private function getPdpClientId()
+    {
+        return EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getPdpClientId();
     }
 
     private function getLocale()

--- a/src/OpenConext/EngineBlockBundle/Pdp/Dto/Request.php
+++ b/src/OpenConext/EngineBlockBundle/Pdp/Dto/Request.php
@@ -47,6 +47,7 @@ final class Request implements JsonSerializable
     public $resource;
 
     /**
+     * @var string $clientId
      * @var string $subjectId
      * @param string $subjectId
      * @param string $idpEntityId
@@ -54,8 +55,9 @@ final class Request implements JsonSerializable
      * @param array $responseAttributes
      * @return Request $request
      */
-    public static function from($subjectId, $idpEntityId, $spEntityId, array $responseAttributes)
+    public static function from($clientId, $subjectId, $idpEntityId, $spEntityId, array $responseAttributes)
     {
+        Assertion::string($clientId, 'The client ID must be a string, received "%s" (%s)');
         Assertion::string($subjectId, 'The SubjectId must be a string, received "%s" (%s)');
         Assertion::string($idpEntityId, 'The IDPentityID must be a string, received "%s" (%s)');
         Assertion::string($spEntityId, 'The SPentityID must be a string, received "%s" (%s)');
@@ -74,6 +76,10 @@ final class Request implements JsonSerializable
         $request->accessSubject = new AccessSubject;
         $request->accessSubject->attributes = [$subjectIdAttribute];
 
+        $clientIdAttribute  = new Attribute;
+        $clientIdAttribute->attributeId = 'ClientID';
+        $clientIdAttribute->value = $clientId;
+
         $spEntityIdAttribute  = new Attribute;
         $spEntityIdAttribute->attributeId = 'SPentityID';
         $spEntityIdAttribute->value = $spEntityId;
@@ -83,7 +89,7 @@ final class Request implements JsonSerializable
         $idpEntityIdAttribute->value = $idpEntityId;
 
         $request->resource = new Resource;
-        $request->resource->attributes = [$spEntityIdAttribute, $idpEntityIdAttribute];
+        $request->resource->attributes = [$clientIdAttribute, $spEntityIdAttribute, $idpEntityIdAttribute];
 
         foreach ($responseAttributes as $id => $values) {
             foreach ($values as $value) {

--- a/tests/unit/OpenConext/EngineBlockBundle/Pdp/Dto/RequestTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Pdp/Dto/RequestTest.php
@@ -35,6 +35,7 @@ class RequestTest extends TestCase
 
     public function setUp()
     {
+        $this->validClientId   = 'clientid';
         $this->validSubjectId   = 'subject-id';
         $this->validIdpEntityId = 'https://my-idp.example';
         $this->validSpEntityId  = 'https://my-sp.example';
@@ -42,7 +43,27 @@ class RequestTest extends TestCase
             ['urn:mace:dir:attribute-def:eduPersonAffiliation' => ['student', 'alumni']]
         ];
     }
-    
+
+    /**
+     * @test
+     * @group Pdp
+     *
+     * @dataProvider \OpenConext\TestDataProvider::notString()
+     */
+    public function a_pdp_requests_client_id_must_be_a_string()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The client ID must be a string');
+
+        Request::from(
+            123,
+            $this->validSubjectId,
+            $this->validIdpEntityId,
+            $this->validSpEntityId,
+            $this->validResponseAttributes
+        );
+    }
+
     /**
      * @test
      * @group Pdp
@@ -56,6 +77,7 @@ class RequestTest extends TestCase
         $this->expectExceptionMessage('SubjectId must be a string');
 
         Request::from(
+            $this->validClientId,
             $invalidSubjectId,
             $this->validIdpEntityId,
             $this->validSpEntityId,
@@ -76,6 +98,7 @@ class RequestTest extends TestCase
         $this->expectExceptionMessage('IDPentityID must be a string');
 
         Request::from(
+            $this->validClientId,
             $this->validSubjectId,
             $invalidIdpEntityId,
             $this->validSpEntityId,
@@ -95,7 +118,13 @@ class RequestTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('SPentityID must be a string');
 
-        Request::from($this->validSubjectId, $this->validIdpEntityId, $invalidSpEntityId, $this->validResponseAttributes);
+        Request::from(
+            $this->validClientId,
+            $this->validSubjectId,
+            $this->validIdpEntityId,
+            $invalidSpEntityId,
+            $this->validResponseAttributes
+        );
     }
 
     /**
@@ -113,6 +142,7 @@ class RequestTest extends TestCase
         ];
 
         Request::from(
+            $this->validClientId,
             $this->validSubjectId,
             $this->validIdpEntityId,
             $this->validSpEntityId,
@@ -136,6 +166,7 @@ class RequestTest extends TestCase
         ];
 
         Request::from(
+            $this->validClientId,
             $this->validSubjectId,
             $this->validIdpEntityId,
             $this->validSpEntityId,
@@ -150,6 +181,7 @@ class RequestTest extends TestCase
     public function a_pdp_request_is_built_correctly()
     {
         $resourceAttributeValues = [
+            'ClientID' => 'clientid',
             'SPentityID' => 'avans_sp',
             'IDPentityID' => 'avans_idp',
         ];
@@ -161,6 +193,7 @@ class RequestTest extends TestCase
         $expectedRequest = $this->buildPdpRequest($resourceAttributeValues, $accessSubjectAttributeValues);
 
         $actualRequest = Request::from(
+            $this->validClientId,
             $accessSubjectAttributeValues[NameIdFormat::UNSPECIFIED],
             $resourceAttributeValues['IDPentityID'],
             $resourceAttributeValues['SPentityID'],
@@ -185,6 +218,7 @@ class RequestTest extends TestCase
         );
 
         $resourceAttributeValues = [
+            'ClientID' => 'clientid',
             'SPentityID' => 'avans_sp',
             'IDPentityID' => 'avans_idp',
         ];

--- a/tests/unit/OpenConext/EngineBlockBundle/Pdp/PdpClientTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Pdp/PdpClientTest.php
@@ -38,7 +38,7 @@ class PdpClientTest extends TestCase
      */
     public function a_pdp_client_gives_policy_decisions_based_on_pdp_responses_to_pdp_requests($responseName)
     {
-        $pdpRequest = Request::from('subject', 'idp', 'sp', []);
+        $pdpRequest = Request::from('clientid', 'subject', 'idp', 'sp', []);
         $denyResponseJson = file_get_contents(__DIR__ . '/fixture/response_' . $responseName . '.json');
 
         $mockHandler = new MockHandler([

--- a/tests/unit/OpenConext/EngineBlockBundle/Pdp/fixture/request.json
+++ b/tests/unit/OpenConext/EngineBlockBundle/Pdp/fixture/request.json
@@ -17,6 +17,10 @@
     "Resource": {
       "Attribute": [
         {
+          "AttributeId": "ClientID",
+          "Value": "clientid"
+        },
+        {
           "AttributeId": "SPentityID",
           "Value": "avans_sp"
         },


### PR DESCRIPTION
StepUp uses PDP for context-based access control, so EngineBlock is no
longer the sole user of PDP. PDP requires a client ID to distinguish
StepUp from EngineBlock.

The client ID must be configured in the ini parameter 'pdp.client_id'.