### PR TITLE
Install Monitor-bundle 1.0.0

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -19,11 +19,14 @@ class AppKernel extends Kernel
             new Sensio\Bundle\DistributionBundle\SensioDistributionBundle(),
             new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle(),
 
-            // Doctrine Integration
+            // Doctrine integration
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
 
-            // EngineBlock Integration
+            // OpenConext Monitor integration
+            new OpenConext\MonitorBundle\OpenConextMonitorBundle(),
+
+            // EngineBlock integration
             new OpenConext\EngineBlockBundle\OpenConextEngineBlockBundle(),
         ];
 

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -15,3 +15,7 @@ openconext_engineblock_api:
     prefix:   /
     defaults:
         domain: "%domain%"
+
+openconext_monitor:
+    resource: "@OpenConextMonitorBundle/Resources/config/routing.yml"
+    prefix: /

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -26,6 +26,10 @@ security:
             stateless: true
             pattern: ^/.+
 
+        monitor:
+            pattern: ^/(info|health)$
+            security: false
+
         main:
             anonymous: ~
             stateless:  true

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "doctrine/doctrine-bundle": "^1.6",
         "ramsey/uuid": "^3.3.0",
         "sensio/generator-bundle": "^3.0",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.0",
+        "openconext/monitor-bundle": "^1.0"
     },
     "require-dev": {
         "phake/phake": "2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0625541470e94d058d7757e57e8edd4a",
+    "content-hash": "48325d54a6237b5e11c957a6d717b115",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1552,6 +1552,59 @@
             ],
             "description": "OpenConext component for EngineBlock Entity Metadata",
             "time": "2017-12-01T13:31:37+00:00"
+        },
+        {
+            "name": "openconext/monitor-bundle",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OpenConext/Monitor-bundle.git",
+                "reference": "b9be093828385e857ff23a106b4429155d7f8d58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OpenConext/Monitor-bundle/zipball/b9be093828385e857ff23a106b4429155d7f8d58",
+                "reference": "b9be093828385e857ff23a106b4429155d7f8d58",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4,<8.0-dev",
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/framework-bundle": ">=2.7,<4",
+                "webmozart/assert": "^1.2"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "liip/rmt": "^1.1",
+                "malukenho/docheader": "^0.1.6",
+                "matthiasnoback/symfony-config-test": "^2.1",
+                "mockery/mockery": "~0.9",
+                "phpdocumentor/reflection-docblock": "3.3.*",
+                "phpmd/phpmd": "^2.6",
+                "phpunit/php-token-stream": "1.4.*",
+                "phpunit/phpunit": "^5.7",
+                "sebastian/phpcpd": "^3.0",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "OpenConext\\MonitorBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "A Symfony2 bundle that facilitates health and info endpoints to a Symfony application",
+            "keywords": [
+                "OpenConext",
+                "health",
+                "monitoring",
+                "stepup",
+                "surfnet"
+            ],
+            "time": "2017-12-07T14:41:46+00:00"
         },
         {
             "name": "openconext/saml-value-object",
@@ -3107,6 +3160,56 @@
                 "templating"
             ],
             "time": "2017-09-27T18:06:46+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "whitehat101/apr1-md5",


### PR DESCRIPTION
This installs version 1.0.0 of the OpenConext Monitor Bundle into engineblock. This enabled the /info and /health endpoints for the public. Access to these endpoints need to be restricted in the load balancer.

Database checks are performed as EB is configured with Doctrine.