### PR TITLE
Disallow authn requests signed with forbidden signature methods

### DIFF
--- a/app/Resources/views/modules/Authentication/View/Feedback/UnsupportedSignatureMethod.phtml
+++ b/app/Resources/views/modules/Authentication/View/Feedback/UnsupportedSignatureMethod.phtml
@@ -1,0 +1,24 @@
+<?php /* This file is generated. Please edit the files of the appropriate theme in the 'theme/' directory. */ ?>
+<?php
+
+/**
+ * @var Zend_Layout $layout
+ */
+$layout = $this->layout();
+
+// Set Layout properties
+$layout->title = $layout->title. ' - ' .$this->t('error_unsupported_signature_method');
+$layout->header = $layout->title;
+$layout->subheader = $this->t('error_unsupported_signature_method');
+$layout->wide = true;
+
+?>
+<div class="box">
+  <div class="mod-content">
+    <h1><?php echo htmlentities($this->layout()->subheader, 0, "UTF-8"); ?></h1>
+
+    <p><?= $this->t('error_unsupported_signature_method_desc', $this->_data['signature-method']); ?>
+
+    <?php require_once realpath(__DIR__ . '/../../../Default/View/Error/include/footer.php'); ?>
+  </div>
+</div>

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -268,3 +268,7 @@ ui.return_to_sp_link.active = false
 ;; Symfony specific variables
 symfony.cachePath = "/tmp/engineblock/cache"
 symfony.logPath = "/tmp/engineblock/logs"
+
+; Signature methods explicitly forbidden by EngineBlock, comma-separated.
+; forbiddenSignatureMethods = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+

--- a/languages/en.php
+++ b/languages/en.php
@@ -264,6 +264,8 @@ Visit <a href="https://wiki.surfnet.nl/x/jq9WAw" target="_blank">the SURFconext 
     'error_invalid_acs_location'    => 'The given "Assertion Consumer Service" is unknown or invalid.',
     'error_invalid_acs_binding'     => 'Invalid ACS Binding Type',
     'error_invalid_acs_binding_desc'     => 'The provided or configured "Assertion Consumer Service" Binding Type is unknown or invalid.',
+    'error_unsupported_signature_method' => 'Signature method is not supported',
+    'error_unsupported_signature_method_desc' => 'The signature method %1$s is not supported, please upgrade to RSA-SHA256 (http://www.w3.org/2001/04/xmldsig-more#rsa-sha256).',
     'error_unknown_preselected_idp' => 'Error - No connection between institution and service',
     'error_unknown_preselected_idp_desc' => '<p>
         The institution that you want to use to login to this service did not activate access to this service. This means you are unable to use this service through SURFconext. Please contact your institution\'s helpdesk to request access to this service. State what service it is about (the &lsquo;Service Provider&rsquo;) and why you need access.

--- a/languages/nl.php
+++ b/languages/nl.php
@@ -263,6 +263,8 @@ Bezoek <a href="https://wiki.surfnet.nl/pages/viewpage.action?pageId=52331093" t
     'error_invalid_acs_location'        => 'De opgegeven "Assertion Consumer Service" is onjuist of bestaat niet.',
     'error_invalid_acs_binding'        => 'Onjuist ACS Binding Type',
     'error_invalid_acs_binding_desc'        => 'Het opgegeven of geconfigureerde "Assertion Consumer Service" Binding Type is onjuist of bestaat niet.',
+    'error_unsupported_signature_method' => 'Ondertekeningsmethode wordt niet ondersteund',
+    'error_unsupported_signature_method_desc' => 'De ondertekeningsmethode %1$s wordt niet ondersteund, upgrade naar RSA-SHA256 (http://www.w3.org/2001/04/xmldsig-more#rsa-sha256).',
     'error_unknown_preselected_idp' => 'Error - Instelling is niet gekoppeld aan dienst',
     'error_unknown_preselected_idp_desc' => '<p>
         De instelling waarmee je wilt inloggen heeft toegang tot deze dienst niet geactiveerd. Dat betekent dat jij geen gebruik kunt maken van deze dienst via SURFconext. Neem contact op met de helpdesk van jouw instelling als je toegang wilt krijgen tot deze dienst. Geef daarbij aan om welke dienst het gaat (de &lsquo;Service Provider&rsquo;) en waarom je toegang wilt.

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -338,6 +338,7 @@ class EngineBlock_Corto_Adapter
             'debug' => $application->getConfigurationValue('debug', false),
             'ConsentStoreValues' => $this->_getConsentConfigurationValue('storeValues', true),
             'metadataValidUntilSeconds' => 86400, // This sets the time (in seconds) the entity metadata is valid.
+            'forbiddenSignatureMethods' => $this->_getForbiddenSignatureMethods(),
         ));
 
         /**
@@ -372,6 +373,22 @@ class EngineBlock_Corto_Adapter
             return $default;
         }
         return $configuration->authentication->consent->$name;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function _getForbiddenSignatureMethods()
+    {
+        $application = EngineBlock_ApplicationSingleton::getInstance();
+        $commaSeparatedList = $application->getConfigurationValue('forbiddenSignatureMethods', '');
+
+        $list = array_map(
+            'trim',
+            explode(',', $commaSeparatedList)
+        );
+
+        return array_filter($list);
     }
 
     public function getProxyServer()

--- a/library/EngineBlock/Corto/Module/Bindings/UnsupportedSignatureMethodException.php
+++ b/library/EngineBlock/Corto/Module/Bindings/UnsupportedSignatureMethodException.php
@@ -1,0 +1,33 @@
+<?php
+
+class EngineBlock_Corto_Module_Bindings_UnsupportedSignatureMethodException extends EngineBlock_Corto_Module_Bindings_Exception
+{
+    /**
+     * @var string $signatureMethod
+     */
+    private $signatureMethod;
+
+    /**
+     * EngineBlock_Corto_Module_Bindings_UnsupportedSignatureMethodException constructor.
+     * @param string $signatureMethod
+     */
+    public function __construct($signatureMethod)
+    {
+        parent::__construct(
+            sprintf(
+                'The signature method %s is not supported',
+                $signatureMethod
+            )
+        );
+
+        $this->signatureMethod = $signatureMethod;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSignatureMethod()
+    {
+        return $this->signatureMethod;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -122,6 +122,23 @@ class FeedbackController
      * @return Response
      * @throws \EngineBlock_Exception
      */
+    public function unsupportedSignatureMethodAction(Request $request)
+    {
+        return new Response(
+            $this->engineBlockView
+                ->setData([
+                    'signature-method' => $request->get('signature-method')
+                ])
+                ->render('Authentication/View/Feedback/UnsupportedSignatureMethod.phtml'),
+            400
+        );
+    }
+
+    /**
+     * @param Request $request
+     * @return Response
+     * @throws \EngineBlock_Exception
+     */
     public function unknownServiceProviderAction(Request $request)
     {
         $viewData = ['entity-id' => $request->get('entity-id')];

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -30,6 +30,7 @@ use EngineBlock_Corto_Exception_UnknownPreselectedIdp;
 use EngineBlock_Corto_Module_Bindings_SignatureVerificationException;
 use EngineBlock_Corto_Module_Bindings_UnableToReceiveMessageException;
 use EngineBlock_Corto_Module_Bindings_UnsupportedBindingException;
+use EngineBlock_Corto_Module_Bindings_UnsupportedSignatureMethodException;
 use EngineBlock_Corto_Module_Bindings_VerificationException;
 use EngineBlock_Corto_Module_Service_SingleSignOn_NoIdpsException;
 use EngineBlock_Corto_Module_Services_SessionLostException;
@@ -125,6 +126,12 @@ class RedirectToFeedbackPageExceptionListener
         } elseif ($exception instanceof EngineBlock_Corto_Module_Bindings_UnsupportedBindingException) {
             $message         = 'Unsupported Binding';
             $redirectToRoute = 'authentication_feedback_invalid_acs_binding';
+        } elseif ($exception instanceof EngineBlock_Corto_Module_Bindings_UnsupportedSignatureMethodException) {
+            $message         = 'Unsupported signature method';
+            $redirectToRoute = 'authentication_feedback_unsupported_signature_method';
+            $redirectParams  = [
+                'signature-method' => $exception->getSignatureMethod(),
+            ];
         } elseif ($exception instanceof EngineBlock_Corto_Exception_ReceivedErrorStatusCode) {
             $message         = 'Received Error Status Code';
             $redirectToRoute = 'authentication_feedback_received_error_status_code';

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
@@ -23,6 +23,11 @@ authentication_feedback_invalid_acs_location:
     methods:    [GET]
     defaults:   { _controller: engineblock.controller.authentication.feedback:invalidAcsLocationAction }
 
+authentication_feedback_unsupported_signature_method:
+    path:       '/unsupportedSignatureMethod'
+    methods:    [GET]
+    defaults:   { _controller: engineblock.controller.authentication.feedback:unsupportedSignatureMethodAction }
+
 authentication_feedback_unknown_service_provider:
     path:       '/unknown-service-provider'
     methods:    [GET]

--- a/theme/material/templates/modules/Authentication/View/Feedback/UnsupportedSignatureMethod.phtml
+++ b/theme/material/templates/modules/Authentication/View/Feedback/UnsupportedSignatureMethod.phtml
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @var Zend_Layout $layout
+ */
+$layout = $this->layout();
+
+// Set Layout properties
+$layout->title = $layout->title. ' - ' .$this->t('error_unsupported_signature_method');
+$layout->header = $layout->title;
+$layout->subheader = $this->t('error_unsupported_signature_method');
+$layout->wide = true;
+
+?>
+<div class="box">
+  <div class="mod-content">
+    <h1><?php echo htmlentities($this->layout()->subheader, 0, "UTF-8"); ?></h1>
+
+    <p><?= $this->t('error_unsupported_signature_method_desc', $this->_data['signature-method']); ?>
+
+    <?php require_once realpath(__DIR__ . '/../../../Default/View/Error/include/footer.php'); ?>
+  </div>
+</div>


### PR DESCRIPTION
EngineBlock now allows configuring one or more 'forbidden signature
methods'. If an authentication request is signed with such a method,
an error is logged and the generic error page is shown to the user.

Before this commit, the notice 'Received signed AuthnRequest from
Issuer...' was only logged when the signature was contained inside the
SAML message, but not when the signature was sent as a query
parameter. This commit changes this behaviour and logs the used
signature method regardless of how the signature was sent.