### PR TITLE
Remove obsolete AbstractMetadataRepository methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ branches:
     - 5.x-dev
     - master
     - refactoring-2018
+    - feature/cleanup-abstract-metadata-repository
 
 addons:
   hosts:

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -288,17 +288,6 @@ class EngineBlock_Corto_Adapter
         return $claimedSpEntityId;
     }
 
-    /**
-     * Gets workflow state for given entity id
-     *
-     * @param string $entityId
-     * @return string $workflowState
-     */
-    protected function _getEntityWorkFlowState($entityId)
-    {
-        return $this->_proxyServer->getRepository()->fetchEntityByEntityId($entityId)->workflowState;
-    }
-
     protected function _callCortoServiceUri($serviceName, $idPProviderHash = "")
     {
         $this->_initProxy();

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -141,7 +141,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         $_SESSION['currentServiceProvider'] = $ebRequest->getIssuer();
 
         // Verify that we know this SP and have metadata for it.
-        $serviceProvider = $this->_verifyKnownMessageIssuer(
+        $serviceProvider = $this->_verifyKnownSP(
             $spEntityId,
             $ebRequest->getDestination()
         );
@@ -277,7 +277,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         }
 
         // Verify that we know this IdP and have metadata for it.
-        $cortoIdpMetadata = $this->_verifyKnownMessageIssuer(
+        $cortoIdpMetadata = $this->_verifyKnownIdP(
             $idpEntityId,
             $sspResponse->getDestination()
         );
@@ -427,16 +427,16 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
     }
 
     /**
-     * Verify if a message has an issuer that is known to us. If not, it
+     * Verify if a message has an issuer that is known as an SP to us. If not, it
      * throws a Corto_Module_Bindings_VerificationException.
      * @param string $messageIssuer
      * @param string $destination
      * @return AbstractRole Remote Entity that issued the message
      * @throws EngineBlock_Corto_Exception_UnknownIssuer
      */
-    protected function _verifyKnownMessageIssuer($messageIssuer, $destination = '')
+    protected function _verifyKnownSP($messageIssuer, $destination = '')
     {
-        $remoteEntity = $this->_server->getRepository()->findEntityByEntityId($messageIssuer);
+        $remoteEntity = $this->_server->getRepository()->findServiceProviderByEntityId($messageIssuer);
 
         if ($remoteEntity) {
             return $remoteEntity;
@@ -444,13 +444,43 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
         $this->_logger->notice(
             sprintf(
-                'Tried to verify a message from issuer "%s", but there is no known entity with that ID.',
+                'Tried to verify a message from issuer "%s", but there is no known SP with that ID.',
                 $messageIssuer
             )
         );
 
         throw new EngineBlock_Corto_Exception_UnknownIssuer(
-            "Issuer '{$messageIssuer}' is not a known remote entity? (please add SP/IdP to Remote Entities)",
+            "Issuer '{$messageIssuer}' is not a known remote entity? (please add SP to Remote Entities)",
+            $messageIssuer,
+            $destination
+        );
+    }
+
+    /**
+     * Verify if a message has an issuer that is known to us. If not, it
+     * throws a Corto_Module_Bindings_VerificationException.
+     * @param string $messageIssuer
+     * @param string $destination
+     * @return AbstractRole Remote Entity that issued the message
+     * @throws EngineBlock_Corto_Exception_UnknownIssuer
+     */
+    protected function _verifyKnownIdP($messageIssuer, $destination = '')
+    {
+        $remoteEntity = $this->_server->getRepository()->findIdentityProviderByEntityId($messageIssuer);
+
+        if ($remoteEntity) {
+            return $remoteEntity;
+        }
+
+        $this->_logger->notice(
+            sprintf(
+                'Tried to verify a message from issuer "%s", but there is no known IdP entity with that ID.',
+                $messageIssuer
+            )
+        );
+
+        throw new EngineBlock_Corto_Exception_UnknownIssuer(
+            "Issuer '{$messageIssuer}' is not a known remote entity? (please add IdP to Remote Entities)",
             $messageIssuer,
             $destination
         );

--- a/library/EngineBlock/Corto/Module/Service/Metadata.php
+++ b/library/EngineBlock/Corto/Module/Service/Metadata.php
@@ -1,6 +1,7 @@
 <?php
 
 use EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer as ServiceReplacer;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
 
 class EngineBlock_Corto_Module_Service_Metadata extends EngineBlock_Corto_Module_Service_Abstract
 {
@@ -11,7 +12,12 @@ class EngineBlock_Corto_Module_Service_Metadata extends EngineBlock_Corto_Module
         $engineEntityId = $this->_server->getUrl($serviceName);
         $this->_server->unsetProcessingMode();
 
-        $engineEntity = $this->_server->getRepository()->fetchEntityByEntityId($engineEntityId);
+        // TODO: Are we dealing with an SP or IdP at this point? The previous solution suggests it can be both
+        try {
+            $engineEntity = $this->_server->getRepository()->fetchServiceProviderByEntityId($engineEntityId);
+        } catch (EntityNotFoundException $e) {
+            $engineEntity = $this->_server->getRepository()->fetchIdentityProviderByEntityId($engineEntityId);
+        }
 
         // Override the EntityID and SSO location to optionally append VO id
         $externalEngineEntityId = $this->_server->getUrl($serviceName);

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/AbstractMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/AbstractMetadataRepository.php
@@ -2,7 +2,6 @@
 
 namespace OpenConext\EngineBlock\Metadata\MetadataRepository;
 
-use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Filter\FilterInterface;
@@ -85,41 +84,6 @@ abstract class AbstractMetadataRepository implements MetadataRepositoryInterface
         }
 
         return $identityProvider;
-    }
-
-    /**
-     * @param string $entityId
-     * @return AbstractRole
-     * @throws EntityNotFoundException
-     */
-    public function fetchEntityByEntityId($entityId)
-    {
-        $entity = $this->findEntityByEntityId($entityId);
-
-        if (!$entity) {
-            throw new EntityNotFoundException("Entity '$entityId' not found in InMemoryMetadataRepository");
-        }
-
-        return $entity;
-    }
-
-    /**
-     * @param string $entityId
-     * @return AbstractRole|null
-     */
-    public function findEntityByEntityId($entityId)
-    {
-        $serviceProvider = $this->findServiceProviderByEntityId($entityId);
-        if ($serviceProvider) {
-            return $serviceProvider;
-        }
-
-        $identityProvider = $this->findIdentityProviderByEntityId($entityId);
-        if ($identityProvider) {
-            return $identityProvider;
-        }
-
-        return null;
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/AbstractMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/AbstractMetadataRepository.php
@@ -2,11 +2,10 @@
 
 namespace OpenConext\EngineBlock\Metadata\MetadataRepository;
 
-use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
-use OpenConext\EngineBlock\Metadata\MetadataRepository\Filter\FilterInterface;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\Filter\FilterInterface;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
 
 /**
@@ -57,70 +56,6 @@ abstract class AbstractMetadataRepository implements MetadataRepositoryInterface
     }
 
     /**
-     *
-     * WARNING: Very inefficient in-memory default.
-     *
-     * @return string[]
-     */
-    public function findAllIdentityProviderEntityIds()
-    {
-        $identityProviders = $this->findIdentityProviders();
-
-        $entityIds = array();
-        foreach ($identityProviders as $identityProvider) {
-            $entityIds[] = $identityProvider->entityId;
-        }
-
-        return $entityIds;
-    }
-
-    /**
-     *
-     * WARNING: Very inefficient in-memory default.
-     *
-     * @return string[]
-     */
-    public function findReservedSchacHomeOrganizations()
-    {
-        $schacHomeOrganizations = array();
-
-        $identityProviders = $this->findIdentityProviders();
-        foreach ($identityProviders as $identityProvider) {
-            if (!$identityProvider->schacHomeOrganization) {
-                continue;
-            }
-
-            $schacHomeOrganizations[] = $identityProvider->schacHomeOrganization;
-        }
-        return $schacHomeOrganizations;
-    }
-
-    /**
-     *
-     *
-     * WARNING: Very inefficient in-memory default.
-     *
-     * @param array $identityProviderEntityIds
-     * @return array|IdentityProvider[]
-     * @throws EntityNotFoundException
-     */
-    public function findIdentityProvidersByEntityId(array $identityProviderEntityIds)
-    {
-        $identityProviders = $this->findIdentityProviders();
-
-        $filteredIdentityProviders = array();
-        foreach ($identityProviderEntityIds as $identityProviderEntityId) {
-            if (!isset($identityProviders[$identityProviderEntityId])) {
-                // @todo warn
-                continue;
-            }
-
-            $filteredIdentityProviders[$identityProviderEntityId] = $identityProviders[$identityProviderEntityId];
-        }
-        return $filteredIdentityProviders;
-    }
-
-    /**
      * @param string $entityId
      * @return ServiceProvider
      * @throws EntityNotFoundException
@@ -153,7 +88,6 @@ abstract class AbstractMetadataRepository implements MetadataRepositoryInterface
     }
 
     /**
-     *
      * @param string $entityId
      * @return AbstractRole
      * @throws EntityNotFoundException
@@ -186,5 +120,28 @@ abstract class AbstractMetadataRepository implements MetadataRepositoryInterface
         }
 
         return null;
+    }
+
+    /**
+     * WARNING: Very inefficient in-memory default.
+     *
+     * @param array $identityProviderEntityIds
+     * @return array|IdentityProvider[]
+     * @throws EntityNotFoundException
+     */
+    public function findIdentityProvidersByEntityId(array $identityProviderEntityIds)
+    {
+        $identityProviders = $this->findIdentityProviders();
+
+        $filteredIdentityProviders = array();
+        foreach ($identityProviderEntityIds as $identityProviderEntityId) {
+            if (!isset($identityProviders[$identityProviderEntityId])) {
+                // @todo warn
+                continue;
+            }
+
+            $filteredIdentityProviders[$identityProviderEntityId] = $identityProviders[$identityProviderEntityId];
+        }
+        return $filteredIdentityProviders;
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
@@ -2,7 +2,6 @@
 
 namespace OpenConext\EngineBlock\Metadata\MetadataRepository;
 
-use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
@@ -84,22 +84,6 @@ class CachedDoctrineMetadataRepository implements MetadataRepositoryInterface
 
     /**
      * @param string $entityId
-     * @return AbstractRole
-     * @throws EntityNotFoundException
-     */
-    public function fetchEntityByEntityId($entityId)
-    {
-        $entity = $this->findEntityByEntityId($entityId);
-
-        if (!$entity) {
-            throw new EntityNotFoundException("Entity '$entityId' not found in database");
-        }
-
-        return $entity;
-    }
-
-    /**
-     * @param string $entityId
      * @return ServiceProvider
      * @throws EntityNotFoundException
      */
@@ -127,26 +111,6 @@ class CachedDoctrineMetadataRepository implements MetadataRepositoryInterface
         }
 
         return $identityProvider;
-    }
-
-    /**
-     * @deprecated Don't use this method: entity ID is NOT unique, in theory,
-     *             service- and identity providers can share the same entity ID.
-     *
-     * @param string $entityId
-     * @return AbstractRole|null
-     */
-    public function findEntityByEntityId($entityId)
-    {
-        $serviceProvider = $this->findServiceProviderByEntityId($entityId);
-        if ($serviceProvider) {
-            return $serviceProvider;
-        }
-
-        $identityProvider = $this->findIdentityProviderByEntityId($entityId);
-        if ($identityProvider) {
-            return $identityProvider;
-        }
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CompositeMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CompositeMetadataRepository.php
@@ -64,22 +64,6 @@ class CompositeMetadataRepository extends AbstractMetadataRepository
     /**
      * {@inheritdoc}
      */
-    public function fetchEntityByEntityId($entityId)
-    {
-        foreach ($this->orderedRepositories as $repository) {
-            $entity = $repository->findEntityByEntityId($entityId);
-
-            if ($entity) {
-                return $entity;
-            }
-        }
-
-        throw new EntityNotFoundException("Unable to find '$entityId' in any configured repository");
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function fetchServiceProviderByEntityId($entityId)
     {
         foreach ($this->orderedRepositories as $repository) {
@@ -107,21 +91,6 @@ class CompositeMetadataRepository extends AbstractMetadataRepository
         }
 
         throw new EntityNotFoundException("Unable to find '$entityId' in any configured repository");
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function findEntityByEntityId($entityId)
-    {
-        foreach ($this->orderedRepositories as $repository) {
-            $entity = $repository->findEntityByEntityId($entityId);
-
-            if ($entity) {
-                return $entity;
-            }
-        }
-        return null;
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CompositeMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CompositeMetadataRepository.php
@@ -2,8 +2,6 @@
 
 namespace OpenConext\EngineBlock\Metadata\MetadataRepository;
 
-use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
-use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Filter\FilterInterface;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
 use Psr\Log\LoggerInterface;

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
@@ -243,4 +243,41 @@ class InMemoryMetadataRepository extends AbstractMetadataRepository
 
         return array_shift($filteredRoles);
     }
+
+    /**
+     * WARNING: Very inefficient in-memory default.
+     *
+     * @return string[]
+     */
+    public function findAllIdentityProviderEntityIds()
+    {
+        $identityProviders = $this->findIdentityProviders();
+
+        $entityIds = array();
+        foreach ($identityProviders as $identityProvider) {
+            $entityIds[] = $identityProvider->entityId;
+        }
+
+        return $entityIds;
+    }
+
+    /**
+     * WARNING: Very inefficient in-memory default.
+     *
+     * @return string[]
+     */
+    public function findReservedSchacHomeOrganizations()
+    {
+        $schacHomeOrganizations = array();
+
+        $identityProviders = $this->findIdentityProviders();
+        foreach ($identityProviders as $identityProvider) {
+            if (!$identityProvider->schacHomeOrganization) {
+                continue;
+            }
+
+            $schacHomeOrganizations[] = $identityProvider->schacHomeOrganization;
+        }
+        return $schacHomeOrganizations;
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/MetadataRepositoryInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/MetadataRepositoryInterface.php
@@ -2,11 +2,10 @@
 
 namespace OpenConext\EngineBlock\Metadata\MetadataRepository;
 
-use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
-use OpenConext\EngineBlock\Metadata\MetadataRepository\Filter\FilterInterface;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\Filter\FilterInterface;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
 use Psr\Log\LoggerInterface;
 
@@ -29,14 +28,6 @@ interface MetadataRepositoryInterface
     public function appendVisitor(VisitorInterface $visitor);
 
     /**
-     *
-     * @param string $entityId
-     * @return AbstractRole
-     * @throws EntityNotFoundException
-     */
-    public function fetchEntityByEntityId($entityId);
-
-    /**
      * @param string $entityId
      * @return ServiceProvider
      * @throws EntityNotFoundException
@@ -48,14 +39,6 @@ interface MetadataRepositoryInterface
      * @return IdentityProvider
      */
     public function fetchIdentityProviderByEntityId($entityId);
-
-    /**
-     * @deprecated depends on repository implementation.
-     *
-     * @param string $entityId
-     * @return AbstractRole|null
-     */
-    public function findEntityByEntityId($entityId);
 
     /**
      * @param string $entityId

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -84,7 +84,7 @@ class MockIdpContext extends AbstractSubContext
     {
         $this->anIdentityProviderNamed($name);
         $mockIdp = $this->mockIdpRegistry->get($name);
-        $this->serviceRegistryFixture->setLogo($mockIdp->entityId(), $logo)->save();
+        $this->serviceRegistryFixture->setIdpLogo($mockIdp->entityId(), $logo)->save();
     }
 
     /**

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -133,7 +133,7 @@ class MockSpContext extends AbstractSubContext
         $mockSp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->setEntityNoConsent($mockSp->entityId())
+            ->setSpEntityNoConsent($mockSp->entityId())
             ->save();
     }
 
@@ -172,7 +172,7 @@ class MockSpContext extends AbstractSubContext
         $this->mockSpRegistry->save();
 
         $this->serviceRegistryFixture
-            ->setEntityWantsSignature($sp->entityId())
+            ->setSpEntityWantsSignature($sp->entityId())
             ->save();
     }
 
@@ -181,7 +181,7 @@ class MockSpContext extends AbstractSubContext
      */
     public function spIsATrustedProxy($spName)
     {
-        $this->serviceRegistryFixture->setEntityTrustedProxy(
+        $this->serviceRegistryFixture->setSpEntityTrustedProxy(
             $this->mockSpRegistry->get($spName)->entityid()
         );
         $this->serviceRegistryFixture->save();
@@ -197,7 +197,7 @@ class MockSpContext extends AbstractSubContext
         /** @var MockServiceProvider $mockSp */
         $mockSp  = $this->mockSpRegistry->get($spName);
 
-        $this->serviceRegistryFixture->disconnect($mockSp->entityId(), $mockIdp->entityId());
+        $this->serviceRegistryFixture->disconnectSp($mockSp->entityId(), $mockIdp->entityId());
 
         $this->serviceRegistryFixture->save();
     }
@@ -300,7 +300,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->setEntityManipulation($sp->entityId(), $manipulation->getRaw())
+            ->setSpEntityManipulation($sp->entityId(), $manipulation->getRaw())
             ->save();
     }
 
@@ -313,7 +313,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->allowNoAttributeValues($sp->entityId())
+            ->allowNoAttributeValuesForSp($sp->entityId())
             ->save();
     }
 
@@ -326,7 +326,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->allowAttributeValue($sp->entityId(), $arpAttribute, "*")
+            ->allowAttributeValueForSp($sp->entityId(), $arpAttribute, "*")
             ->save();
     }
 
@@ -339,7 +339,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->allowAttributeValue($sp->entityId(), $arpAttribute, $arpAttributeValue)
+            ->allowAttributeValueForSp($sp->entityId(), $arpAttribute, $arpAttributeValue)
             ->save();
     }
 
@@ -352,7 +352,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->allowAttributeValue($sp->entityId(), $arpAttribute, "*", $attributeSource)
+            ->allowAttributeValueForSp($sp->entityId(), $arpAttribute, "*", $attributeSource)
             ->save();
     }
 
@@ -366,7 +366,7 @@ class MockSpContext extends AbstractSubContext
 
         foreach ($attributes->getHash() as $attribute) {
             $this->serviceRegistryFixture
-                ->allowAttributeValue($sp->entityId(), $attribute['Name'], $attribute['Value'], $attribute['Source'])
+                ->allowAttributeValueForSp($sp->entityId(), $attribute['Name'], $attribute['Value'], $attribute['Source'])
                 ->save();
         }
     }
@@ -380,7 +380,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->setEntityNameIdFormatUnspecified($sp->entityId())
+            ->setSpEntityNameIdFormatUnspecified($sp->entityId())
             ->save();
     }
 
@@ -393,7 +393,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->setEntityNameIdFormatPersistent($sp->entityId())
+            ->setSpEntityNameIdFormatPersistent($sp->entityId())
             ->save();
     }
 
@@ -406,7 +406,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->setEntityNameIdFormatTransient($sp->entityId())
+            ->setSpEntityNameIdFormatTransient($sp->entityId())
             ->save();
     }
 
@@ -419,7 +419,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->setWorkflowState($sp->entityId(), $workflowState)
+            ->setSpWorkflowState($sp->entityId(), $workflowState)
             ->save();
     }
 
@@ -457,7 +457,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->anUnregisteredServiceProviderNamed($spName);
 
         $this->serviceRegistryFixture
-            ->spRequiresPolicyEnforcementDecision($sp->entityId())
+            ->spRequiresPolicyEnforcementDecisionForSp($sp->entityId())
             ->save();
     }
 
@@ -471,7 +471,7 @@ class MockSpContext extends AbstractSubContext
         $mockSp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture
-            ->requireAttributeAggregation($mockSp->entityId())
+            ->requireAttributeAggregationForSp($mockSp->entityId())
             ->save();
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
@@ -8,9 +8,17 @@ Feature:
       And no registered SPs
       And no registered Idps
       And an Identity Provider named "SSO-IdP"
+      And an Identity Provider named "SSO-Foobar"
       And a Service Provider named "SSO-SP"
+      And a Service Provider named "SSO-Foobar"
 
   Scenario: IdPs are allowed to create NameIDs
     When I log in at "SSO-SP"
+     And I select "SSO-IdP" on the WAYF
      And I pass through EngineBlock
     Then the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:NameIDPolicy[@AllowCreate="true" or @AllowCreate="1"]'
+
+  Scenario: IdPs and SPs can share EntityID
+    When I log in at "SSO-Foobar"
+    Then I should see "SSO-Foobar"
+     And I should see "SSO-IdP"

--- a/tests/unit/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepositoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepositoryTest.php
@@ -38,19 +38,6 @@ class CachedDoctrineMetadataRepositoryTest extends PHPUnit_Framework_TestCase
         $repository->findEntitiesPublishableInEdugain();
     }
 
-    public function testFetchEntityThrowExceptions()
-    {
-        $doctrineRepository = Mockery::mock('OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataRepository');
-        $doctrineRepository->shouldReceive('findEntityByEntityId');
-        $doctrineRepository->shouldReceive('findServiceProviderByEntityId');
-        $doctrineRepository->shouldReceive('findIdentityProviderByEntityId');
-
-        $this->setExpectedException('OpenConext\\EngineBlock\\Metadata\\MetadataRepository\\EntityNotFoundException');
-
-        $repository = new CachedDoctrineMetadataRepository($doctrineRepository);
-        $repository->fetchEntityByEntityId('test');
-    }
-
     public function testFetchIdentityProviderThrowExceptions()
     {
         $doctrineRepository = Mockery::mock('OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataRepository');

--- a/tests/unit/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepositoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepositoryTest.php
@@ -19,20 +19,6 @@ class MetadataRepositoryTest extends PHPUnit_Framework_TestCase
 {
     const MOCK_IDP_NAME = 'https://idp.example.edu';
 
-    public function testFetchEntityByEntityId()
-    {
-        $repository = new InMemoryMetadataRepository(array(), array());
-
-        $e = null;
-        try {
-            $repository->fetchEntityByEntityId(self::MOCK_IDP_NAME);
-        } catch (Exception $e) {
-        }
-        $this->assertNotNull($e);
-        $repository->registerServiceProvider(new ServiceProvider('https://sp.example.edu'));
-        $this->assertNotNull($repository->fetchEntityByEntityId('https://sp.example.edu'));
-    }
-
     public function testFetchIdentityProviderByEntityId()
     {
         $repository = new InMemoryMetadataRepository(array(), array());
@@ -125,7 +111,6 @@ class MetadataRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($repository->findAllIdentityProviderEntityIds());
         $this->assertEmpty($repository->findIdentityProvidersByEntityId(array('https://idp2.example.edu')));
 
-        $this->assertNull($repository->findEntityByEntityId('https://idp1.example.edu'));
         $this->assertNull($repository->findIdentityProviderByEntityId('https://idp1.example.edu'));
         $this->assertNull($repository->findServiceProviderByEntityId('https://sp1.example.edu'));
 
@@ -159,9 +144,6 @@ class MetadataRepositoryTest extends PHPUnit_Framework_TestCase
         $identityProviders = $repository->findIdentityProvidersByEntityId(array('https://idp2.example.edu'));
         $this->assertCount(1, $identityProviders);
         $this->assertEquals('MOCKED', reset($identityProviders)->nameEn);
-
-        $identityProvider = $repository->findEntityByEntityId('https://idp3.example.edu');
-        $this->assertEquals('MOCKED', $identityProvider->nameEn);
     }
 
     /**


### PR DESCRIPTION
Three methods have been moved to the InMemoryMetadataRepository as the only repository still depending on these methods was the InMemory  repository itself.

The remaining methods are shared between the Doctrine and InMemory repositories and my fingers are itching to get rid of the AbstractMetadataRepository altogether.

❕ Note that this branch did not trigger a Travis build. This should be remedied when this PR is merged back on top of #481 