### PR TITLE
Fix missing idp debug mail configuration

### DIFF
--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -204,7 +204,7 @@ $ymlContent = array(
 
         // Email configuration
         'email_help_address'                                      => $config->get('email.help'),
-        'email_idp_debugging'                                     => $config->get('email.idpDebugging'),
+        'email_idp_debugging'                                     => $config->get('email.idpDebugging')->toArray(),
 
         // Profile.
         'profile_base_url'                                        => $config->get('profile.baseUrl', ''),


### PR DESCRIPTION
The configuration was always set to 'null' in ini_parameters.yml, due
to a bug introduced in 917901f.