### PR TITLE
Fix possible bug in CompositeFilter

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/Filter/CompositeFilter.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/Filter/CompositeFilter.php
@@ -116,12 +116,12 @@ class CompositeFilter implements FilterInterface
             $expressions[] = $expression;
         }
 
-        if (count($expression) === 0) {
+        if (count($expressions) === 0) {
             return null;
         }
 
-        if (count($expression) === 1) {
-            return $expression;
+        if (count($expressions) === 1) {
+            return reset($expressions);
         }
 
         return new CompositeExpression(CompositeExpression::TYPE_AND, $expressions);


### PR DESCRIPTION
The toExpression method in CompositeFilter contained a possible bug or at least a very confusing code construction. The if statements testing for the size of the expressions tested on the 'expression' variable who

  1. Might not have been set
  2. Might not be countable

This commit changes the method to the state is was intended to reflect.