### PR TITLE
Accept 'showSources' parameter in arp endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "kriswallsmith/assetic": "~1.2.0",
         "monolog/monolog": "~1.13",
         "mrclay/minify": "~2.2",
-        "openconext/engineblock-metadata": "^2.3.0",
+        "openconext/engineblock-metadata": "^2.4.0",
         "openconext/stoker-metadata": "~0.1",
         "pimple/pimple": "~2.1",
         "simplesamlphp/saml2": "1.10.3 as 1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "009bb5f700669f712eb7223ac831e0f3",
+    "content-hash": "0625541470e94d058d7757e57e8edd4a",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1517,16 +1517,16 @@
         },
         {
             "name": "openconext/engineblock-metadata",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/OpenConext-engineblock-metadata.git",
-                "reference": "1e6c34c967f9e6893aa0cdc44269bf41b983fb8f"
+                "reference": "753a70b28674a1d57405f22b5e6d0e3654bc15b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/OpenConext-engineblock-metadata/zipball/1e6c34c967f9e6893aa0cdc44269bf41b983fb8f",
-                "reference": "1e6c34c967f9e6893aa0cdc44269bf41b983fb8f",
+                "url": "https://api.github.com/repos/OpenConext/OpenConext-engineblock-metadata/zipball/753a70b28674a1d57405f22b5e6d0e3654bc15b3",
+                "reference": "753a70b28674a1d57405f22b5e6d0e3654bc15b3",
                 "shasum": ""
             },
             "require": {
@@ -1551,7 +1551,7 @@
                 "Apache-2.0"
             ],
             "description": "OpenConext component for EngineBlock Entity Metadata",
-            "time": "2017-12-01T08:02:12+00:00"
+            "time": "2017-12-01T13:31:37+00:00"
         },
         {
             "name": "openconext/saml-value-object",
@@ -4368,7 +4368,7 @@
                     "name": "Manuel Pichler",
                     "email": "github@manuel-pichler.de",
                     "homepage": "https://github.com/manuelpichler",
-                    "role": "Project Founder"
+                    "role": "Project founder"
                 },
                 {
                     "name": "Other contributors",

--- a/library/EngineBlock/Arp/AttributeReleasePolicyEnforcer.php
+++ b/library/EngineBlock/Arp/AttributeReleasePolicyEnforcer.php
@@ -4,9 +4,26 @@ use OpenConext\Component\EngineBlockMetadata\AttributeReleasePolicy;
 
 class EngineBlock_Arp_AttributeReleasePolicyEnforcer
 {
-    public function enforceArp(AttributeReleasePolicy $arp = null, $responseAttributes)
+    public function enforceArp(AttributeReleasePolicy $arp = null, $responseAttributes, $showSources = false)
     {
         if (!$arp) {
+            if ($showSources) {
+                $newAttributes = array();
+                foreach ($responseAttributes as $attributeName => $attributeValues) {
+                    foreach ($attributeValues as $attributeValue) {
+                        if (!isset($newAttributes[$attributeName])) {
+                            $newAttributes[$attributeName] = array();
+                        }
+                        $attribute = array(
+                            'value' => $attributeValue,
+                            'source' => 'idp',
+                        );
+                        $newAttributes[$attributeName][] = $attribute;
+                    }
+                }
+                $responseAttributes = $newAttributes;
+            }
+
             return $responseAttributes;
         }
 
@@ -28,7 +45,15 @@ class EngineBlock_Arp_AttributeReleasePolicyEnforcer
                     $newAttributes[$attributeName] = array();
                 }
 
-                $newAttributes[$attributeName][] = $attributeValue;
+                if ($showSources) {
+                    $attribute = array(
+                        'value' => $attributeValue,
+                        'source' => $arp->getSource($attributeName),
+                    );
+                    $newAttributes[$attributeName][] = $attribute;
+                } else {
+                    $newAttributes[$attributeName][] = $attributeValue;
+                }
             }
         }
         return $newAttributes;

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyController.php
@@ -82,6 +82,12 @@ final class AttributeReleasePolicyController
             throw new BadApiRequestHttpException('Invalid JSON structure: "attributes" must be a JSON object');
         }
 
+        if (!isset($body['showSources']) || !is_bool($body['showSources'])) {
+            $showSources = false;
+        } else {
+            $showSources = $body['showSources'];
+        }
+
         foreach ($body['attributes'] as $attributeName => $attributeValues) {
             if (!is_string($attributeName) || !is_array($attributeValues)) {
                 throw new BadApiRequestHttpException(
@@ -93,7 +99,7 @@ final class AttributeReleasePolicyController
         $releasedAttributes = [];
         foreach ($body['entityIds'] as $entityId) {
             $arp = $this->metadataService->findArpForServiceProviderByEntityId(new EntityId($entityId));
-            $releasedAttributes[$entityId] = $this->arpEnforcer->enforceArp($arp, $body['attributes']);
+            $releasedAttributes[$entityId] = $this->arpEnforcer->enforceArp($arp, $body['attributes'], $showSources);
         }
 
         return new JsonResponse(json_encode($releasedAttributes));


### PR DESCRIPTION
This parameter trigger the inclusion of the attribute source. The source is omitted by default, but will be included per attribute when using this parameter.

I've tested this myself using PHPStorm REST Client. But using curl should do just fine. 

**Test info**
Hostname: `https://engine-api.vm.openconext.org`
Endpoint: POST `/arp`
Request body (attributes without sources are sent for each sp)
```
{"showSources":true, "entityIds":["https:\/\/aa.vm.openconext.org\/shibboleth","https:\/\/profile-dev.vm.openconext.org\/app_dev.php\/authentication\/metadata"],"attributes":{"urn:mace:dir:attribute-def:cn":["John Doe"],"urn:oid:2.5.4.3":["John Doe"],"urn:mace:dir:attribute-def:displayName":["John Doe"],"urn:oid:2.16.840.1.113730.3.1.241":["John Doe"],"urn:mace:dir:attribute-def:eduPersonPrincipalName":["j.doe@example.com"],"urn:oid:1.3.6.1.4.1.5923.1.1.1.6":["j.doe@example.com"],"urn:mace:dir:attribute-def:givenName":["John"],"urn:oid:2.5.4.42":["John"],"urn:mace:dir:attribute-def:mail":["j.doe@example.com"],"urn:oid:0.9.2342.19200300.100.1.3":["j.doe@example.com"],"urn:mace:dir:attribute-def:sn":["Doe"],"urn:oid:2.5.4.4":["Doe"],"urn:mace:dir:attribute-def:uid":["student435"],"urn:oid:0.9.2342.19200300.100.1.1":["student435"],"urn:mace:terena.org:attribute-def:schacHomeOrganization":["example.com"],"urn:oid:1.3.6.1.4.1.25178.1.2.9":["example.com"],"urn:oid:1.3.6.1.4.1.1466.115.121.1.15":["example.com"],"urn:mace:dir:attribute-def:isMemberOf":["urn:collab:org:vm.openconext.org"],"urn:oid:1.3.6.1.4.1.5923.1.5.1.1":["urn:collab:org:vm.openconext.org"],"urn:oid:1.3.6.1.4.1.1076.20.40.40.1":["urn:collab:person:example.com:student435"],"urn:mace:dir:attribute-def:eduPersonTargetedID":["34cda9f1d5c1323d640ff99e671955dd5e30b79d"],"urn:oid:1.3.6.1.4.1.5923.1.1.1.10":["34cda9f1d5c1323d640ff99e671955dd5e30b79d"]}}
```

For retrieving consent information (no changes here but might be interesting)
Endpoint: GET `/consent/urn:collab:person:example.com:student435`