### PR TITLE
Move arp field declaration to AbstractRole

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
@@ -4,6 +4,7 @@ namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
@@ -251,6 +252,13 @@ abstract class AbstractRole
     public $manipulation;
 
     /**
+     * @var null|AttributeReleasePolicy
+     *
+     * @ORM\Column(name="attribute_release_policy", type="array")
+     */
+    public $attributeReleasePolicy;
+
+    /**
      * @param $entityId
      * @param Organization $organizationEn
      * @param Organization $organizationNl
@@ -277,6 +285,7 @@ abstract class AbstractRole
      * @param Service $responseProcessingService
      * @param string $workflowState
      * @param string $manipulation
+     * @param AttributeReleasePolicy $attributeReleasePolicy
      */
     public function __construct(
         $entityId,
@@ -307,9 +316,11 @@ abstract class AbstractRole
         $signatureMethod = XMLSecurityKey::RSA_SHA1,
         Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
-        $manipulation = ''
+        $manipulation = '',
+        AttributeReleasePolicy $attributeReleasePolicy = null
     ) {
         $this->additionalLogging = $additionalLogging;
+        $this->attributeReleasePolicy = $attributeReleasePolicy;
         $this->certificates = $certificates;
         $this->contactPersons = $contactPersons;
         $this->descriptionEn = $descriptionEn;

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -6,8 +6,8 @@ use Doctrine\ORM\Mapping as ORM;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
 use OpenConext\EngineBlock\Metadata\Organization;
-use OpenConext\EngineBlock\Metadata\ShibMdScope;
 use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Constants;
 
@@ -185,10 +185,10 @@ class IdentityProvider extends AbstractRole
             $signatureMethod,
             $responseProcessingService,
             $workflowState,
-            $manipulation
+            $manipulation,
+            $attributeReleasePolicy
         );
 
-        $this->attributeReleasePolicy = $attributeReleasePolicy;
         $this->enabledInWayf = $enabledInWayf;
         $this->guestQualifier = $guestQualifier;
         $this->hidden = $hidden;

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -2,16 +2,16 @@
 
 namespace OpenConext\EngineBlock\Metadata\Entity;
 
+use Doctrine\ORM\Mapping as ORM;
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\IndexedService;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
 use OpenConext\EngineBlock\Metadata\Organization;
 use OpenConext\EngineBlock\Metadata\RequestedAttribute;
-use OpenConext\EngineBlock\Metadata\IndexedService;
 use OpenConext\EngineBlock\Metadata\Service;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Constants;
-use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Class ServiceProvider
@@ -22,13 +22,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class ServiceProvider extends AbstractRole
 {
-    /**
-     * @var null|AttributeReleasePolicy
-     *
-     * @ORM\Column(name="attribute_release_policy", type="array")
-     */
-    public $attributeReleasePolicy;
-
     /**
      * @var IndexedService[]
      *
@@ -233,10 +226,10 @@ class ServiceProvider extends AbstractRole
             $signatureMethod,
             $responseProcessingService,
             $workflowState,
-            $manipulation
+            $manipulation,
+            $attributeReleasePolicy
         );
 
-        $this->attributeReleasePolicy = $attributeReleasePolicy;
         $this->allowedIdpEntityIds = $allowedIdpEntityIds;
         $this->assertionConsumerServices = $assertionConsumerServices;
         $this->displayUnconnectedIdpsWayf = $displayUnconnectedIdpsWayf;


### PR DESCRIPTION
The $attributeReleasePolicy field declaration was set on the
 ServiceProvider implementation. The IdentityProvider also exposed this
 field. PHP generously dynamically published this field publicly. To
 get a consistent result, the field was moved from ServiceProvider to
 the AbstractRole.