### PR TITLE
Remove SURF-isms from config and code

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -143,7 +143,7 @@ database.test.dbname = eb_test
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; Location of PDP
-pdp.baseUrl = "https://pdp.surfconext.nl/decide/policy"
+pdp.baseUrl = "https://pdp.example.org/decide/policy"
 
 ; PDP uses basic auth
 pdp.username = "pdp_admin"
@@ -162,7 +162,7 @@ profile.baseUrl = "https://profile.example.org/"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; Location of AA
-attributeAggregation.baseUrl = "https://aa.surfconext.nl/aa/api/attribute/aggregate"
+attributeAggregation.baseUrl = "https://aa.example.org/aa/api/attribute/aggregate"
 
 ; AA uses basic auth
 attributeAggregation.username = "eb"
@@ -175,41 +175,41 @@ attributeAggregation.password = "secret"
 ; Minimum execution time in milliseconds when a received response is deemed invalid (default: 5000 ms)
 minimumExecutionTimeOnInvalidReceivedResponse = 5000
 
-; the value for guest qualifier. Can be overridden for specific non-surfnet environments
-addgueststatus.guestqualifier = "urn:collab:org:surf.nl"
+; the value for guest qualifier. Can be overridden for specific environments
+addgueststatus.guestqualifier = "urn:collab:org:example.org"
 
 ; Language Cookie settings
-cookie.lang.domain = ".surfconext.nl"
+cookie.lang.domain = ".example.org"
 ; Cookie expiry time, specify the time in seconds, set empty to let the cookie get expired after the session
 cookie.lang.expiry = 5184000 ; 60 days in seconds
 
-defaults.title      = "SURFconext"
-defaults.header     = "SURFconext"
+defaults.title      = "OpenConext"
+defaults.header     = "OpenConext"
 defaults.layout     = "default"
 
 ; edugain metadata
-edugain.publication.publisher = "https://engine.surfconext.nl/authentication/proxy/edugain-metadata"
+edugain.publication.publisher = "https://engine.example.org/authentication/proxy/edugain-metadata"
 edugain.publication.policy = "http://www.edugain.org/policy/metadata-tou_1_0.txt"
-edugain.registration.authority = "http://www.surfconext.nl/"
-edugain.registration.policy = "https://wiki.surfnet.nl/display/eduGAIN/EduGAIN"
+edugain.registration.authority = "http://www.example.org/"
+edugain.registration.policy = "https://wiki.example.org/policy"
 edugain.termsOfUse = "Use of this metadata is subject to the Terms of Use at http://www.edugain.org/policy/metadata-tou_1_0.txt"
 
 ; The default email where IdP request access are send
-email.help = "help@surfconext.nl"
+email.help = "help@example.org"
 
 ; Where to send IdP debugging mail
-;email.idpDebugging.to.address = "surfconext-beheer@surfnet.nl"
-email.idpDebugging.from.name  = "SURFconext EngineBlock"
-email.idpDebugging.from.address = "noreply@surfnet.nl"
-email.idpDebugging.to.address = "surfconext-beheer@surfnet.nl"
-email.idpDebugging.to.name    = "SURFconext Beheer"
+;email.idpDebugging.to.address = "openconext@example.org"
+email.idpDebugging.from.name  = "OpenConext EngineBlock"
+email.idpDebugging.from.address = "noreply@example.org"
+email.idpDebugging.to.address = "admin@example.org"
+email.idpDebugging.to.name    = "OpenConext"
 email.idpDebugging.subject    = "IdP debug info van %1$s"
 
 ; Set a fixed hostname for OpenConext EngineBlock to use.
 ;hostname = engine.demo.openconext.org
 
-; terms of use surfconext
-openconext.termsOfUse = "https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28EN%29"
+; terms of use openconext
+openconext.termsOfUse = "https://www.example.org/terms-of-service"
 
 ; Which LDAP attribute to use as the primary identifier.
 ; EXPERT use only!

--- a/library/EngineBlock/Attributes/Normalizer.php
+++ b/library/EngineBlock/Attributes/Normalizer.php
@@ -103,7 +103,7 @@ class EngineBlock_Attributes_Normalizer
         foreach ($this->_attributes as $attributeName => $attributeValues) {
             $newAttributes[$attributeName] = $attributeValues;
 
-            // Not defined in SURFconext attributes... can't find any aliases.
+            // Not defined in EngineBlock attribute definitions... can't find any aliases.
             if (!isset($this->_definitions[$attributeName])) {
                 $this->_logger->debug(
                     "Attribute Denormalization: Don't have a definition for '$attributeName', unable to add any aliases"

--- a/library/EngineBlock/Attributes/Provider/Interface.php
+++ b/library/EngineBlock/Attributes/Provider/Interface.php
@@ -12,7 +12,7 @@ interface EngineBlock_Attributes_Provider_Interface
      * Retrieve all attributes that the Attributes Provider provides for the
      * given user.
      * @param String $uid The URN of a user, for example
-     *                    urn:collab:surfnet.nl:niels
+     *                    urn:collab:example.org:niels
      * @param String $format Format of the attributes to get.
      * @return Array An array containing attributes. The keys of the array are
      *               the names of the attributes. Each array element contains


### PR DESCRIPTION
There are some more references to SURF(conext) but those are in the templating layer which I don't want to change right now while they're being ported to twig.

https://www.pivotaltracker.com/n/projects/1425900