### PR TITLE
Make Profile url configurable in application.ini

### DIFF
--- a/app/Resources/views/modules/Authentication/View/Proxy/consent-slidein-about.phtml
+++ b/app/Resources/views/modules/Authentication/View/Proxy/consent-slidein-about.phtml
@@ -4,7 +4,7 @@
   <div class="mod-content">
     <a class="close" href="#"><?= $this->t('slidein_close'); ?></a>
     <section>
-      <?= $this->t('consent_slidein_about_text'); ?>
+      <?= $this->t('consent_slidein_about_text', $profile_url); ?>
     </section>
     <a href="https://support.surfconext.nl/"><?= $this->t('slidein_read_more'); ?></a>
   </div>

--- a/app/Resources/views/modules/Authentication/View/Proxy/consent.phtml
+++ b/app/Resources/views/modules/Authentication/View/Proxy/consent.phtml
@@ -175,12 +175,13 @@ $layout->title      = $layout->title . ' - '. $this->t('consent_header_title', $
 
     <footer>
       <p>
+
         <?php if ($consent_count === 0): ?>
-          <?= $this->t('consent_footer_text_first_consent'); ?>
+          <?= $this->t('consent_footer_text_first_consent', $profile_url); ?>
         <?php elseif ($consent_count === 1): ?>
-          <?= $this->t('consent_footer_text_singular'); ?>
+          <?= $this->t('consent_footer_text_singular', $profile_url); ?>
         <?php else: ?>
-          <?= $this->t('consent_footer_text_plural', $consent_count); ?>
+          <?= $this->t('consent_footer_text_plural', $consent_count, $profile_url); ?>
         <?php endif; ?>
       </p>
     </footer>

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -196,7 +196,14 @@ pdp.password = "secret"
 pdp.client_id = "EngineBlock"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;; ATTRIBUTE AGGREGATION SETTINGS ;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;; PROFILE SETTINGS ;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; Location of Profile
+profile.baseUrl = "https://profile.example.org/"
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;; ATTRIBUTE AGGREGATION SETTINGS ;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; Location of AA

--- a/languages/en.php
+++ b/languages/en.php
@@ -189,9 +189,9 @@ If you have any questions about your privacy and the policy applied, please visi
     'consent_buttons_title'                   => 'Do you agree with sharing this data?',
     'consent_buttons_ok'                      => 'Yes, proceed to %s',
     'consent_buttons_nok'                     => 'No, I do not agree',
-    'consent_footer_text_singular'            => 'You are using one other service via SURFconext. <a href="https://profile.surfconext.nl/" target="_blank">View the list of services and your profile information.</a>',
-    'consent_footer_text_plural'              => 'You are using %1$s services via SURFconext. <a href="https://profile.surfconext.nl/" target="_blank">View the list of services and your profile information.</a>',
-    'consent_footer_text_first_consent'       => 'You are not using any services via SURFconext. <a href="https://profile.surfconext.nl/" target="_blank">View your profile information.</a>',
+    'consent_footer_text_singular'            => 'You are using one other service via SURFconext. <a href="%1$s" target="_blank">View the list of services and your profile information.</a>',
+    'consent_footer_text_plural'              => 'You are using %1$s services via SURFconext. <a href="%2$s" target="_blank">View the list of services and your profile information.</a>',
+    'consent_footer_text_first_consent'       => 'You are not using any services via SURFconext. <a href="%1$s" target="_blank">View your profile information.</a>',
     'consent_slidein_details_email'           => 'Email',
     'consent_slidein_details_phone'           => 'Phone',
     'consent_slidein_text_contact'            => 'If you have any questions about this page, please contact the help desk of your institution. SURFconext has the following contact information:',
@@ -207,7 +207,7 @@ If you have any questions about your privacy and the policy applied, please visi
 <h1>Logging in through SURFconext</h1>
 <img src="/images/about-surfconext.png" alt="SURFconext diagram"/>
 <p>Via SURFconext, researchers, staff and students can easily and securely log in into various cloud services using their own institutional account. SURFconext offers extra privacy protection by sending a minimum set of personal data to these cloud services.</p>
-<p>Curious about which services already received your information before through SURFconext? Visit your <a href="https://profile.surfconext.nl/">SURFconext profile page</a>.</p>
+<p>Curious about which services already received your information before through SURFconext? Visit your <a href="%1$s">SURFconext profile page</a>.</p>
 
 <h1>SURFconext is part of SURF</h1>
 <p>SURF is the collaborative ICT organisation for Dutch education and research.</p>

--- a/languages/nl.php
+++ b/languages/nl.php
@@ -187,9 +187,9 @@ Het privacybeleid voor deze dienstverlening is in detail beschreven en na te lez
     'consent_buttons_title'                   => 'Ga je akkoord met het doorsturen van deze gegevens?',
     'consent_buttons_ok'                      => 'Ja, ga door naar %s',
     'consent_buttons_nok'                     => 'Nee, ik ga niet akkoord',
-    'consent_footer_text_singular'            => 'Je gebruikt al één andere dienst via SURFconext. <a href="https://profile.surfconext.nl/" target="_blank">Bekijk hier het overzicht en je profielinformatie.</a>',
-    'consent_footer_text_plural'              => 'Je gebruikt al %1$s diensten via SURFconext. <a href="https://profile.surfconext.nl/" target="_blank">Bekijk hier het overzicht en je profielinformatie.</a>',
-    'consent_footer_text_first_consent'       => 'Je gebruikt nog geen diensten via SURFconext. <a href="https://profile.surfconext.nl/" target="_blank">Bekijk hier je profielinformatie.</a>',
+    'consent_footer_text_singular'            => 'Je gebruikt al één andere dienst via SURFconext. <a href="%1$s" target="_blank">Bekijk hier het overzicht en je profielinformatie.</a>',
+    'consent_footer_text_plural'              => 'Je gebruikt al %1$s diensten via SURFconext. <a href="%2$s" target="_blank">Bekijk hier het overzicht en je profielinformatie.</a>',
+    'consent_footer_text_first_consent'       => 'Je gebruikt nog geen diensten via SURFconext. <a href="%1$s" target="_blank">Bekijk hier je profielinformatie.</a>',
     'consent_slidein_details_email'           => 'Email',
     'consent_slidein_details_phone'           => 'Telefoon',
     'consent_slidein_text_contact'            => 'Neem voor vragen hierover contact op met de helpdesk van je instelling. De volgende gegevens zijn bij SURFconext bekend:',
@@ -206,7 +206,7 @@ Het privacybeleid voor deze dienstverlening is in detail beschreven en na te lez
 <h1>Inloggen met SURFconext</h1>
 <img src="/images/about-surfconext.png" alt="SURFconext diagram"/>
 <p>Via SURFconext loggen onderzoekers, medewerkers en studenten met hun eigen instellingsaccount veilig en gemakkelijk in bij clouddiensten van verschillende aanbieders. SURFconext biedt extra privacy-bescherming doordat een minimaal aantal persoonlijke gegevens wordt doorgegeven aan deze clouddiensten.</p>
-<p>Zien waar je al eerder toestemming voor hebt gegeven? Bekijk hier je <a href="https://profile.surfconext.nl/" target="_blank">SURFconext profielpagina</a>.</p>
+<p>Zien waar je al eerder toestemming voor hebt gegeven? Bekijk hier je <a href="%1$s" target="_blank">SURFconext profielpagina</a>.</p>
 
 <h1>SURFconext is onderdeel van SURF</h1>
 <p>SURF is de ICT-samenwerkingsorganisatie van het onderwijs en onderzoek in Nederland.</p>

--- a/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
@@ -105,6 +105,12 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
         $layout->hideHeader = true;
         $layout->hideFooter = true;
 
+        // Profile url is configurable in application.ini (profile.baseUrl)
+        $profileUrl = '#';
+        if (EngineBlock_ApplicationSingleton::getInstance()->getConfigurationValue('profile', null)) {
+            $profileUrl = EngineBlock_ApplicationSingleton::getInstance()->getConfigurationValue('profile')->baseUrl;
+        }
+
         $html = $this->_server->renderTemplate(
             'consent',
             array(
@@ -117,7 +123,8 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
                 'idp_support'       => $this->getSupportContact($identityProvider),
                 'consent_count'     => $this->_consentService->countAllFor(
                     $response->getNameIdValue()
-                )
+                ),
+                'profile_url'       => $profileUrl
             ),
             $layout
         );

--- a/theme/material/templates/modules/Authentication/View/Proxy/consent-slidein-about.phtml
+++ b/theme/material/templates/modules/Authentication/View/Proxy/consent-slidein-about.phtml
@@ -3,7 +3,7 @@
   <div class="mod-content">
     <a class="close" href="#"><?= $this->t('slidein_close'); ?></a>
     <section>
-      <?= $this->t('consent_slidein_about_text'); ?>
+    <?= $this->t('consent_slidein_about_text', $profile_url); ?>
     </section>
     <a href="https://support.surfconext.nl/"><?= $this->t('slidein_read_more'); ?></a>
   </div>

--- a/theme/material/templates/modules/Authentication/View/Proxy/consent.phtml
+++ b/theme/material/templates/modules/Authentication/View/Proxy/consent.phtml
@@ -174,12 +174,13 @@ $layout->title      = $layout->title . ' - '. $this->t('consent_header_title', $
 
     <footer>
       <p>
+
         <?php if ($consent_count === 0): ?>
-          <?= $this->t('consent_footer_text_first_consent'); ?>
+          <?= $this->t('consent_footer_text_first_consent', $profile_url); ?>
         <?php elseif ($consent_count === 1): ?>
-          <?= $this->t('consent_footer_text_singular'); ?>
+          <?= $this->t('consent_footer_text_singular', $profile_url); ?>
         <?php else: ?>
-          <?= $this->t('consent_footer_text_plural', $consent_count); ?>
+          <?= $this->t('consent_footer_text_plural', $consent_count, $profile_url); ?>
         <?php endif; ?>
       </p>
     </footer>


### PR DESCRIPTION
A new configuration parameter was added to the application.ini. This config is read in the ProvideConsent service and injected into the consent view. The profile url is then fed into the translation helper who in turn sprintf's it into the translation string.

When no application ini is not configured with the profile url, '#' is used as a fallback value, rendering the link useless.