### PR TITLE
Don't store SAML responses in user sessions

### DIFF
--- a/library/EngineBlock/Corto/Model/Response/Cache.php
+++ b/library/EngineBlock/Corto/Model/Response/Cache.php
@@ -1,27 +1,64 @@
 <?php
 
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+
 class EngineBlock_Corto_Model_Response_Cache
 {
-    const RESPONSE_CACHE_TYPE_IN  = 'in';
-
-    public static function cacheResponse(
+    /**
+     * Remember the IDP used to authenticate.
+     *
+     * Note that only the SP/IDP entity ID combination is stored, and not the
+     * complete response. Responses are never re-purposed. This information is
+     * only used to allow auto-selecting the IDP on subsequent logins.
+     *
+     * @param EngineBlock_Saml2_AuthnRequestAnnotationDecorator $receivedRequest
+     * @param EngineBlock_Saml2_ResponseAnnotationDecorator $receivedResponse
+     */
+    public static function rememberIdp(
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $receivedRequest,
-        EngineBlock_Saml2_ResponseAnnotationDecorator $receivedResponse,
-        $type
+        EngineBlock_Saml2_ResponseAnnotationDecorator $receivedResponse
     ) {
-        if ($type !== self::RESPONSE_CACHE_TYPE_IN) {
-            throw new EngineBlock_Exception('Unknown response type');
-        }
-
         if (!isset($_SESSION['CachedResponses'])) {
             $_SESSION['CachedResponses'] = array();
         }
+
         $_SESSION['CachedResponses'][] = array(
-            'sp'            => $receivedRequest->getIssuer(),
-            'idp'           => $receivedResponse->getIssuer(),
-            'type'          => $type,
-            'response'      => $receivedResponse,
-            'key'           => $receivedRequest->getKeyId(),
+            'sp'  => $receivedRequest->getIssuer(),
+            'idp' => $receivedResponse->getIssuer(),
         );
+    }
+
+    /**
+     * Find remembered IDP applicable for given SP.
+     *
+     * @param ServiceProvider $sp
+     * @param array $scopedIdps
+     * @return string|null
+     */
+    public static function findRememberedIdp(ServiceProvider $sp, array $scopedIdps)
+    {
+        $cachedResponses = [];
+        if (isset($_SESSION['CachedResponses'])) {
+            $cachedResponses = $_SESSION['CachedResponses'];
+        }
+
+        // First, if there is scoping, we reject responses from idps not in
+        // the list.
+        if (count($scopedIdps) > 0) {
+            foreach ($cachedResponses as $key => $cachedResponse) {
+                if (!in_array($cachedResponse['idp'], $scopedIdps)) {
+                    unset($cachedResponses[$key]);
+                }
+            }
+        }
+
+        foreach ($cachedResponses as $cachedResponse) {
+            // Check if it is for an allowed idp
+            if (!$sp->isAllowed($cachedResponse['idp'])) {
+                continue;
+            }
+
+            return $cachedResponse['idp'];
+        }
     }
 }

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -83,12 +83,10 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
             $this->_server->setKeyId($receivedRequest->getKeyId());
         }
 
-        // Cache the response
-        EngineBlock_Corto_Model_Response_Cache::cacheResponse(
-            $receivedRequest,
-            $receivedResponse,
-            EngineBlock_Corto_Model_Response_Cache::RESPONSE_CACHE_TYPE_IN
-        );
+        // Keep track of what IDP was used for this SP. This way the user does
+        // not have to go trough the WAYF again when logging into this service
+        // or another service.
+        EngineBlock_Corto_Model_Response_Cache::rememberIdp($receivedRequest, $receivedResponse);
 
         $this->_server->filterInputAssertionAttributes($receivedResponse, $receivedRequest);
 


### PR DESCRIPTION
EngineBlock stores all SAML responses from the IDP in the user
session. Years ago, those responses were re-purposed on subsequent
logins. In order to support key roll-over EngineBlock also had to save
and restore the ID of the used signing key when re-using an old response.

Repurposing of responses is tricky in several ways so that feature was
removed (it's not EngineBlocks responsibility, the IDP should decide
if a session is still valid). But the SAML response is still stored
in the session, and the old signing key ID still overrides active
configuration.

This commit refactors the response cache mechanism:

 - the SAML response and ID of the used signing key is not saved to
   the session
 - leaving only the SP/IDP entity ID combination in the user
   session (so no more distinction between IN/OUT)
 - signing key used is always the key of the most recent/active configuration
 - rename methods to reflect that we are 'remembering the last used
   IDP' instead of 'sending a cached response'
 - after determining the 'remembered idp', resume the normal SSO flow
   but scoped to the remembered IDP instead of branching into a
   different code path to send the authentication request to the IDP

Pivotal: https://www.pivotaltracker.com/story/show/155279525