### PR TITLE
Update simplesamlphp packages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2137,16 +2137,16 @@
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "e9786e2e47971b9e3684391778d2c489e4725f26"
+                "reference": "b2ecfbaf10bee0a0a64bfb444aad23467fcbd4c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/e9786e2e47971b9e3684391778d2c489e4725f26",
-                "reference": "e9786e2e47971b9e3684391778d2c489e4725f26",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/b2ecfbaf10bee0a0a64bfb444aad23467fcbd4c9",
+                "reference": "b2ecfbaf10bee0a0a64bfb444aad23467fcbd4c9",
                 "shasum": ""
             },
             "require": {
@@ -2190,20 +2190,20 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2018-01-26T07:55:28+00:00"
+            "time": "2018-02-26T15:22:03+00:00"
         },
         {
             "name": "simplesamlphp/simplesamlphp",
-            "version": "v1.15.2",
+            "version": "v1.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/simplesamlphp.git",
-                "reference": "d6d8df7297778317fbf07edc8d882ceb283715f0"
+                "reference": "1cba48676420d7889ba8223d4f2ea1b9867c0184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/simplesamlphp/zipball/d6d8df7297778317fbf07edc8d882ceb283715f0",
-                "reference": "d6d8df7297778317fbf07edc8d882ceb283715f0",
+                "url": "https://api.github.com/repos/simplesamlphp/simplesamlphp/zipball/1cba48676420d7889ba8223d4f2ea1b9867c0184",
+                "reference": "1cba48676420d7889ba8223d4f2ea1b9867c0184",
                 "shasum": ""
             },
             "require": {
@@ -2220,7 +2220,7 @@
                 "jaimeperez/twig-configurable-i18n": "^1.2",
                 "php": ">=5.4",
                 "robrichards/xmlseclibs": "~3.0",
-                "simplesamlphp/saml2": "~3.1.1",
+                "simplesamlphp/saml2": "~3.1.3",
                 "twig/twig": "~1.0",
                 "whitehat101/apr1-md5": "~1.0"
             },
@@ -2240,7 +2240,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-2.1"
+                "LGPL-2.1-or-later"
             ],
             "authors": [
                 {
@@ -2266,7 +2266,7 @@
                 "sp",
                 "ws-federation"
             ],
-            "time": "2018-01-31T10:45:27+00:00"
+            "time": "2018-02-27T09:21:42+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",


### PR DESCRIPTION
Updates simplesamlphp to 1.15.3 and saml2 to 3.1.3.

Resolves security advisory SA-201802-01