### PR TITLE
Do not validate EngineBlocks own hostname

### DIFF
--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -325,13 +325,7 @@ class EngineBlock_ApplicationSingleton
             return $configHostname;
         }
 
-        $httpRequestHostname = $_SERVER['HTTP_HOST'];
-        $validator = new Zend_Validate_Hostname();
-        if ($validator->isValid($httpRequestHostname)) {
-            return $httpRequestHostname;
-        }
-
-        throw new EngineBlock_Exception('No hostname configured and Host header is invalid.');
+        return $_SERVER['HTTP_HOST'];
     }
 
     /**

--- a/tests/library/EngineBlock/Test/ApplicationSingletonTest.php
+++ b/tests/library/EngineBlock/Test/ApplicationSingletonTest.php
@@ -40,14 +40,4 @@ class EngineBlock_Test_ApplicationSingletonTest extends PHPUnit_Framework_TestCa
         //        but that's not easy to test because the application class does
         //        no use DI.
     }
-
-    /**
-     * @expectedException EngineBlock_Exception
-     */
-    public function testGetHostnameRefusesInvalidHostname()
-    {
-        $application = EngineBlock_ApplicationSingleton::getInstance();
-        $_SERVER['HTTP_HOST'] = '145.100.191.206"><foo>alert(1)';
-        $application->getHostname();
-    }
 }


### PR DESCRIPTION
It is not EngineBlocks responsibility to validate it's own
hostname. The webserver should be configured to allow specific
hostnames under which EngineBlock is served.