### PR TITLE
Log sigalg for both Response AND Assertion.

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -45,9 +45,10 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         $log = $application->getLogInstance();
 
         $log->notice(sprintf(
-            'Received Assertion from Issuer "%s" with signature method algorithm "%s"',
+            'Received Assertion from Issuer "%s" with signature method algorithms Response: "%s" and Assertion: "%s"',
             $receivedResponse->getIssuer(),
-            $receivedResponse->getSignatureMethod()
+            $receivedResponse->getSignatureMethod(),
+            $receivedResponse->getAssertion()->getSignatureMethod()
         ));
 
         $sp  = $this->_server->getRepository()->fetchServiceProviderByEntityId($receivedRequest->getIssuer());


### PR DESCRIPTION
A SAML response can have a signature in the Response, in the Assertion
contained therein, or both. Log all information we have.