### PR TITLE
Add the SP entity ID to the attribute aggregation API

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/AttributeAggregator.php
+++ b/library/EngineBlock/Corto/Filter/Command/AttributeAggregator.php
@@ -106,6 +106,7 @@ class EngineBlock_Corto_Filter_Command_AttributeAggregator extends EngineBlock_C
         try {
             $response = $this->client->aggregate(
                 Request::from(
+                    $serviceProvider->entityId,
                     $this->_collabPersonId,
                     (array) $this->_responseAttributes,
                     $rules

--- a/src/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/Request.php
+++ b/src/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/Request.php
@@ -26,6 +26,11 @@ final class Request implements JsonSerializable
     /**
      * @var string
      */
+    public $spEntityId;
+
+    /**
+     * @var string
+     */
     public $subjectId;
 
     /**
@@ -41,16 +46,19 @@ final class Request implements JsonSerializable
     public $rules = [];
 
     /**
+     * @param string $spEntityId
      * @param string $subjectId
      * @param AttributeRule[] $rules
      * @return Request $request
      */
-    public static function from($subjectId, array $attributes, array $rules)
+    public static function from($spEntityId, $subjectId, array $attributes, array $rules)
     {
+        Assertion::string($spEntityId, 'The SP entity ID must be a string, received "%s" (%s)');
         Assertion::string($subjectId, 'The SubjectId must be a string, received "%s" (%s)');
         Assertion::allIsInstanceOf($rules, AttributeRule::class, 'All attributes must be of type AttributeRule');
 
         $request = new self;
+        $request->spEntityId = $spEntityId;
         $request->subjectId = $subjectId;
         $request->attributes = $attributes;
         $request->rules = $rules;
@@ -67,6 +75,10 @@ final class Request implements JsonSerializable
                         'name' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
                         'values' => [$this->subjectId],
                     ],
+                    [
+                        'name' => 'SPentityID',
+                        'values' => [$this->spEntityId],
+                    ]
                 ],
                 array_map(
                     function ($values, $name) {

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/AttributeAggregationClientTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/AttributeAggregationClientTest.php
@@ -40,12 +40,13 @@ class AttributeAggregationClientTest extends TestCase
     public function an_attributeaggregation_client_parses_the_aggregator_response()
     {
         $request = Request::from(
-          'subject',
-          [],
-          [
-            AttributeRule::from('name', 'value', 'source'),
-            AttributeRule::from('name', 'value', 'source'),
-          ]
+            'sp-entity-id',
+            'subject',
+            [],
+            [
+                AttributeRule::from('name', 'value', 'source'),
+                AttributeRule::from('name', 'value', 'source'),
+            ]
         );
 
         $responseFixture = file_get_contents(__DIR__ . '/fixture/success-response.json');

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/RequestTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/RequestTest.php
@@ -34,6 +34,7 @@ class RequestTest extends TestCase
     public function request_serializes_to_aa_api_format()
     {
         $request = Request::from(
+            'sp-entity-id',
             'subject',
             [
                 'attr' => [1, 2, 3],
@@ -50,6 +51,10 @@ class RequestTest extends TestCase
                     [
                         'name' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
                         'values' => ['subject'],
+                    ],
+                    [
+                        'name' => 'SPentityID',
+                        'values' => ['sp-entity-id'],
                     ],
                     [
                         'name' => 'attr',
@@ -83,7 +88,16 @@ class RequestTest extends TestCase
     public function request_subject_must_be_set()
     {
         $this->setExpectedException(InvalidArgumentException::class);
-        Request::from(NULL, [], []);
+        Request::from('sp-entity-id', NULL, [], []);
+    }
+
+    /**
+     * @test
+     */
+    public function request_sp_entity_id_must_be_set()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+        Request::from(NULL,'subject-id', [], []);
     }
 
     /**
@@ -92,6 +106,6 @@ class RequestTest extends TestCase
     public function request_attributes_must_be_of_type_dto()
     {
         $this->setExpectedException(InvalidArgumentException::class);
-        Request::from('subject', [], [['invalid']]);
+        Request::from('sp-entity-id', 'subject', [], [['invalid']]);
     }
 }


### PR DESCRIPTION
The attribute aggregator requires the SP entity ID in the
request. This commit adds the entity ID to the request object as a
user attribute:

    {
      "userAttributes": [
        {
          "name": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
          "values": [
            "urn:collab:person:surfnet.nl:henny"
          ]
        },
        {
          "name": "SPentityID",
          "values": [
            "http://localhost/metadata"
          ]
        }
      ],
      "arpAttributes": {}
    }