### PR TITLE
Do not process authn requests multiple times per request

### DIFF
--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -74,8 +74,12 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         $this->_logger                     = EngineBlock_ApplicationSingleton::getLog();
     }
 
-
     /**
+     * Process an authorization request.
+     *
+     * NOTE: Never call this method more than once for the same request. This method
+     *       does not cache its results.
+     *
      * @return EngineBlock_Saml2_AuthnRequestAnnotationDecorator
      * @throws EngineBlock_Corto_Module_Bindings_UnsupportedBindingException
      * @throws EngineBlock_Corto_Module_Bindings_VerificationException
@@ -162,6 +166,10 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         }
 
         $this->_annotateRequestWithKeyId($ebRequest);
+
+        // Corto service modules (SingleSignOn) can use the received
+        // request object without having to process it again.
+        $this->_server->setReceivedRequest($ebRequest);
 
         return $ebRequest;
     }

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -173,8 +173,10 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
             $request = $this->_createDebugRequest();
             $logMessage = 'Created debug SAML request';
         } else {
-            // parse SAML request
-            $request = $this->_server->getBindingsModule()->receiveRequest();
+            // Get the previously parsed request object, see
+            // EngineBlock_Corto_Adapter::singleSignOn() and
+            // EngineBlock_Corto_Module_Bindings::receiveRequest().
+            $request = $this->_server->getReceivedRequest();
 
             // set transparent proxy mode
             if ($this->_server->getConfig('TransparentProxy', false)) {

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -55,6 +55,11 @@ class EngineBlock_Corto_ProxyServer
     private $_hostName;
 
     /**
+     * @var EngineBlock_Saml2_AuthnRequestAnnotationDecorator
+     */
+    private $receivedRequest;
+
+    /**
      * @var MetadataRepositoryInterface
      */
     private $_repository;
@@ -119,6 +124,25 @@ class EngineBlock_Corto_ProxyServer
     public function setHostName($hostName)
     {
         $this->_hostName = $hostName;
+    }
+
+    /**
+     * @param EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request
+     * @return EngineBlock_Corto_ProxyServer
+     */
+    public function setReceivedRequest(EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request)
+    {
+        $this->receivedRequest = $request;
+
+        return $this;
+    }
+
+    /**
+     * @return EngineBlock_Saml2_AuthnRequestAnnotationDecorator
+     */
+    public function getReceivedRequest()
+    {
+        return $this->receivedRequest;
     }
 
     /**


### PR DESCRIPTION
The receiveRequest() and receiveResponse() methods on the bindings
module are costly methods that do logging, signature validation and
fetching of metadata. The methods do not cache their results so they
should never be called more than once per request.

Until commit 2ed6926, the receiveRequest() method was called just once
per request, by the Corto SingleSignOn module. Starting from that
commit, the method was called in two places, relying on caching by the
'internal bindings' mechanism to be efficient - which presumably has
never worked as intended for requests. In later commits, two more
invocations of the method were added causing signatures to be
validated four times for a single request.

This commit fixes the issue in three places:

1. The receiveRequest() method on the bindings module now stores the
   request object in the proxy server instance, making it available
   for other corto modules.

2. The SingleSignOn corto module uses the received request on the
   proxy server instead of calling receiveRequest() again.

3. The EngineBlock Corto adapter calls receiveRequest() just a single
   time, removing misleading comments about caching.