### PR TITLE
Require the 'hostname' INI setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Copy over the example configuration file from the *docs* directory to */etc/open
     sudo mkdir /etc/openconext
     sudo cp docs/example.engineblock.ini /etc/openconext/engineblock.ini
 
+For the development VM, you should replace all occurrences of demo.openconext.org with vm.openconext.org.
+
 Then edit this file with your favorite editor and review the settings to make sure it matches your configuration.
 The settings in the *example.engineblock.ini* are a subset of all configuration options, which can be found, along
 with their default value in *application/configs/application.ini*.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,23 @@ If those options are not removed from the configuration, they will be ignored.
 
 https://www.pivotaltracker.com/story/show/154839908
 
+### Configuration of hostname is required
+The INI setting 'hostname' was previously optional. EngineBlock used the Host header from the request (HTTP_HOST) when
+omitted. Starting from EB5.7, the hostname setting is required and must be present in application.ini or
+/etc/openconext/engineblock.ini.
+
+Make sure your INI file contains the hostname setting before deploying EB5.7.
+
+    hostname = engine.example.org
+
+For the development VM:
+
+    hostname = engine.vm.openconext.org
+
+For the demo environment:
+
+    hostname = engine.demo.openconext.org
+
 ### Removal of legacy INI settings
 
 The following INI settings are inherited from EB4.x and were never used in EB5.x. They can be safely removed from

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -12,6 +12,11 @@
 ;;;
 [base]
 
+base_domain = example.org
+
+; Set a fixed hostname for OpenConext EngineBlock to use.
+hostname = engine.example.org
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; PHP SETTINGS ;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -203,9 +208,6 @@ email.idpDebugging.from.address = "noreply@example.org"
 email.idpDebugging.to.address = "admin@example.org"
 email.idpDebugging.to.name    = "OpenConext"
 email.idpDebugging.subject    = "IdP debug info van %1$s"
-
-; Set a fixed hostname for OpenConext EngineBlock to use.
-;hostname = engine.demo.openconext.org
 
 ; terms of use openconext
 openconext.termsOfUse = "https://www.example.org/terms-of-service"

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -115,7 +115,7 @@ $ymlContent = array(
         // setting. For example:
         //
         //    domain = vm.openconext.org
-        //    hostname = empty, or engine.vm.openconext.org
+        //    hostname = engine.vm.openconext.org
         'domain'                                                  => $config->get('base_domain'),
         'hostname'                                                => $config->get('hostname'),
 

--- a/ci/travis/files/engineblock.ini
+++ b/ci/travis/files/engineblock.ini
@@ -2,6 +2,7 @@
 version = test
 
 base_domain = vm.openconext.org
+hostname = engine.vm.openconext.org
 
 ;; Travis CI mysql config
 database.host = 127.0.0.1

--- a/docs/example.engineblock.ini
+++ b/docs/example.engineblock.ini
@@ -1,4 +1,5 @@
 base_domain = demo.openconext.org
+hostname = engine.demo.openconext.org
 
 cookie.lang.domain = .demo.openconext.org
 

--- a/library/EngineBlock/Application/Bootstrapper.php
+++ b/library/EngineBlock/Application/Bootstrapper.php
@@ -80,6 +80,15 @@ class EngineBlock_Application_Bootstrapper
     protected function _bootstrapHttpCommunication()
     {
         $httpRequest = EngineBlock_Http_Request::createFromEnvironment();
+
+        $configuredHostname = $this->_application->getDiContainer()->getHostname();
+        if (empty($configuredHostname)) {
+            throw new RuntimeException(
+                "The 'hostname' application.ini setting is required"
+            );
+        }
+        $httpRequest->setHostName($configuredHostname);
+
         $this->_application->getLogInstance()->info(
             sprintf(
                 'Handling incoming request: %s %s',

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -297,23 +297,6 @@ class EngineBlock_ApplicationSingleton
     }
 
     /**
-     * Get the hostname that EngineBlock is hosted on and should use in absolute URLs.
-     *
-     * @return string
-     * @throws EngineBlock_Exception
-     */
-    public function getHostname()
-    {
-        $configHostname = $this->getDiContainer()->getHostname();
-
-        if (is_string($configHostname) && !empty($configHostname)) {
-            return $configHostname;
-        }
-
-        return $_SERVER['HTTP_HOST'];
-    }
-
-    /**
      * Logs exception and redirects user to feedback page
      *
      * @param Exception $exception

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -338,7 +338,7 @@ class EngineBlock_Corto_Adapter
         $application = EngineBlock_ApplicationSingleton::getInstance();
         $settings = $application->getDiContainer();
 
-        $proxyServer->setHostName($application->getHostname());
+        $proxyServer->setHostName($settings->getHostname());
 
         $proxyServer->setConfigs(array(
             'debug' => $settings->isDebug(),

--- a/library/EngineBlock/Http/Request.php
+++ b/library/EngineBlock/Http/Request.php
@@ -24,7 +24,6 @@ class EngineBlock_Http_Request
         $request->setProtocol((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS']==='on'));
         $request->setMethod($_SERVER['REQUEST_METHOD']);
         $request->setHttpProtocol($_SERVER['SERVER_PROTOCOL']);
-        $request->setHostName($_SERVER['HTTP_HOST']);
 
         $queryStart = strpos($_SERVER['REQUEST_URI'], '?');
         if ($queryStart !== false) {

--- a/tests/library/EngineBlock/Test/ApplicationSingletonTest.php
+++ b/tests/library/EngineBlock/Test/ApplicationSingletonTest.php
@@ -28,16 +28,4 @@ class EngineBlock_Test_ApplicationSingletonTest extends PHPUnit_Framework_TestCa
         unset($_SERVER['REMOTE_ADDR']);
         $this->assertEquals(EngineBlock_ApplicationSingleton::IP_ADDRESS_CLI, $application->getClientIpAddress());
     }
-
-    public function testGetHostname()
-    {
-        $application = EngineBlock_ApplicationSingleton::getInstance();
-
-        $_SERVER['HTTP_HOST'] = 'engine2.example.edu';
-        $this->assertEquals('engine2.example.edu', $application->getHostname());
-
-        // @TODO: the 'hostname' configuration options should override this value,
-        //        but that's not easy to test because the application class does
-        //        no use DI.
-    }
 }


### PR DESCRIPTION
You can already configure this option in earlier versions of EB in
order to be forward compatible.

See PR #510 and https://www.pivotaltracker.com/story/show/155617973