### PR TITLE
Fixed two misusages of the NameID value object

### DIFF
--- a/app/Resources/views/modules/Authentication/View/Proxy/debugidpmail.phtml
+++ b/app/Resources/views/modules/Authentication/View/Proxy/debugidpmail.phtml
@@ -30,7 +30,7 @@ SAML2 Subject
 =============
 <?php
 $nameId = $response->getAssertion()->getNameId();
-echo 'NameID             ' . $nameId['Value'] ?>
+echo 'NameID             ' . $nameId->value ?>
 
 
 

--- a/app/Resources/views/modules/Authentication/View/Proxy/debugidpresponse.phtml
+++ b/app/Resources/views/modules/Authentication/View/Proxy/debugidpresponse.phtml
@@ -103,7 +103,7 @@ $validationResult = EngineBlock_ApplicationSingleton::getInstance()
               <th>NameID</th>
 
               <td>
-                  <?php $nameId = $response->getAssertion()->getNameId(); echo EngineBlock_View::htmlSpecialCharsText($nameId['Value']); ?>
+                  <?php $nameId = $response->getAssertion()->getNameId(); echo EngineBlock_View::htmlSpecialCharsText($nameId->value); ?>
               </td>
           </tr>
       </table>

--- a/theme/material/templates/modules/Authentication/View/Proxy/debugidpmail.phtml
+++ b/theme/material/templates/modules/Authentication/View/Proxy/debugidpmail.phtml
@@ -29,7 +29,7 @@ SAML2 Subject
 =============
 <?php
 $nameId = $response->getAssertion()->getNameId();
-echo 'NameID             ' . $nameId['Value'] ?>
+echo 'NameID             ' . $nameId->value ?>
 
 
 

--- a/theme/material/templates/modules/Authentication/View/Proxy/debugidpresponse.phtml
+++ b/theme/material/templates/modules/Authentication/View/Proxy/debugidpresponse.phtml
@@ -102,7 +102,7 @@ $validationResult = EngineBlock_ApplicationSingleton::getInstance()
               <th>NameID</th>
 
               <td>
-                  <?php $nameId = $response->getAssertion()->getNameId(); echo EngineBlock_View::htmlSpecialCharsText($nameId['Value']); ?>
+                  <?php $nameId = $response->getAssertion()->getNameId(); echo EngineBlock_View::htmlSpecialCharsText($nameId->value); ?>
               </td>
           </tr>
       </table>


### PR DESCRIPTION
During the SAML2 upgrade, I failed to grep the /theme folder for misusage of the NameID value object. This commit fixes this for the debugidpmail and debugidpresponse templates.