### PR TITLE
Use release identifier as cache buster

### DIFF
--- a/app/Resources/views/layouts/scripts/default.phtml
+++ b/app/Resources/views/layouts/scripts/default.phtml
@@ -20,7 +20,7 @@
   <meta content="yes" name="apple-mobile-web-app-capable">
   <meta content="translucent-black" name="apple-mobile-web-app-status-bar-style">
   <link href="/favicon.ico" rel="shortcut icon">
-  <link href="/stylesheets/application.css?v=5.5.2" rel="stylesheet" type="text/css" />
+  <link href="/stylesheets/application.css?v=<?= EngineBlock_View::htmlSpecialCharsAttributeValue($this->layout()->assetVersion) ?>" rel="stylesheet" type="text/css" />
   <!-- Firefox CSS -->
   <style>
     @-moz-document url-prefix() {
@@ -127,7 +127,7 @@
 
   <?= $this->layout()->beforeScriptHtml ?>
 
-  <script src="/javascripts/application.min.js?v=5.5.2" type="text/javascript"></script>
+  <script src="/javascripts/application.min.js?v=<?= EngineBlock_View::htmlSpecialCharsAttributeValue($this->layout()->assetVersion) ?>" type="text/javascript"></script>
 
 </body>
 </html>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -11,6 +11,9 @@ parameters:
     #   4102bffe58a9ecbce3c7c934e0aa8ece46efcf82/library/EngineBlock/Application/Bootstrapper.php#L242
     locale: en
 
+    # This value is used as cache-buster, replaced by the release script
+    asset_version: "#ASSET_VERSION#"
+
 open_conext_engine_block:
     features:
         api.metadata_push:   "%feature_api_metadata_push%"
@@ -33,7 +36,6 @@ framework:
     #serializer:      { enable_annotations: true }
     templating:
         engines: ['php']
-        #assets_version: SomeVersionScheme
     default_locale:  "%locale%"
     trusted_hosts:   ~
     trusted_proxies: "%trusted_proxies%"

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -2,6 +2,11 @@ imports:
     - { resource: functional_testing.yml }
     - { resource: config.yml }
 
+# Put parameters here that don't need to change on each machine where the app is deployed
+parameters:
+    # This value is used as cache-buster
+    asset_version: "dev"
+
 framework:
     router:
         resource: "%kernel.root_dir%/config/routing_dev.yml"

--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -56,6 +56,9 @@ COMMITHASH=`git rev-parse HEAD` &&
 echo "Tag: ${TAG}" > ${PROJECT_DIR}/RELEASE &&
 echo "Commit: ${COMMITHASH}" >> ${PROJECT_DIR}/RELEASE &&
 
+echo "Updating asset_version in config"
+sed -i s,#ASSET_VERSION#,${TAG},g ${PROJECT_DIR}/app/config/config.yml
+
 echo "Cleaning build of dev files" &&
 rm -rf ${PROJECT_DIR}/.idea &&
 rm -rf ${PROJECT_DIR}/.git &&

--- a/src/OpenConext/EngineBlockBundle/Resources/config/compat.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/compat.yml
@@ -41,6 +41,7 @@ services:
         properties:
             title: "@=service('engineblock.bridge.config').get('defaults.title')"
             header: "@=service('engineblock.bridge.config').get('defaults.header')"
+            assetVersion: "%asset_version%"
 
     engineblock.compat.logger:
         class: Monolog\Logger

--- a/theme/material/templates/layouts/scripts/default.phtml
+++ b/theme/material/templates/layouts/scripts/default.phtml
@@ -19,7 +19,7 @@
   <meta content="yes" name="apple-mobile-web-app-capable">
   <meta content="translucent-black" name="apple-mobile-web-app-status-bar-style">
   <link href="/favicon.ico" rel="shortcut icon">
-  <link href="/stylesheets/application.css?v=5.5.2" rel="stylesheet" type="text/css" />
+  <link href="/stylesheets/application.css?v=<?= EngineBlock_View::htmlSpecialCharsAttributeValue($this->layout()->assetVersion) ?>" rel="stylesheet" type="text/css" />
   <!-- Firefox CSS -->
   <style>
     @-moz-document url-prefix() {
@@ -126,7 +126,7 @@
 
   <?= $this->layout()->beforeScriptHtml ?>
 
-  <script src="/javascripts/application.min.js?v=5.5.2" type="text/javascript"></script>
+  <script src="/javascripts/application.min.js?v=<?= EngineBlock_View::htmlSpecialCharsAttributeValue($this->layout()->assetVersion) ?>" type="text/javascript"></script>
 
 </body>
 </html>


### PR DESCRIPTION
The makeRelease.sh script replaces a placeholder in config.yml when
creating a tarball, setting the 'asset_version' parameter to the tag,
branch or commit hash used to create the release. This value is used
as cache buster in the html template.

See https://www.pivotaltracker.com/story/show/154839009
