### PR TITLE
Expose the /read-arp endpoint on EB API

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1517,16 +1517,16 @@
         },
         {
             "name": "openconext/engineblock-metadata",
-            "version": "2.4.0",
+            "version": "2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/OpenConext-engineblock-metadata.git",
-                "reference": "753a70b28674a1d57405f22b5e6d0e3654bc15b3"
+                "reference": "ffd471a074e3e9dac0f402c45610e25f88586344"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/OpenConext-engineblock-metadata/zipball/753a70b28674a1d57405f22b5e6d0e3654bc15b3",
-                "reference": "753a70b28674a1d57405f22b5e6d0e3654bc15b3",
+                "url": "https://api.github.com/repos/OpenConext/OpenConext-engineblock-metadata/zipball/ffd471a074e3e9dac0f402c45610e25f88586344",
+                "reference": "ffd471a074e3e9dac0f402c45610e25f88586344",
                 "shasum": ""
             },
             "require": {
@@ -1551,7 +1551,7 @@
                 "Apache-2.0"
             ],
             "description": "OpenConext component for EngineBlock Entity Metadata",
-            "time": "2017-12-01T13:31:37+00:00"
+            "time": "2018-01-10T10:20:11+00:00"
         },
         {
             "name": "openconext/monitor-bundle",

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyController.php
@@ -104,4 +104,35 @@ final class AttributeReleasePolicyController
 
         return new JsonResponse(json_encode($releasedAttributes));
     }
+
+    /**
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function readArpAction(Request $request)
+    {
+        if (!$request->isMethod(Request::METHOD_POST)) {
+            throw ApiMethodNotAllowedHttpException::methodNotAllowed($request->getMethod(), [Request::METHOD_POST]);
+        }
+
+        if (!$this->authorizationChecker->isGranted('ROLE_API_USER_PROFILE')) {
+            throw new ApiAccessDeniedHttpException('Access to the ARP API requires the role ROLE_API_USER_PROFILE');
+        }
+
+        $body = JsonRequestHelper::decodeContentAsArrayOf($request);
+
+        if (!isset($body['entityIds'])) {
+            throw new BadApiRequestHttpException('Invalid JSON structure: key "entityIds" not found');
+        }
+
+        $arpCollection = [];
+        foreach ($body['entityIds'] as $entityId) {
+            $arp = $this->metadataService->findArpForServiceProviderByEntityId(new EntityId($entityId));
+            if ($arp) {
+                $arpCollection[$entityId] = $arp->getAttributeRules();
+            }
+        }
+
+        return new JsonResponse(json_encode($arpCollection));
+    }
 }

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyController.php
@@ -111,22 +111,18 @@ final class AttributeReleasePolicyController
      */
     public function readArpAction(Request $request)
     {
-        if (!$request->isMethod(Request::METHOD_POST)) {
-            throw ApiMethodNotAllowedHttpException::methodNotAllowed($request->getMethod(), [Request::METHOD_POST]);
+        if (!$request->isMethod(Request::METHOD_GET)) {
+            throw ApiMethodNotAllowedHttpException::methodNotAllowed($request->getMethod(), [Request::METHOD_GET]);
         }
 
         if (!$this->authorizationChecker->isGranted('ROLE_API_USER_PROFILE')) {
             throw new ApiAccessDeniedHttpException('Access to the ARP API requires the role ROLE_API_USER_PROFILE');
         }
 
-        $body = JsonRequestHelper::decodeContentAsArrayOf($request);
-
-        if (!isset($body['entityIds'])) {
-            throw new BadApiRequestHttpException('Invalid JSON structure: key "entityIds" not found');
-        }
+        $entityIds = explode(',', $request->get('entityIds'));
 
         $arpCollection = [];
-        foreach ($body['entityIds'] as $entityId) {
+        foreach ($entityIds as $entityId) {
             $arp = $this->metadataService->findArpForServiceProviderByEntityId(new EntityId($entityId));
             if ($arp) {
                 $arpCollection[$entityId] = $arp->getAttributeRules();

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
@@ -24,7 +24,12 @@ api_metadata_idp:
     defaults:
         _controller: engineblock.controller.api.metadata:idpAction
 
-api_attribute_release_policy:
+api_apply_attribute_release_policy:
     path:   /arp
     defaults:
         _controller: engineblock.controller.api.attribute_release_policy:applyArpAction
+
+api_read_attribute_release_policy:
+    path:   /read-arp
+    defaults:
+        _controller: engineblock.controller.api.attribute_release_policy:readArpAction


### PR DESCRIPTION
The arp configuration of entities can now be read from the EB API using
the /read-arp endpoint. The endpoint expects to be called using POST.
An array of entityIds must be provided to specify what Arp config should
be read.