### PR TITLE
Optimize metadata reading

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -94,6 +94,9 @@ doctrine:
                         dir:       "%kernel.root_dir%/../src/OpenConext/EngineBlock/Metadata"
                         prefix:    OpenConext\EngineBlock\Metadata
                         is_bundle: false
+                dql:
+                    string_functions:
+                        md5: OpenConext\EngineBlockBundle\Doctrine\DqlFunction\Md5
 
 doctrine_migrations:
     dir_name:   "%kernel.root_dir%/../database/DoctrineMigrations"

--- a/database/DoctrineMigrations/Version20180215132859.php
+++ b/database/DoctrineMigrations/Version20180215132859.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180215132859 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD allow_all TINYINT(1) DEFAULT NULL AFTER allowed_idp_entity_ids');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP allow_all');
+    }
+}

--- a/library/EngineBlock/Corto/Filter/Command/ValidateAllowedConnection.php
+++ b/library/EngineBlock/Corto/Filter/Command/ValidateAllowedConnection.php
@@ -7,8 +7,7 @@ class EngineBlock_Corto_Filter_Command_ValidateAllowedConnection extends EngineB
 {
     public function execute()
     {
-        $allowedIdpEntityIds = $this->_serviceProvider->allowedIdpEntityIds;
-        if (!in_array($this->_identityProvider->entityId, $allowedIdpEntityIds)) {
+        if (!$this->_serviceProvider->isAllowed($this->_identityProvider->entityId)) {
             throw new EngineBlock_Corto_Exception_InvalidConnection(
                 "Disallowed response by SP configuration. " .
                 "Response from IdP '{$this->_identityProvider->entityId}' to SP '{$this->_serviceProvider->entityId}'"

--- a/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
+++ b/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
@@ -28,7 +28,7 @@ class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Mo
         $ssoServiceReplacer = new ServiceReplacer($engineIdentityProvider, 'SingleSignOnService', ServiceReplacer::REQUIRED);
         $slServiceReplacer  = new ServiceReplacer($engineIdentityProvider, 'SingleLogoutService', ServiceReplacer::OPTIONAL);
 
-        if (isset($spEntity)) {
+        if (isset($spEntity) && !$spEntity->allowAll) {
             $identityProviders = $this->_server->getRepository()->findIdentityProvidersByEntityId(
                 $spEntity->allowedIdpEntityIds
             );

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -64,7 +64,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         // or we could have it configured that the SP may only be serviced by specific IdPs
         $scopedIdps = $this->_getScopedIdPs($request);
 
-        $cacheResponseSent = $this->_sendCachedResponse($request, $scopedIdps);
+        $cacheResponseSent = $this->_sendCachedResponse($request, $sp, $scopedIdps);
         if ($cacheResponseSent) {
             return;
         }
@@ -304,7 +304,8 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
 
     protected function _sendCachedResponse(
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request,
-        $scopedIdps
+        ServiceProvider $sp,
+        array $scopedIdps
     ) {
         /** @var AuthnRequest $request */
         if ($request->getForceAuthn()) {
@@ -329,7 +330,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
             return false;
         }
 
-        $cachedResponse = $this->_pickCachedResponse($cachedResponses);
+        $cachedResponse = $this->_pickCachedResponse($cachedResponses, $sp);
         if (!$cachedResponse) {
             return false;
         }
@@ -342,17 +343,17 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         return true;
     }
 
-    protected function _pickCachedResponse(array $cachedResponses)
+    protected function _pickCachedResponse(array $cachedResponses, ServiceProvider $sp)
     {
-        $idpEntityIds = $this->_server->getRepository()->findAllIdentityProviderEntityIds();
-
+        // Find the first cached response for an IDP that is allowed by the SP
+        // we're authentication for.
         foreach ($cachedResponses as $cachedResponse) {
             if ($cachedResponse['type'] !== EngineBlock_Corto_Model_Response_Cache::RESPONSE_CACHE_TYPE_IN) {
                 continue;
             }
 
-            // Check if it is for a valid idp
-            if (!in_array($cachedResponse['idp'], $idpEntityIds)) {
+            // Check if it is for an allowed idp
+            if (!$sp->isAllowed($cachedResponse['idp'])) {
                 continue;
             }
 

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -80,7 +80,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         // Get all registered Single Sign On Services
         // Note that we could also only get the ones that are allowed for this SP, but we may also want to show
         // those that are not allowed.
-        $candidateIDPs = $this->_server->getRepository()->findAllIdentityProviderEntityIds();
+        $candidateIDPs = $this->_server->getRepository()->findAllIdentityProviderEntityIds($scopedIdps);
 
         $posOfOwnIdp = array_search($this->_server->getUrl('idpMetadataService'), $candidateIDPs);
         if ($posOfOwnIdp !== false) {
@@ -88,16 +88,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
             unset($candidateIDPs[$posOfOwnIdp]);
         }
 
-
-        // If we have scoping, filter out every non-scoped IdP
         if (count($scopedIdps) > 0) {
-            $log->info(
-                sprintf('%d candidate IdPs before scoping', count($candidateIDPs)),
-                array('idps' => array_values($candidateIDPs))
-            );
-
-            $candidateIDPs = array_intersect($scopedIdps, $candidateIDPs);
-
             $log->info(
                 sprintf('%d candidate IdPs after scoping', count($candidateIDPs)),
                 array('idps' => array_values($candidateIDPs))
@@ -108,7 +99,6 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
                 array('idps' => array_values($candidateIDPs))
             );
         }
-
 
         // 0 IdPs found! Throw an exception.
         if (count($candidateIDPs) === 0) {

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -336,31 +336,24 @@ class EngineBlock_Corto_ProxyServer
 
     public function setRemoteIdpMd5($remoteIdPMd5)
     {
-        $idpEntityIds = $this->_repository->findAllIdentityProviderEntityIds();
+        $entityId = $this->_repository->findIdentityProviderEntityIdByMd5Hash($remoteIdPMd5);
 
-        foreach ($idpEntityIds as $idpEntityId) {
-            if (md5($idpEntityId) !== $remoteIdPMd5) {
-                continue;
-            }
-
-            $this->_configs['Idp'] = $idpEntityId;
+        if ($entityId !== null) {
+            $this->_configs['Idp'] = $entityId;
             $this->_configs['TransparentProxy'] = true;
             $this->getLogger()->info(
-                "Detected pre-selection of $idpEntityId as IdP, switching to transparent mode"
+                "Detected pre-selection of $entityId as IdP, switching to transparent mode"
             );
-            break;
+        } else {
+            $this->getLogger()->notice(sprintf('Unable to map remote IdpMD5 "%s" to a remote entity.', $remoteIdPMd5));
+
+            throw new EngineBlock_Corto_Exception_UnknownPreselectedIdp(
+                "Unable to map remote IdpMD5 '$remoteIdPMd5' to a remote entity!",
+                $remoteIdPMd5
+            );
         }
 
-        if (isset($this->_configs['Idp'])) {
-            return $this;
-        }
-
-        $this->getLogger()->notice(sprintf('Unable to map remote IdpMD5 "%s" to a remote entity.', $remoteIdPMd5));
-
-        throw new EngineBlock_Corto_Exception_UnknownPreselectedIdp(
-            "Unable to map remote IdpMD5 '$remoteIdPMd5' to a remote entity!",
-            $remoteIdPMd5
-        );
+        return $this;
     }
 
 ////////  REQUEST HANDLING /////////

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/JanusPushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/JanusPushMetadataAssembler.php
@@ -102,7 +102,14 @@ class JanusPushMetadataAssembler
                 unset($allowedIdpEntityIds[$index]);
             }
 
-            $role->allowedIdpEntityIds = array_values($allowedIdpEntityIds);
+            if ($allowedIdpEntityIds === $allIdpEntityIds) {
+                // If a blacklist was configured, and no IDPs were explicitly
+                // blacklisted, then don't keep track of all entity IDs, but
+                // remember that all IDPs are allowed.
+                $role->allowAll = true;
+            } else {
+                $role->allowedIdpEntityIds = $allowedIdpEntityIds;
+            }
         }
         return $roles;
     }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -88,6 +88,13 @@ class ServiceProvider extends AbstractRole
     /**
      * @var bool
      *
+     * @ORM\Column(name="allow_all", type="boolean")
+     */
+    public $allowAll;
+
+    /**
+     * @var bool
+     *
      * @ORM\Column(name="policy_enforcement_decision_required", type="boolean")
      */
     public $policyEnforcementDecisionRequired;
@@ -147,6 +154,7 @@ class ServiceProvider extends AbstractRole
      * @param Service $responseProcessingService
      * @param string $workflowState
      * @param array $allowedIdpEntityIds
+     * @param bool $allowAll
      * @param array $assertionConsumerServices
      * @param bool $displayUnconnectedIdpsWayf
      * @param null $termsOfServiceUrl
@@ -192,6 +200,7 @@ class ServiceProvider extends AbstractRole
         Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         array $allowedIdpEntityIds = array(),
+        $allowAll = false,
         array $assertionConsumerServices = array(),
         $displayUnconnectedIdpsWayf = false,
         $termsOfServiceUrl = null,
@@ -238,6 +247,7 @@ class ServiceProvider extends AbstractRole
 
         $this->attributeReleasePolicy = $attributeReleasePolicy;
         $this->allowedIdpEntityIds = $allowedIdpEntityIds;
+        $this->allowAll = $allowAll;
         $this->assertionConsumerServices = $assertionConsumerServices;
         $this->displayUnconnectedIdpsWayf = $displayUnconnectedIdpsWayf;
         $this->termsOfServiceUrl = $termsOfServiceUrl;
@@ -266,5 +276,14 @@ class ServiceProvider extends AbstractRole
     public function getAttributeReleasePolicy()
     {
         return $this->attributeReleasePolicy;
+    }
+
+    /**
+     * @param string $idpEntityId
+     * @return bool
+     */
+    public function isAllowed($idpEntityId)
+    {
+        return $this->allowAll || in_array($idpEntityId, $this->allowedIdpEntityIds);
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
@@ -123,6 +123,15 @@ class CachedDoctrineMetadataRepository implements MetadataRepositoryInterface
     }
 
     /**
+     * @param string $hash
+     * @return string|null
+     */
+    public function findIdentityProviderEntityIdByMd5Hash($hash)
+    {
+        return $this->invoke(__FUNCTION__, func_get_args());
+    }
+
+    /**
      * @param $entityId
      * @param LoggerInterface|null $logger
      * @return null|ServiceProvider

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
@@ -150,9 +150,10 @@ class CachedDoctrineMetadataRepository implements MetadataRepositoryInterface
     }
 
     /**
+     * @param array $scope
      * @return string[]
      */
-    public function findAllIdentityProviderEntityIds()
+    public function findAllIdentityProviderEntityIds(array $scope = [])
     {
         return $this->invoke(__FUNCTION__, func_get_args());
     }

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/DoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/DoctrineMetadataRepository.php
@@ -56,13 +56,20 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
 
     /**
      *
+     * @param array $scope
      * @return string[]
      */
-    public function findAllIdentityProviderEntityIds()
+    public function findAllIdentityProviderEntityIds(array $scope = [])
     {
         $queryBuilder = $this->idpRepository
             ->createQueryBuilder('role')
             ->select('role.entityId');
+
+        if (!empty($scope)) {
+            $queryBuilder
+                ->where('role.entityId IN (:scopedEntityIds)')
+                ->setParameter('scopedEntityIds', $scope);
+        }
 
         $this->compositeFilter->toQueryBuilder($queryBuilder, $this->idpRepository->getClassName());
 

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/DoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/DoctrineMetadataRepository.php
@@ -147,6 +147,32 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
     }
 
     /**
+     * @param string $hash
+     * @return string|null
+     */
+    public function findIdentityProviderEntityIdByMd5Hash($hash)
+    {
+        $queryBuilder = $this->idpRepository->createQueryBuilder('role')
+            ->select('role.entityId')
+            ->andWhere('MD5(role.entityId) = :hash')
+            ->setParameter('hash', $hash);
+
+        $this->compositeFilter->toQueryBuilder($queryBuilder, $this->idpRepository->getClassName());
+
+        $result = $queryBuilder->getQuery()->execute();
+
+        if (empty($result)) {
+            return null;
+        }
+
+        if (count($result) > 1) {
+            throw new RuntimeException('Multiple Identity Providers found for entityId MD5 hash: ' . $hash);
+        }
+
+        return reset($result)['entityId'];
+    }
+
+    /**
      * @param $entityId
      * @param LoggerInterface|null $logger
      * @return null|ServiceProvider

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
@@ -12,6 +12,7 @@ use Psr\Log\LoggerInterface;
  * Class InMemoryMetadataRepository
  * @package OpenConext\EngineBlock\Metadata\MetadataRepository
  * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class InMemoryMetadataRepository extends AbstractMetadataRepository
 {
@@ -76,6 +77,21 @@ class InMemoryMetadataRepository extends AbstractMetadataRepository
         foreach ($roles as $role) {
             if ($role->entityId === $entityId) {
                 return $role;
+            }
+        }
+    }
+
+    /**
+     * @param string $hash
+     * @return string|null
+     */
+    public function findIdentityProviderEntityIdByMd5Hash($hash)
+    {
+        $roles = $this->findIdentityProviders();
+
+        foreach ($roles as $role) {
+            if (md5($role->entityId) === $hash) {
+                return $role->entityId;
             }
         }
     }

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
@@ -160,15 +160,20 @@ class InMemoryMetadataRepository extends AbstractMetadataRepository
     }
 
     /**
+     * @param array $scope
      * @return string[]
      */
-    public function findAllIdentityProviderEntityIds()
+    public function findAllIdentityProviderEntityIds(array $scope = [])
     {
         $identityProviders = $this->findIdentityProviders();
 
         $entityIds = array();
         foreach ($identityProviders as $identityProvider) {
             $entityIds[] = $identityProvider->entityId;
+        }
+
+        if (!empty($scope)) {
+            $entityIds = array_intersect($entityIds, $scope);
         }
 
         return $entityIds;

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/MetadataRepositoryInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/MetadataRepositoryInterface.php
@@ -47,6 +47,12 @@ interface MetadataRepositoryInterface
     public function findIdentityProviderByEntityId($entityId);
 
     /**
+     * @param string $hash
+     * @return string|null
+     */
+    public function findIdentityProviderEntityIdByMd5Hash($hash);
+
+    /**
      * @param $entityId
      * @param LoggerInterface|null $logger
      * @return null|ServiceProvider

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/MetadataRepositoryInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/MetadataRepositoryInterface.php
@@ -65,9 +65,10 @@ interface MetadataRepositoryInterface
     public function findIdentityProvidersByEntityId(array $identityProviderEntityIds);
 
     /**
+     * @param array $scope
      * @return string[]
      */
-    public function findAllIdentityProviderEntityIds();
+    public function findAllIdentityProviderEntityIds(array $scope = []);
 
     /**
      * @return string[]

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/Visitor/EngineBlockMetadataVisitor.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/Visitor/EngineBlockMetadataVisitor.php
@@ -42,32 +42,24 @@ class EngineBlockMetadataVisitor implements VisitorInterface
     private $consentService;
 
     /**
-     * @var array
-     */
-    private $allIdpEntityIds;
-
-    /**
      * @param string $idpEntityId
      * @param string $spEntityId
      * @param KeyPair $keyPair
      * @param AttributesMetadata $attributes
      * @param Service $consentService
-     * @param array $allIdpEntityIds
      */
     public function __construct(
         $idpEntityId,
         $spEntityId,
         KeyPair $keyPair,
         AttributesMetadata $attributes,
-        Service $consentService,
-        array $allIdpEntityIds
+        Service $consentService
     ) {
         $this->idpEntityId = $idpEntityId;
         $this->spEntityId = $spEntityId;
         $this->keyPair = $keyPair;
         $this->attributes = $attributes;
         $this->consentService = $consentService;
-        $this->allIdpEntityIds = $allIdpEntityIds;
     }
 
     /**
@@ -167,6 +159,6 @@ class EngineBlockMetadataVisitor implements VisitorInterface
     private function setConsentService(ServiceProvider $entity)
     {
         $entity->responseProcessingService = $this->consentService;
-        $entity->allowedIdpEntityIds = $this->allIdpEntityIds;
+        $entity->allowAll = true;
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Doctrine/DqlFunction/Md5.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/DqlFunction/Md5.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\DqlFunction;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+class Md5 extends FunctionNode
+{
+    public $value;
+
+    public function getSql(SqlWalker $walker)
+    {
+        $platform = $walker->getConnection()->getDatabasePlatform();
+
+        return $platform->getMd5Expression(
+            $this->value->dispatch($walker)
+        );
+    }
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        $this->value = $parser->StringPrimary();
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}


### PR DESCRIPTION
This PR adds four improvements to unrelated use-cases in EngineBlock. The main principle is not loading all IDP entity IDs from the database, so the number of IDPs in the database does not affect the amount of traffic to and from the database. 

See [pivotal](https://www.pivotaltracker.com/story/show/154840957) and the individual commits for more information.