### PR TITLE
Explicitly set the consent date when user gives consent

### DIFF
--- a/database/DoctrineMigrations/Version20180221133212.php
+++ b/database/DoctrineMigrations/Version20180221133212.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180221133212 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE consent CHANGE consent_date consent_date DATETIME NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE consent CHANGE consent_date consent_date DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL');
+    }
+}

--- a/library/EngineBlock/Corto/Model/Consent.php
+++ b/library/EngineBlock/Corto/Model/Consent.php
@@ -120,9 +120,9 @@ class EngineBlock_Corto_Model_Consent
             return false;
         }
 
-        $query = "INSERT INTO consent (hashed_user_id, service_id, attribute, consent_type)
-                  VALUES (?, ?, ?, ?)
-                  ON DUPLICATE KEY UPDATE attribute=VALUES(attribute), consent_type=VALUES(consent_type)";
+        $query = "INSERT INTO consent (hashed_user_id, service_id, attribute, consent_type, consent_date)
+                  VALUES (?, ?, ?, ?, NOW())
+                  ON DUPLICATE KEY UPDATE attribute=VALUES(attribute), consent_type=VALUES(consent_type), consent_date=NOW()";
         $parameters = array(
             sha1($this->_getConsentUid()),
             $serviceProvider->entityId,

--- a/src/OpenConext/EngineBlockBundle/Authentication/Entity/Consent.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Entity/Consent.php
@@ -20,7 +20,7 @@ class Consent
     /**
      * @var DateTime
      *
-     * @ORM\Column(name="consent_date", type="datetime", options={"default": 0})
+     * @ORM\Column(name="consent_date", type="datetime", nullable=false)
      */
     public $date;
 


### PR DESCRIPTION
Relying on the database to set the consent date works, but has some
disadvantages:

 * does not work on MySQL (it possibly does in non-strict mode, or
   with a nullable field)

 * doctrine must be set to 'options={"default": 0}' which is interpreted
   as '"default": CURRENT_TIMESTAMP', while DEFAULT 0 in MySQL is a very
   different feature than DEFAULT CURRENT_TIMESTAMP - too much
   confusion here!

The actual problem we're trying to fix is travis throwing this error
in PR #413:

    SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'consent_date'

Instead of changing travis to use MariaDB or trying to fix this issue
by making the SQL compatible with both MySQL and MariaDB, we decided
not to depend on this feature at all and simply insert new rows in the
consent table with consent_date=NOW().