### PR TITLE
Create signatures using a configurable signature method

### DIFF
--- a/database/DoctrineMigrations/Version20180118115853.php
+++ b/database/DoctrineMigrations/Version20180118115853.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180118115853 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD signature_method VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sso_provider_roles_eb5 SET signature_method = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP signature_method');
+    }
+}

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -475,7 +475,11 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             $keyPair = $this->_server->getSigningCertificates();
 
             $sspMessage->setCertificates(array($keyPair->getCertificate()->toPem()));
-            $sspMessage->setSignatureKey($keyPair->getPrivateKey()->toXmlSecurityKey());
+            $sspMessage->setSignatureKey(
+                $keyPair->getPrivateKey()->toXmlSecurityKey(
+                    $remoteEntity->signatureMethod
+                )
+            );
         }
 
         $sspBinding = Binding::getBinding($bindingUrn);

--- a/library/EngineBlock/X509/PrivateKey.php
+++ b/library/EngineBlock/X509/PrivateKey.php
@@ -24,9 +24,9 @@ class EngineBlock_X509_PrivateKey
         return $this->_filePath;
     }
 
-    public function toXmlSecurityKey()
+    public function toXmlSecurityKey($signatureMethod)
     {
-        $privateKeyObj = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' => 'private'));
+        $privateKeyObj = new XMLSecurityKey($signatureMethod, array('type' => 'private'));
         $privateKeyObj->loadKey($this->_filePath, true);
         return $privateKeyObj;
     }


### PR DESCRIPTION
A signature method can be configured per SP and IDP using the
'coin:signature_method' metadata property. If this property is not
set, RSA_SHA1 is used in order to maintain backwards compatibility.

Depends on https://github.com/OpenConext/OpenConext-engineblock-metadata/pull/19 (already merged).