### PR TITLE
Send all attributes to the aggregation endpoint

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/AttributeAggregator.php
+++ b/library/EngineBlock/Corto/Filter/Command/AttributeAggregator.php
@@ -101,17 +101,18 @@ class EngineBlock_Corto_Filter_Command_AttributeAggregator extends EngineBlock_C
             return;
         }
 
+        // The AA request contains all response attributes.
+        $request = Request::from(
+            $serviceProvider->entityId,
+            $this->_collabPersonId,
+            (array) $this->_responseAttributes,
+            $rules
+        );
+
         $this->clearAttributesForAggregation($rules);
 
         try {
-            $response = $this->client->aggregate(
-                Request::from(
-                    $serviceProvider->entityId,
-                    $this->_collabPersonId,
-                    (array) $this->_responseAttributes,
-                    $rules
-                )
-            );
+            $response = $this->client->aggregate($request);
 
             $this->addAggregatedAttributes($response->attributes);
         } catch (HttpException $e) {

--- a/src/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/Request.php
+++ b/src/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/Request.php
@@ -48,6 +48,7 @@ final class Request implements JsonSerializable
     /**
      * @param string $spEntityId
      * @param string $subjectId
+     * @param array $attributes
      * @param AttributeRule[] $rules
      * @return Request $request
      */


### PR DESCRIPTION
Previous implementation cleared all response attributes before adding
them to the AA request. This was a bug: the attribute aggregator
should receive all attributes in the assertion.