### PR TITLE
Allow translation overrides and remove references to SURFconext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/ignore_me.php
 /app/config/ini_parameters.yml
 /app/config/config_local.yml
 .idea
+/languages/overrides.*.php

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -64,6 +64,14 @@ configuration files and will be ignored otherwise.
     symfony.logPath
     symfony.cachePath
 
+### New configuration parameter openconext.supportUrl
+
+A new INI parameter `openconext.supportUrl` has been added. It is currently only used on the 'about OpenConext' slide-in
+on the consent page.
+
+It defaults to "https://www.example.org/support" and should contain a URL to a support page for users to read more about
+the platform.
+
 ### Migration to Twig as template render engine
 All .phtml templates (Zend_Layout) have been rewritten to Twig templates. Any custom theme should be rewritten to
 utilize Twig templates. 
@@ -79,59 +87,34 @@ The following files have been renamed:
  - languages/nl.php -> languages/messages.nl.php
  - languages/en.php -> languages/messages.en.php
 
-The placeholder format for translations has been changed from sprintf-style to symfony-style. The following command can
-be used to effortlessly convert the placeholders in your existing translation files:
+The placeholder format for translations has been changed from sprintf-style (%1$s) to symfony-style (%named%).
 
-      sed 's,%\([sd]\),%arg1%,;s,%\([sd]\),%arg2%,;s,%\([sd]\),%arg3%,;s,%\([0-9]\)$[sd],%arg\1%,g' -i languages/*.php
+In order to make the default translations less specific to deployment in the educational world, and less specific to
+SURFconext, all occurrences of SURFconext and the noun 'institution' are configurable. Instead of translations like:
 
-Above command will replace placeholders like '%s' and '%d' with named arguments %arg1% through %arg3%, and placeholders
-like '%x$s' and '%x$d' with named arguments '%argx%'.
+    'More information about SURFconext'
+    'Find your institution'
 
-The following translation messages are not used by EB5.x and can be removed from the translation files:
+We now write the translations as:
 
- - english
- - dutch
- - back
- - attribute
- - authentication\_urls
- - idp\_selection\_title
- - idp\_selection\_subheader
- - idp\_selection\_desc
- - our\_suggestion
- - no\_access
- - no\_access\_more\_info
- - no\_results
- - error\_header
- - edit
- - done
- - remove
- - cookie\_not\_set
- - footer
- - close\_question
- - sorry
- - form\_description
- - deleteuser\_success\_header
- - deleteuser\_success\_subheader
- - deleteuser\_success\_desc
- - external\_link
- - consent\_header
- - consent\_subheader
- - consent\_intro
- - consent\_idp\_provides
- - consent\_sp\_is\_provided
- - consent\_terms\_of\_service
- - consent\_accept
- - consent\_decline
- - consent\_notice
- - consent\_header\_info
- - consent\_sp\_idp\_info
- - consent\_aggregated\_attributes\_info
- - sp\_terms\_of\_service
- - name\_id
- - error\_authorization\_policy\_violation\_name
- - error\_group\_oauth
- - error\_group\_oauth\_desc
- - info\_mail\_link
+    'More information about %suiteName%
+    'Find your %organisationNoun%
+
+The values of suiteName and organisationNoun are themselves translations, defaulting to:
+
+    'suite_name'        => 'OpenConext',
+    'organisation_noun' => 'organisation',
+
+It is possible to override all translations by placing a overrides.en.php or overrides.nl.php inside the languages
+folder. For SURFconext, on deployment the two files will have to be added containing at least:
+
+
+    <?php
+
+    return [
+        'suite_name'        => 'SURFconext,
+        'organisation_noun' => 'institution,
+    ];
 
 ## 5.x -> 5.2
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -87,6 +87,52 @@ be used to effortlessly convert the placeholders in your existing translation fi
 Above command will replace placeholders like '%s' and '%d' with named arguments %arg1% through %arg3%, and placeholders
 like '%x$s' and '%x$d' with named arguments '%argx%'.
 
+The following translation messages are not used by EB5.x and can be removed from the translation files:
+
+ - english
+ - dutch
+ - back
+ - attribute
+ - authentication\_urls
+ - idp\_selection\_title
+ - idp\_selection\_subheader
+ - idp\_selection\_desc
+ - our\_suggestion
+ - no\_access
+ - no\_access\_more\_info
+ - no\_results
+ - error\_header
+ - edit
+ - done
+ - remove
+ - cookie\_not\_set
+ - footer
+ - close\_question
+ - sorry
+ - form\_description
+ - deleteuser\_success\_header
+ - deleteuser\_success\_subheader
+ - deleteuser\_success\_desc
+ - external\_link
+ - consent\_header
+ - consent\_subheader
+ - consent\_intro
+ - consent\_idp\_provides
+ - consent\_sp\_is\_provided
+ - consent\_terms\_of\_service
+ - consent\_accept
+ - consent\_decline
+ - consent\_notice
+ - consent\_header\_info
+ - consent\_sp\_idp\_info
+ - consent\_aggregated\_attributes\_info
+ - sp\_terms\_of\_service
+ - name\_id
+ - error\_authorization\_policy\_violation\_name
+ - error\_group\_oauth
+ - error\_group\_oauth\_desc
+ - info\_mail\_link
+
 ## 5.x -> 5.2
 
 ### Consent API

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -210,6 +210,7 @@ email.idpDebugging.to.name    = "OpenConext"
 email.idpDebugging.subject    = "IdP debug info van %1$s"
 
 ; terms of use openconext
+openconext.supportUrl = "https://www.example.org/support"
 openconext.termsOfUse = "https://www.example.org/terms-of-service"
 
 ; Which LDAP attribute to use as the primary identifier.

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -197,9 +197,10 @@ $ymlContent = array(
         // Guest qualifier for the AddGuestStatus filter.
         'addgueststatus_guestqualifier'                           => $config->get('addgueststatus.guestqualifier', ''),
 
-        // OpenConext terms-of-use URL.
+        // OpenConext support and terms-of-use URL.
         // Note the escaping of '%' to support URLs like '/Terms+of+Service+%28EN%29'.
-        'openconext_terms_of_use'                                 => escapeYamlValue($config->get('openconext.termsOfUse')),
+        'openconext_support_url'                                  => escapeYamlValue($config->get('openconext.supportUrl')),
+        'openconext_terms_of_use_url'                             => escapeYamlValue($config->get('openconext.termsOfUse')),
 
         // Email configuration
         'email_request_access_address'                            => $config->get('email.help'),

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -1,11 +1,7 @@
 <?php
 
 return array(
-    'english'               => 'English',
-
     // General
-    'back'                  => 'back',
-    'attribute'             => 'Attribute',
     'value'                 => 'Value',
     'post_data'             => 'POST Data',
     'processing'            => 'Connecting to the service',
@@ -14,10 +10,9 @@ return array(
     'go_back'               => '&lt;&lt; Go back',
     'note'                  => 'Note',
     'note_no_script'        => 'Since your browser does not support JavaScript, you must press the button below to proceed.',
-    'authentication_urls'   => 'Authentication URLs',
-    'timestamp'             => 'Timestamp',
 
     // Feedback
+    'timestamp'             => 'Timestamp',
     'requestId'             => 'Unique Request ID',
     'identityProvider'      => 'Identity Provider',
     'serviceProvider'       => 'Service Provider',
@@ -27,23 +22,12 @@ return array(
     'statusMessage'         => 'Status Message',
 
     // WAYF
-    'idp_selection_title'       => 'Identity Provider Selection - %arg1%',
-    'idp_selection_subheader'   => 'Login via your institution',
     'search'                    => 'Search for an institution...',
-    'idp_selection_desc'        => 'Select an institution to login to <i>%arg1%</i>',
-    'our_suggestion'            => 'Previously chosen:',
     'idps_with_access'          => 'Identity Providers with access',
     'idps_without_access'       => 'Identity Providers without access',
-    'no_access'                 => 'No access',
-    'no_access_more_info'       => 'No access. &raquo;',
-    'no_results'                => 'Your search did not return any results.',
-    'error_header'              => 'Error',
     'log_in_to'                 => 'Select an institution to login to the service:',
     'press_enter_to_select'     => 'Press enter to select',
     'loading_idps'              => 'Loading Identity Providers...',
-    'edit'                      => 'Edit List',
-    'done'                      => 'Done',
-    'remove'                    => 'Remove',
     'request_access'            => 'Request access',
     'no_idp_results'            => 'Your search did not return any results.',
     'no_idp_results_request_access' => 'Can\'t find your institution? &nbsp;<a href="#no-access" class="noaccess">Request access</a>&nbsp;or try tweaking your search.',
@@ -52,7 +36,6 @@ return array(
 
     // Remove cookies
     'remember_choice'           => 'Remember my choice',
-    'cookie_not_set'            => 'Not set',
     'cookie_removal_header'     => 'Remove cookies',
     'cookie_remove_button'      => 'Remove',
     'cookie_remove_all_button'  => 'Remove all',
@@ -64,7 +47,6 @@ return array(
     'service_by'            => 'This is a service connected through',
     'serviceprovider_link'  => '<a href="https://www.surfconext.nl/" target="_blank">SURFconext</a>',
     'terms_of_service_link' => '<a href="https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28EN%29" target="_blank">Terms of Service</a>',
-    'footer'                => '<a href="https://www.surfconext.nl/" target="_blank">SURFconext</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28EN%29">Terms of Service</a>',
 
     // Help
     'help'                  => 'Help',
@@ -73,8 +55,6 @@ return array(
 
     <p>For more detailed information, please visit <a href="https://support.surfconext.nl/">the SURFconext support page</a>
         or contact the SURFconext helpdesk at <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
-
-    'close_question'        =>      'Close',
 
     // Help questions
     // general help questions
@@ -108,9 +88,6 @@ If you have any questions about your privacy and the policy applied, please visi
     'answer_cannot_select'              =>      '<p>The dialog box to select your institution can be used in most popular browsers, including Internet Explorer, Firefox, Chrome, and Safari. Other browsers may not be supported. Your browser must support the use of cookies and JavaScript.</p>',
 
     //Form
-    'sorry'                 => 'Unfortunately,',
-    'form_description'      => 'does not have access to this service. What can you do?</h2>
-            <p>If you want to access this service, please fill out the form below. We will then forward your request to the person responsible for the services portfolio management at your institution.</p>',
     'request_access_instructions' => '<h2>Unfortunately, you do not have access to the service you are looking for.
                                    What can you do?</h2>
                                 <p>If you want to access this service, please fill out the form below.
@@ -134,31 +111,6 @@ If you have any questions about your privacy and the policy applied, please visi
     <p>SURFnet has forwarded your request, but the decision and planning to make this service available depends on the ICT policy of your institution.</p>
 
     <p>If you have any questions about your request, please contact <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
-
-    //Delete User
-    'deleteuser_success_header'         => 'SURFconext exit procedure',
-    'deleteuser_success_subheader'      => 'You are almost done...',
-    'deleteuser_success_desc'           => '<strong>Important!</strong> To finalize the exit procedure you must close your browser.',
-
-    // Consent theme before EB 2.3.0
-    'external_link'                     => 'opens in a new window',
-    'consent_header'                    => '%arg1% requests your information',
-    'consent_subheader'                 => '%arg1% requests your information',
-    'consent_intro'                     => '%arg1% requests this information that %arg2% has stored for you:',
-    'consent_idp_provides'              => 'wants to provide the following information:',
-    'consent_sp_is_provided'            => 'to',
-    'consent_terms_of_service'          => 'This information will be passed on to %arg1%. Terms of service of %arg2% and %arg3% apply.',
-
-    'consent_accept'                    => 'Yes, share this data',
-    'consent_decline'                   => 'No, I don\'t want to use this service',
-    'consent_notice'                    => '(We will ask you again when the information changes)',
-
-    // Consent theme before EB 5.5.0
-    'consent_header_info'               => 'Request for release of your information',
-    'consent_sp_idp_info'               => 'In order to log in to <strong class="service-provider">%arg1%</strong> using your institutional account, <strong class="identity-provider">%arg2%</strong> uses SURFconext. This service is only accessible through SURFconext if <strong class="identity-provider">%arg2%</strong> shares certain information with this service. For this, your permission is required. The service needs the following information:',
-    'consent_aggregated_attributes_info' => '<strong class="service-provider">%arg1%</strong> also requires access to information from the source <strong class="attribute-source">%arg2%</strong>. The service needs the following additional information:',
-    'sp_terms_of_service'               => 'View %arg1%\'s <a href="%arg2%" target="_blank">Terms of Service</a>',
-    'name_id'                           => 'SURFconext user ID',
 
     // Consent theme EB 5.5.0 and later
     'consent_header_title'                    => '%arg1% needs your information before logging in',
@@ -247,7 +199,6 @@ Visit <a href="https://wiki.surfnet.nl/x/jq9WAw" target="_blank">the SURFconext 
     'error_authorization_policy_violation_desc'       => '<p>
         You have successfully logged in at your institution, but unfortunately you cannot use this service (the &lsquo;Service Provider&rsquo;) because you have no access. Your institution limits access to this service with an <i>authorization policy</i>. Please contact your institution\'s helpdesk if you think you should be allowed access to this service.
     </p>',
-    'error_authorization_policy_violation_name'       => 'Authorization policy message',
     'error_authorization_policy_violation_info'       => 'Message from your institution: ',
     'error_no_message'              => 'Error - No message received',
     'error_no_message_desc'         => 'We were expecting a message, but did not get one? Something went wrong. Please try again.',
@@ -287,11 +238,6 @@ Your log-in has failed and we don\'t know exactly why. Try again first, and if t
             <li>schacHomeOrganization</li>
         </ul>
     </p>',
-    'error_group_oauth'            =>  'Error - Group authorization failed',
-    'error_group_oauth_desc'       => '<p>
-        The external group provider <b>%arg1%</b> reported an error. </p>
-        <p>Please contact the SURFconext team at <a href="mailto:help@surfconext.nl">help@surfconext.nl</a>.
-       </p>',
     'error_received_error_status_code'     => 'Error - Identity Provider error',
     'error_received_error_status_code_desc'=> '<p>
 Your institution has denied you access to this service. You will have to contact your own (IT-)servicedesk to see if this can be fixed.
@@ -343,7 +289,4 @@ Your institution has denied you access to this service. You will have to contact
     'logout' => 'logout',
     'logout_description' => 'This application uses centralized log in, which provides single sign on for several applications. To be sure your log out is 100% secure you should close your browser completely.',
     'logout_information_link' => '<a href="https://wiki.surfnet.nl/display/conextsupport/Log+out+SURFconext">More information about secure log out</a>',
-
-    // Internal
-    'info_mail_link' => '<a href="support@surfconext.nl">support@surfconext.nl</a>',
 );

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -1,6 +1,33 @@
 <?php
 
-return array(
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.en.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
+    // Values used in placeholders for other translations
+    // %suiteName%: OpenConext (default), SURFconext, ACMEconext
+    'suite_name' => 'OpenConext',
+
+    // Example translation message:
+    //     'Find an %organisationNoun%'
+    //
+    // Becomes:
+    //     'Find an organisation' (default)
+    // or: 'Find an institution' (when overridden)
+    'organisation_noun' => 'organisation',
+    'organisation_noun_plural' => 'organisations',
+
+    // Example translation message:
+    //     'Use your %accountNoun%'
+    //
+    // Becomes:
+    //     'Use your organisation account' (default)
+    // or: 'Use your institutional account' (when overridden)
+    'account_noun' => 'organisation account',
+
     // General
     'value'                 => 'Value',
     'post_data'             => 'POST Data',
@@ -22,17 +49,24 @@ return array(
     'statusMessage'         => 'Status Message',
 
     // WAYF
-    'search'                    => 'Search for an institution...',
+    'search'                    => 'Search for an %organisationNoun%...',
     'idps_with_access'          => 'Identity Providers with access',
     'idps_without_access'       => 'Identity Providers without access',
-    'log_in_to'                 => 'Select an institution to login to the service:',
+    'log_in_to'                 => 'Select an %organisationNoun% to login to the service:',
     'press_enter_to_select'     => 'Press enter to select',
     'loading_idps'              => 'Loading Identity Providers...',
     'request_access'            => 'Request access',
     'no_idp_results'            => 'Your search did not return any results.',
-    'no_idp_results_request_access' => 'Can\'t find your institution? &nbsp;<a href="#no-access" class="noaccess">Request access</a>&nbsp;or try tweaking your search.',
+    'no_idp_results_request_access' => 'Can\'t find your %organisationNoun%? &nbsp;<a href="#no-access" class="noaccess">Request access</a>&nbsp;or try tweaking your search.',
     'more_idp_results'          => '%arg1% results not shown. Refine your search to show more specific results.',
     'return_to_sp'              => 'Return to Service Provider',
+
+    // Help page
+    'help_header'       => 'Help',
+    'help_page_content' => <<<HTML
+<p>No help content available.</p>
+HTML
+    ,
 
     // Remove cookies
     'remember_choice'           => 'Remember my choice',
@@ -45,60 +79,21 @@ return array(
 
     // Footer
     'service_by'            => 'This is a service connected through',
-    'serviceprovider_link'  => '<a href="https://www.surfconext.nl/" target="_blank">SURFconext</a>',
-    'terms_of_service_link' => '<a href="https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28EN%29" target="_blank">Terms of Service</a>',
+    'serviceprovider_link'  => '<a href="https://openconext.org/" target="_blank">%suiteName%</a>',
+    'terms_of_service_link' => '<a href="#" target="_blank">Terms of Service</a>',
 
-    // Help
-    'help'                  => 'Help',
-    'help_header'           => 'Help',
-    'help_description'      => '<p>Check the FAQ below if you have any questions about this screen or about SURFconext.</p>
-
-    <p>For more detailed information, please visit <a href="https://support.surfconext.nl/">the SURFconext support page</a>
-        or contact the SURFconext helpdesk at <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
-
-    // Help questions
-    // general help questions
-    'question_surfconext'               =>      'What is SURFconext?',
-    'answer_surfconext'                 =>      '<p>SURFconext is a next generation collaboration infrastructure that creates new opportunities to collaborate online based on a combination of federation technology, group management, concepts from social networking and applications from different providers. SURFconext allows you to access online services with the username and password issued to you by your own institution.</p>',
-    'question_log_in'                   =>      'How do you login via SURFconext?',
-    'answer_log_in'                     =>      '<ul>
-                            <li>Click on your institution in this screen.</li>
-                            <li>You will then be redirected to the log-in page of your institution where you can log in.</li>
-                            <li>Your institution will notify SURFconext that you have logged in successfully.</li>
-                            <li>You will be taken to the service for which you have logged in. You can then start using that service.</li>
-                        </ul>',
-    'question_security'                 =>      'Is SURFconext secure?',
-    'answer_security'                   =>      '<p>Your institution and SURFnet believe that user privacy is extremely important.<br />
-<br />
-Personal details are only provided to a service provider if these details are needed to use the service. Contractual agreements between your institution, SURFconext and the service provider guarantee that your personal details will be handled and processed with care.<br />
-<br />
-If you have any questions about your privacy and the policy applied, please visit <a href="https://wiki.surfnet.nl/display/conextsupport/">the SURFconext support page</a> for more information or contact the SURFconext helpdesk at <a href="mailto:help@surfconext.nl">help@surfconext.nl</a>.
-</p>',
-
-    // WAYF help questions
-    'question_screen'                   =>      'Why this screen?',
-    'answer_screen'                     =>      '<p>You can log in to this service with your institutional account. In this screen, you select the institution you are affiliated with.</p>',
-    'question_institution_not_listed'   =>      'My institution is not listed. What should I do?',
-    'answer_institution_not_listed'     =>      '<p>If your institution is not listed, then it is either not linked to SURFconext or your institution may not allow access to this particular service. Go back to the page for the service. In some cases, there will be alternative ways of logging in.</p>',
-    'question_institution_no_access'    =>      'My institution does not allow access to the service. What should I do?',
-    'answer_institution_no_access'      =>      '<p>It is possible that your institution is connected to SURFconext but has not (or not yet) made any arrangements with the service provider about the use of the service. We will forward your request to your institution. Based on your request your institution may consider to add this service to its service portfolio.</p>',
-    'question_asked_institution_access'  =>      'I have asked my institution for access but I still cannot get access. Why not?',
-    'answer_asked_institution_access'    =>      '<p>Apparently, your institution has not arranged a license yet or, access to this service is not on the roadmap of your institution. Such decisions are beyond the scope and control of SURFnet.</p>',
-    'question_cannot_select'            =>      'In my browser I cannot select my institution. What should I do?',
-    'answer_cannot_select'              =>      '<p>The dialog box to select your institution can be used in most popular browsers, including Internet Explorer, Firefox, Chrome, and Safari. Other browsers may not be supported. Your browser must support the use of cookies and JavaScript.</p>',
-
-    //Form
+    // Form
     'request_access_instructions' => '<h2>Unfortunately, you do not have access to the service you are looking for.
                                    What can you do?</h2>
                                 <p>If you want to access this service, please fill out the form below.
                                    We will then forward your request to the person responsible for the services
-                                   portfolio management at your institution.</p>',
+                                   portfolio management at your %organisationNoun%.</p>',
     'name'                  => 'Name',
     'name_error'            => 'Enter your name',
     'email'                 => 'E-mail',
     'email_error'           => 'Enter your (correct) e-mail address',
-    'institution'           => 'Institution',
-    'institution_error'     => 'Enter an institution',
+    '%organisationNoun%'    => '%organisationNoun%',
+    'institution_error'     => 'Enter an %organisationNoun%',
     'comment'               => 'Comment',
     'comment_error'         => 'Enter a comment',
     'cancel'                => 'Cancel',
@@ -106,54 +101,36 @@ If you have any questions about your privacy and the policy applied, please visi
     'close'                 => 'Close',
 
     'send_confirm'          => 'Your request has been sent',
-    'send_confirm_desc'     => '<p>Your request has been forwarded to your institution. Further settlement and decisions on the availability of this service will be taken by the ICT staff of your institution.</p>
+    'send_confirm_desc'     => '<p>Your request has been forwarded to your %organisationNoun%. Further settlement and decisions on the availability of this service will be taken by the ICT staff of your %organisationNoun%.</p>',
 
-    <p>SURFnet has forwarded your request, but the decision and planning to make this service available depends on the ICT policy of your institution.</p>
-
-    <p>If you have any questions about your request, please contact <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
-
-    // Consent theme EB 5.5.0 and later
+    // Consent page
     'consent_header_title'                    => '%arg1% needs your information before logging in',
-    'consent_header_text'                     => 'The service needs the following information to function properly. These data will be sent securely from your institution towards %arg1% via <a class="help" href="#" data-slidein="about">SURFconext</a>.',
+    'consent_header_text'                     => 'The service needs the following information to function properly. These data will be sent securely from your %organisationNoun% towards %arg1% via <a class="help" href="#" data-slidein="about">%suiteName%</a>.',
     'consent_privacy_title'                   => 'The following information will be shared with %arg1%:',
     'consent_privacy_link'                    => 'Read the privacy policy of this service',
     'consent_attributes_correction_link'      => 'Are your details incorrect?',
     'consent_attributes_show_more'            => 'Show more information',
     'consent_attributes_show_less'            => 'Show less information',
-    'consent_attribute_source_voot'           => 'Group membership',
-    'consent_attribute_source_sab'            => 'SURFnet Autorisatie Beheer',
-    'consent_attribute_source_orcid'          => 'ORCID iD',
-    'consent_attribute_source_surfmarket_entitlements' => 'SURFmarket entitlements',
-    'consent_attribute_source_logo_url_voot'  => 'https://static.surfconext.nl/media/aa/voot.png',
-    'consent_attribute_source_logo_url_sab'   => 'https://static.surfconext.nl/media/aa/sab.png',
-    'consent_attribute_source_logo_url_orcid' => 'https://static.surfconext.nl/media/aa/orcid.png',
-    'consent_attribute_source_logo_url_surfmarket_entitlements' => 'https://static.surfconext.nl/media/aa/surfmarket_entitlements.png',
     'consent_buttons_title'                   => 'Do you agree with sharing this data?',
     'consent_buttons_ok'                      => 'Yes, proceed to %arg1%',
     'consent_buttons_nok'                     => 'No, I do not agree',
-    'consent_footer_text_singular'            => 'You are using one other service via SURFconext. <a href="%arg1%" target="_blank">View the list of services and your profile information.</a>',
-    'consent_footer_text_plural'              => 'You are using %arg1% services via SURFconext. <a href="%arg2%" target="_blank">View the list of services and your profile information.</a>',
-    'consent_footer_text_first_consent'       => 'You are not using any services via SURFconext. <a href="%arg1%" target="_blank">View your profile information.</a>',
+    'consent_footer_text_singular'            => 'You are using one other service via %suiteName%. <a href="%arg1%" target="_blank">View the list of services and your profile information.</a>',
+    'consent_footer_text_plural'              => 'You are using %arg1% services via %suiteName%. <a href="%arg2%" target="_blank">View the list of services and your profile information.</a>',
+    'consent_footer_text_first_consent'       => 'You are not using any services via %suiteName%. <a href="%arg1%" target="_blank">View your profile information.</a>',
     'consent_slidein_details_email'           => 'Email',
     'consent_slidein_details_phone'           => 'Phone',
-    'consent_slidein_text_contact'            => 'If you have any questions about this page, please contact the help desk of your institution. SURFconext has the following contact information:',
+    'consent_slidein_text_contact'            => 'If you have any questions about this page, please contact the help desk of your %organisationNoun%. %suiteName% has the following contact information:',
     'consent_slidein_text_no_support'         => 'No contact data available.',
 
     // Consent slidein: Is the data shown incorrect?
     'consent_slidein_correction_title' => 'Is the data shown incorrect?',
-    'consent_slidein_correction_text_idp'  => 'SURFconext receives the information directly from your institution and does not store the information itself. If your information is incorrect, please contact the help desk of your institution to change it.',
-    'consent_slidein_correction_text_aa'  => 'SURFconext receives the information directly from the attribute provider and does not store the information itself. If your information is incorrect, please contact the attribute provider directly to correct it. You can ask the help desk of your institution for assistance with this.',
+    'consent_slidein_correction_text_idp'  => '%suiteName% receives the information directly from your %organisationNoun% and does not store the information itself. If your information is incorrect, please contact the help desk of your %organisationNoun% to change it.',
+    'consent_slidein_correction_text_aa'  => '%suiteName% receives the information directly from the attribute provider and does not store the information itself. If your information is incorrect, please contact the attribute provider directly to correct it. You can ask the help desk of your %organisationNoun% for assistance with this.',
 
-    // Consent slidein: About SURFconext
+    // Consent slidein: About %suiteName%
     'consent_slidein_about_text'  => <<<'TXT'
-<h1>Logging in through SURFconext</h1>
-<img src="/images/about-surfconext.png" alt="SURFconext diagram"/>
-<p>Via SURFconext, researchers, staff and students can easily and securely log in into various cloud services using their own institutional account. SURFconext offers extra privacy protection by sending a minimum set of personal data to these cloud services.</p>
-<p>Curious about which services already received your information before through SURFconext? Visit your <a href="%arg1%">SURFconext profile page</a>.</p>
-
-<h1>SURFconext is part of SURF</h1>
-<p>SURF is the collaborative ICT organisation for Dutch education and research.</p>
-<p>SURF provides access to the best possible internet and IT facilities to students, teachers and researchers in the Netherlands. Want to know more about SURF? Have a look at the <a href="https://www.surf.nl/" target="_blank">website from SURF</a>.</p>
+<h1>Logging in through %suiteName%</h1>
+<p>%suiteName% allows people to easily and securely log in into various cloud services using their own %accountNoun%. %suiteName% offers extra privacy protection by sending a minimum set of personal data to these cloud services.</p>
 TXT
     ,
 
@@ -168,12 +145,10 @@ TXT
     'slidein_close' => 'Close',
     'slidein_read_more' => 'Read more',
 
-    //Error screens
+    // Error screens
     'error_404'                         => '404 - Page not found',
     'error_404_desc'                    => 'This page has not been found.',
-    'error_help_desc'               => '<p>
-        Please visit <a href="https://support.surfconext.nl/" target="_blank">the SURFconext support pages</a> for help solving this problem. These pages also contain contact information for the support team if the problem persists.
-    </p>',
+    'error_help_desc'               => '<p></p>',
     'error_no_consent'              => 'Unable to continue to service',
     'error_no_consent_desc'         => 'This application can only be used when you share the mentioned information.<br /><br />
 
@@ -183,23 +158,19 @@ If you want to use this application you have to:<br />
 <li>share your information</li></ul>',
     'error_no_idps'                 => 'Error - No Identity Providers found',
     'error_no_idps_desc'            => '<p>
-The service you\'re trying to reach (&lsquo;Service Provider&rsquo;) is not accessible through SURFconext.<br /><br />
-
-Visit <a href="https://wiki.surfnet.nl/x/m69WAw" target="_blank">the SURFconext support pages</a> for more support, if you think you should have access to this service.
-        <br /><br />
+The service you\'re trying to reach (&lsquo;Service Provider&rsquo;) is not accessible through %suiteName%.<br /><br />
     </p>',
     'error_session_lost'            => 'Error - your session was lost',
     'error_session_lost_desc'       => '<p>
 We somehow lost where you wanted to go. Did you wait too long? If so, try again first. Does your browser accept cookies? Are you using an outdated URL or bookmark?<br /><br />
-Visit <a href="https://wiki.surfnet.nl/x/jq9WAw" target="_blank">the SURFconext supportpages</a> for more extensive support on this error.
         <br /><br />
     </p>',
 
     'error_authorization_policy_violation'            => 'Error - No access',
     'error_authorization_policy_violation_desc'       => '<p>
-        You have successfully logged in at your institution, but unfortunately you cannot use this service (the &lsquo;Service Provider&rsquo;) because you have no access. Your institution limits access to this service with an <i>authorization policy</i>. Please contact your institution\'s helpdesk if you think you should be allowed access to this service.
+        You have successfully logged in at your %organisationNoun%, but unfortunately you cannot use this service (the &lsquo;Service Provider&rsquo;) because you have no access. Your %organisationNoun% limits access to this service with an <i>authorization policy</i>. Please contact the helpdesk of your %organisationNoun% if you think you should be allowed access to this service.
     </p>',
-    'error_authorization_policy_violation_info'       => 'Message from your institution: ',
+    'error_authorization_policy_violation_info'       => 'Message from your %organisationNoun%: ',
     'error_no_message'              => 'Error - No message received',
     'error_no_message_desc'         => 'We were expecting a message, but did not get one? Something went wrong. Please try again.',
     'error_invalid_acs_location'    => 'The given "Assertion Consumer Service" is unknown or invalid.',
@@ -207,32 +178,30 @@ Visit <a href="https://wiki.surfnet.nl/x/jq9WAw" target="_blank">the SURFconext 
     'error_invalid_acs_binding_desc'     => 'The provided or configured "Assertion Consumer Service" Binding Type is unknown or invalid.',
     'error_unsupported_signature_method' => 'Signature method is not supported',
     'error_unsupported_signature_method_desc' => 'The signature method %arg1% is not supported, please upgrade to RSA-SHA256 (http://www.w3.org/2001/04/xmldsig-more#rsa-sha256).',
-    'error_unknown_preselected_idp' => 'Error - No connection between institution and service',
+    'error_unknown_preselected_idp' => 'Error - No connection between %organisationNoun% and service',
     'error_unknown_preselected_idp_desc' => '<p>
-        The institution that you want to use to login to this service did not activate access to this service. This means you are unable to use this service through SURFconext. Please contact your institution\'s helpdesk to request access to this service. State what service it is about (the &lsquo;Service Provider&rsquo;) and why you need access.
+        The %organisationNoun% that you want to use to login to this service did not activate access to this service. This means you are unable to use this service through %suiteName%. Please contact the helpdesk of your %organisationNoun% to request access to this service. State what service it is about (the &lsquo;Service Provider&rsquo;) and why you need access.
     </p>',
     'error_unknown_service_provider'          => 'Error - Cannot provide metadata for EntityID \'%arg1%\'',
-    'error_unknown_service_provider_desc'     => '<p>
-Your requested service couldn\'t be found. Visit <a href="https://wiki.surfnet.nl/x/k69WAw" target="_blank">the SURFconext supportpages</a> for more extensive support on this error.
-    </p>',
+    'error_unknown_service_provider_desc'     => '<p>Your requested service couldn\'t be found.</p>',
 
     'error_unknown_issuer'          => 'Error - Unknown service',
     'error_unknown_issuer_desc'     => '<p>
-        The service you are trying to log in to is unknown to SURFconext. Possibly your institution has never enabled access to this service. Please contact the helpdesk of your institution and provide them with the following information:
+        The service you are trying to log in to is unknown to %suiteName%. Possibly your %organisationNoun% has never enabled access to this service. Please contact the helpdesk of your %organisationNoun% and provide them with the following information:
     </p>',
     'error_generic'                     => 'Error - An error occurred',
     'error_generic_desc'                => '<p>
-Your log-in has failed and we don\'t know exactly why. Try again first, and if that doesn\'t work visit <a href="https://wiki.surfnet.nl/x/iq9WAw" target="_blank">the SURFconext supportpages</a> for more support with this error. On that page you can also find how to contact us if the error persists.
+Your log-in has failed and we don\'t know exactly why. Try again first, and if that doesn\'t work contact your %organisationNoun% for help.
     </p>',
     'error_missing_required_fields'     => 'Error - Missing required fields',
     'error_missing_required_fields_desc'=> '<p>
-        You can not use this application because your institution is not providing the needed information.
+        You can not use this application because your %organisationNoun% is not providing the needed information.
     </p>
     <p>
-        Please contact your institution with the information stated below.
+        Please contact your %organisationNoun% with the information stated below.
     </p>
     <p>
-        Login failed because the institution\'s identity provider did not provide SURFconext with one or more of the following required attribute(s):
+        Login failed because the identity provider of your %organisationNoun% did not provide %suiteName% with one or more of the following required attribute(s):
         <ul>
             <li>UID</li>
             <li>schacHomeOrganization</li>
@@ -240,13 +209,13 @@ Your log-in has failed and we don\'t know exactly why. Try again first, and if t
     </p>',
     'error_received_error_status_code'     => 'Error - Identity Provider error',
     'error_received_error_status_code_desc'=> '<p>
-Your institution has denied you access to this service. You will have to contact your own (IT-)servicedesk to see if this can be fixed.
+Your %organisationNoun% has denied you access to this service. You will have to contact your own (IT-)servicedesk to see if this can be fixed.
     </p>',
     'error_received_invalid_response'       => 'Error - Invalid Identity Provider response',
     'error_received_invalid_signed_response'=> 'Error - Invalid signature on Identity Provider response',
     'error_stuck_in_authentication_loop' => 'Error - You got stuck in a black hole',
     'error_stuck_in_authentication_loop_desc' => '<p>
-        You\'ve successfully authenticated at your Identity Provider but the service you are trying to access sends you back again to SURFconext. Because you are already logged in, SURFconext then forwards you back to the service, which results in an infinite black hole. Likely, this is caused by an error at the Service Provider. Visit <a href="https://support.surfconext.nl" target="_blank">the SURFconext support pages</a> for more extensive support on this error.
+        You\'ve successfully authenticated at your Identity Provider but the service you are trying to access sends you back again to %suiteName%. Because you are already logged in, %suiteName% then forwards you back to the service, which results in an infinite black hole. Likely, this is caused by an error at the Service Provider.
     </p>',
 
     /**
@@ -265,12 +234,12 @@ Your institution has denied you access to this service. You will have to contact
     'error_attribute_validator_min'                 => '%arg1% should have at least %arg2% values (%arg3% given)',
     'error_attribute_validator_max'                 => '%arg1% may have no more than %arg2% values (%arg3% given)',
     'error_attribute_validator_regex'               => '\'%arg3%\' does not match the expected format of this attribute (%arg2%)',
-    'error_attribute_validator_not_in_definitions'  => '%arg1% is not known in the SURFconext schema',
+    'error_attribute_validator_not_in_definitions'  => '%arg1% is not known in the schema',
     'error_attribute_validator_allowed'             => '\'%arg3%\' is not an allowed value for this attribute',
     'error_attribute_validator_availability'        => '\'%arg3%\' is a reserved schacHomeOrganization for another Identity Provider',
 
     'error_unknown_service'         => 'Error - Unknown service',
-    'error_unknown_service_desc'    => '<p>Your requested service couldn\'t be found.Please contact the SURFconext helpdesk at <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
+    'error_unknown_service_desc'    => '<p>Your requested service couldn\'t be found.</p>',
 
     'attributes_validation_succeeded' => 'Authentication success',
     'attributes_validation_failed'    => 'Some attributes failed validation',
@@ -280,13 +249,13 @@ Your institution has denied you access to this service. You will have to contact
 
     'attributes' => 'Attributes',
     'validation' => 'Validation',
-    'idp_debugging_mail_explain' => 'When requested by SURFconext,
-                                        use the "Mail to SURFconext" button below
+    'idp_debugging_mail_explain' => 'When requested by %suiteName%,
+                                        use the "Mail to %suiteName%" button below
                                         to mail the information in this screen.',
-    'idp_debugging_mail_button' => 'Mail to SURFconext',
+    'idp_debugging_mail_button' => 'Mail to %suiteName%',
 
     // Logout
     'logout' => 'logout',
     'logout_description' => 'This application uses centralized log in, which provides single sign on for several applications. To be sure your log out is 100% secure you should close your browser completely.',
-    'logout_information_link' => '<a href="https://wiki.surfnet.nl/display/conextsupport/Log+out+SURFconext">More information about secure log out</a>',
-);
+    'logout_information_link' => '',
+];

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -1,11 +1,7 @@
 <?php
 
 return array(
-    'dutch'                 => 'Nederlands',
-
     //General
-    'back'                  => 'terug',
-    'attribute'             => 'Attribuut',
     'value'                 => 'Waarde',
     'post_data'             => 'POST Data',
     'processing'            => 'Verbinden met de dienst',
@@ -14,10 +10,9 @@ return array(
     'go_back'               => '&lt;&lt; Ga terug',
     'note'                  => 'Mededeling',
     'note_no_script'        => 'Jouw browser ondersteunt geen JavaScript. Je moet op de onderstaande knop drukken om door te gaan.',
-    'authentication_urls'   => 'Authenticatie URLs',
-    'timestamp'             => 'Timestamp',
 
      // Feedback
+    'timestamp'             => 'Timestamp',
     'requestId'             => 'Uniek Request ID',
     'identityProvider'      => 'Identity Provider',
     'serviceProvider'       => 'Service Provider',
@@ -27,22 +22,12 @@ return array(
     'statusMessage'         => 'Statusbericht',
 
     //WAYF
-    'idp_selection_title'       => 'Identity Provider Selectie - %arg1%',
-    'idp_selection_subheader'   => 'Login via je eigen instelling',
     'search'                    => 'Zoek een instelling...',
-    'idp_selection_desc'        => 'Selecteer een instelling en login bij <i>%arg1%</i>',
-    'our_suggestion'            => 'Eerder gekozen:',
     'idps_with_access'          => 'Instellingen met toegang',
     'idps_without_access'       => 'Instellingen zonder toegang',
-    'no_access'                 => 'Geen toegang.',
-    'no_access_more_info'       => 'Geen toegang. &raquo;',
-    'no_results'                => 'Geen resultaten gevonden.',
     'log_in_to'                 => 'Selecteer een instelling en login bij',
     'press_enter_to_select'     => 'Druk op enter om te kiezen',
     'loading_idps'              => 'Instellingen worden geladen...',
-    'edit'                      => 'Bewerken',
-    'done'                      => 'Klaar',
-    'remove'                    => 'Verwijderen',
     'request_access'            => 'Toegang aanvragen',
     'no_idp_results'            => 'Je zoekterm heeft geen resultaten opgeleverd.',
     'no_idp_results_request_access' => 'Kun je je instelling niet vinden? &nbsp;<a href="#no-access" class="noaccess">Vraag toegang aan</a>&nbsp;of pas je zoekopdracht aan.',
@@ -51,7 +36,6 @@ return array(
     'remember_choice'           => 'Onthoud mijn keuze',
 
     //Remove cookies
-    'cookie_not_set'            => 'Geen waarde',
     'cookie_removal_header'     => 'Cookies verwijderen',
     'cookie_remove_button'      => 'Verwijderen',
     'cookie_remove_all_button'  => 'Alles verwijderen',
@@ -63,7 +47,6 @@ return array(
     'service_by'            => 'Deze dienst is verbonden via',
     'serviceprovider_link'  => '<a href="https://www.surfconext.nl/" target="_blank">SURFconext</a>',
     'terms_of_service_link' => '<a href="https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28NL%29" target="_blank">Gebruiksvoorwaarden</a>',
-    'footer'                => '<a href="https://www.surfconext.nl/" target="_blank">SURFconext</a>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28NL%29">Gebruiksvoorwaarden</a>',
 
     //Help
     'help'                  => 'Help',
@@ -71,8 +54,6 @@ return array(
     'help_description'      => '<p>Heb je vragen over dit scherm of de SURFconext dienstverlening, bekijk dan de antwoorden bij de FAQ hieronder.</p>
 
     <p>Staat je vraag er niet bij, of ben je niet tevreden met een antwoord? Bezoek dan <a href="https://wiki.surfnet.nl/display/conextsupport/">de SURFconext support pagina</a> of stuur een mail naar <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
-
-    'close_question'        =>      'Sluit',
 
     //Help questions
     // general help questions
@@ -106,10 +87,6 @@ Het privacybeleid voor deze dienstverlening is in detail beschreven en na te lez
     'answer_cannot_select'              =>      '<p>Het keuzescherm van SURFconext is te gebruiken in de meest gangbare browsers waaronder, Internet Explorer, Firefox, Chrome en Safari. Andere browsers worden mogelijk niet ondersteund. Verder moet je browser het gebruik van cookies en javascript toestaan.</p>',
 
     // Request Access Form
-    'sorry'                 => 'Helaas,',
-    'form_description'      => 'heeft geen toegang tot deze dienst. Wat nu?</h2>
-            <p>Wil je toch graag toegang tot deze dienst, vul dan
-      het onderstaande formulier in. Wij sturen je verzoek door naar de juiste persoon binnen jouw instelling.</p>',
     'request_access_instructions' => '<h2>Helaas, je hebt geen toegang tot de dienst die je zoekt. Wat nu?</h2>
                                 <p>Wil je toch graag toegang tot deze dienst, vul dan het onderstaande formulier in.
                                    Wij sturen je verzoek door naar de juiste persoon binnen jouw instelling.</p>',
@@ -131,32 +108,6 @@ Het privacybeleid voor deze dienstverlening is in detail beschreven en na te lez
     <p>SURFnet faciliteert het doorsturen van je verzoek maar heeft geen controle over de snelheid waarmee je antwoord of toegang krijgt.</p>
 
     <p>Heb je vragen over je verzoek, neem dan contact op met <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
-
-    // Delete User
-    'deleteuser_success_header'         => 'SURFconext exit procedure',
-    'deleteuser_success_subheader'      => 'U bent bijna klaar...',
-    'deleteuser_success_desc'           => '<strong>Belangrijk!</strong> Om de exit procedure succesvol af te ronden, moet je nu de browser afsluiten.',
-
-
-    // Consent theme before EB 2.3.0
-    'external_link'                     => 'opent in een nieuw venster',
-    'consent_header'                    => '%arg1% verzoekt jouw informatie',
-    'consent_subheader'                 => '%arg1% verzoekt jouw informatie',
-    'consent_intro'                     => '%arg1% verzoekt deze informatie die %arg2% voor jou heeft opgeslagen:',
-    'consent_idp_provides'              => 'wilt de volgende informatie vrijgeven:',
-    'consent_sp_is_provided'            => 'aan',
-    'consent_terms_of_service'          => 'Deze informatie zal worden doorgegeven aan %arg1%. Gebruiksvoorwaarden van %arg2% en %arg3% zijn van toepassing.',
-
-    'consent_accept'                    => 'Ja, deel deze gegevens',
-    'consent_decline'                   => 'Nee, ik wil geen gebruik maken van deze dienst',
-    'consent_notice'                    => '(We zullen dit nogmaals vragen als jouw informatie wijzigt)',
-
-    // Consent theme before EB 5.5.0
-    'consent_header_info'               => 'Verzoek voor doorgeven van jouw informatie',
-    'consent_sp_idp_info'               => 'Om met je instellingsaccount in te kunnen loggen op de dienst <strong class="service-provider">%arg1%</strong> maakt <strong class="identity-provider">%arg2%</strong> gebruik van SURFconext. Voor het functioneren van deze dienst is het noodzakelijk dat <strong class="identity-provider">%arg2%</strong> een aantal gegevens via SURFconext deelt met deze dienst. Hiervoor is jouw toestemming nodig. Het gaat om de volgende gegevens:',
-    'consent_aggregated_attributes_info' => '<strong class="service-provider">%arg1%</strong> heeft ook toegang nodig tot gegevens uit de gegevensbron <strong class="attribute-source">%arg2%</strong>. Het gaat om de volgende aanvullende gegevens:',
-    'sp_terms_of_service'               => 'Bekijk de %arg1%\'s <a href="%arg2%" target="_blank">gebruiksvoorwaarden</a>',
-    'name_id'                           => 'SURFconext gebruikers ID',
 
     // Consent theme EB 5.5.0 and later
     'consent_header_title'                    => 'Om in te loggen heeft %arg1% jouw gegevens nodig',
@@ -246,7 +197,6 @@ Bezoek <a href="https://wiki.surfnet.nl/pages/viewpage.action?pageId=52331093" t
     'error_authorization_policy_violation_desc'       => '<p>
         Je bent succesvol ingelogd bij jouw instelling, maar je kunt geen gebruik maken van deze dienst omdat je geen toegang hebt. Voor deze dienst (de &lsquo;Service Provider&rsquo;) heeft jouw instelling met <i>autorisatieregels</i> ingesteld dat alleen bepaalde gebruikers toegang krijgen. Neem contact op met de (IT-)servicedesk van je instelling als je vindt dat je wel toegang moet hebben.
     </p>',
-    'error_authorization_policy_violation_name'       => 'Omschrijving autorisatieregels',
     'error_authorization_policy_violation_info'       => 'Bericht van je instelling: ',
     'error_no_message'                  => 'Error - Geen bericht ontvangen',
     'error_no_message_desc'             => 'We verwachtten een bericht, maar we hebben er geen ontvangen. Er is iets fout gegaan. Probeer het alstublieft opnieuw.',
@@ -286,12 +236,6 @@ Inloggen is niet gelukt en we kunnen je niet precies vertellen waarom. Probeer h
             <li>UID</li>
             <li>schacHomeOrganization</li>
         </ul>
-    </p>',
-    'error_group_oauth'            =>  'Error - Groepautorisatie is mislukt',
-    'error_group_oauth_desc'       => '<p>
-        De extere groepprovider <b>%arg1%</b> retourneerde een fout.<br />
-        Neem contact op met de SURFconext helpdesk via <a href="mailto:help@surfconext.nl">help@surfconext.nl</a>.
-        <br />
     </p>',
 
     'error_received_error_status_code'     => 'Error - Fout bij Identity Provider',
@@ -345,7 +289,4 @@ Je instelling heeft je de toegang geweigerd tot deze dienst. Je zult dus contact
     'logout' => 'uitloggen',
     'logout_description' => 'Deze applicatie maakt gebruik van centrale login. Hiermee is het mogelijk om met single sign on bij verschillende applicaties in te loggen. Om er 100% zeker van te zijn dat je uitgelogd bent, moet je de browser helemaal afsluiten.',
     'logout_information_link' => '<a href="https://wiki.surfnet.nl/display/conextsupport/Uitloggen+SURFconext">Meer informatie over veilig uitloggen</a>',
-
-    // Internal
-    'info_mail_link' => '<a href="support@surfconext.nl">support@surfconext.nl</a>',
 );

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -1,7 +1,33 @@
 <?php
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.nl.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
 
-return array(
-    //General
+return $overrides + [
+    // Values used in placeholders for other translations
+    // %suiteName%: OpenConext, SURFconext, ACMEconext
+    'suite_name' => 'OpenConext',
+
+    // Example translation message:
+    //     'Find an %organisationNoun%'
+    //
+    // Becomes:
+    //     'Find an organisation' (default)
+    // or: 'Find an institution' (when overridden)
+    'organisation_noun' => 'organisatie',
+    'organisation_noun_plural' => 'organisaties',
+
+    // Example translation message:
+    //     'Use your %accountNoun%'
+    //
+    // Becomes:
+    //     'Use your organisation account' (default)
+    // or: 'Use your institutional account' (when overridden)
+    'account_noun' => 'organisatieaccount',
+
+    // General
     'value'                 => 'Waarde',
     'post_data'             => 'POST Data',
     'processing'            => 'Verbinden met de dienst',
@@ -21,21 +47,28 @@ return array(
     'statusCode'            => 'Statuscode',
     'statusMessage'         => 'Statusbericht',
 
-    //WAYF
-    'search'                    => 'Zoek een instelling...',
-    'idps_with_access'          => 'Instellingen met toegang',
-    'idps_without_access'       => 'Instellingen zonder toegang',
-    'log_in_to'                 => 'Selecteer een instelling en login bij',
+    // WAYF
+    'search'                    => 'Zoek een %organisationNoun%...',
+    'idps_with_access'          => '%organisationNounPlural% met toegang',
+    'idps_without_access'       => '%organisationNounPlural% zonder toegang',
+    'log_in_to'                 => 'Selecteer een %organisationNoun% en login bij',
     'press_enter_to_select'     => 'Druk op enter om te kiezen',
-    'loading_idps'              => 'Instellingen worden geladen...',
+    'loading_idps'              => '%organisationNounPlural% worden geladen...',
     'request_access'            => 'Toegang aanvragen',
     'no_idp_results'            => 'Je zoekterm heeft geen resultaten opgeleverd.',
-    'no_idp_results_request_access' => 'Kun je je instelling niet vinden? &nbsp;<a href="#no-access" class="noaccess">Vraag toegang aan</a>&nbsp;of pas je zoekopdracht aan.',
+    'no_idp_results_request_access' => 'Kun je je %organisationNoun% niet vinden? &nbsp;<a href="#no-access" class="noaccess">Vraag toegang aan</a>&nbsp;of pas je zoekopdracht aan.',
     'more_idp_results'          => '%arg1% resultaten worden niet getoond. Verfijn je zoekopdracht voor specifiekere resultaten.',
     'return_to_sp'              => 'Keer terug naar Service Provider',
-    'remember_choice'           => 'Onthoud mijn keuze',
 
-    //Remove cookies
+    // Help page
+    'help_header'       => 'Help',
+    'help_page_content' => <<<HTML
+<p>No help content available.</p>
+HTML
+    ,
+
+    // Remove cookies
+    'remember_choice'           => 'Onthoud mijn keuze',
     'cookie_removal_header'     => 'Cookies verwijderen',
     'cookie_remove_button'      => 'Verwijderen',
     'cookie_remove_all_button'  => 'Alles verwijderen',
@@ -43,59 +76,21 @@ return array(
     'cookie_removal_confirm'     => 'Uw cookie is verwijderd.',
     'cookies_removal_confirm'    => 'Uw cookies zijn verwijderd.',
 
-    //Footer
+    // Footer
     'service_by'            => 'Deze dienst is verbonden via',
-    'serviceprovider_link'  => '<a href="https://www.surfconext.nl/" target="_blank">SURFconext</a>',
-    'terms_of_service_link' => '<a href="https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28NL%29" target="_blank">Gebruiksvoorwaarden</a>',
-
-    //Help
-    'help'                  => 'Help',
-    'help_header'           => 'Help',
-    'help_description'      => '<p>Heb je vragen over dit scherm of de SURFconext dienstverlening, bekijk dan de antwoorden bij de FAQ hieronder.</p>
-
-    <p>Staat je vraag er niet bij, of ben je niet tevreden met een antwoord? Bezoek dan <a href="https://wiki.surfnet.nl/display/conextsupport/">de SURFconext support pagina</a> of stuur een mail naar <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
-
-    //Help questions
-    // general help questions
-    'question_surfconext'               =>      'Wat is SURFconext?',
-    'answer_surfconext'                 =>      '<p>SURFconext is een verbindingsinfrastructuur die een aantal bouwstenen voor online samenwerking met elkaar verbindt. Die bouwstenen zijn services voor federatieve authenticatie, groepsbeheer, sociale netwerken en cloud applicaties van verschillende aanbieders. Met SURFconext is het mogelijk om met je eigen instellingsaccount toegang te krijgen tot diensten van verschillende aanbieders.</p>',
-    'question_log_in'                   =>      'Hoe werkt inloggen via SURFconext?',
-    'answer_log_in'                     =>      '<ul>
-                            <li>Je selecteert in dit scherm je eigen instelling.</li>
-                            <li>Je wordt doorgestuurd naar een inlogpagina van je eigen instelling. Daar log je in.</li>
-                            <li>Je instelling geeft door aan SURFconext dat je succesvol bent ingelogd.</li>
-                            <li>Je wordt doorgestuurd naar de dienst waarop je hebt ingelogd om deze te gaan gebruiken.</li>
-                        </ul>',
-    'question_security'                 =>      'Is de SURFconext infrastructuur veilig?',
-    'answer_security'                   =>      '<p>Jouw instelling en SURFnet hechten veel belang aan de privacy van gebruikers.<br />
-<br />
-Persoonsgegevens worden alleen verstrekt aan een dienstaanbieder wanneer dat noodzakelijk is voor het gebruik van de dienst. Contractuele afspraken tussen jouw instelling, SURFnet en de dienstaanbieder waarborgen dat er zorgvuldig wordt omgegaan met jouw persoonsgegevens.<br />
-<br />
-Het privacybeleid voor deze dienstverlening is in detail beschreven en na te lezen op <a href="https://wiki.surfnet.nl/display/conextsupport/">de SURFconext support pagina</a>. Heb je vragen ten aanzien van het privacybeleid van SURFconext, mail deze dan naar de SURFconext helpdesk via <a href="mailto:help@surfconext.nl">help@surfconext.nl</a>.
-</p>',
-
-    // WAYF help questions
-    'question_screen'                   =>      'Waarom dit scherm?',
-    'answer_screen'                     =>      '<p>Je kunt met je instellingsaccount inloggen bij deze dienst. In dit scherm geef je aan via welke instelling je wilt inloggen.</p>',
-    'question_institution_not_listed'   =>      'Ik zie mijn instelling er niet tussen staan, wat nu?',
-    'answer_institution_not_listed'     =>      '<p>Staat jouw instelling niet in de lijst? Dan is jouw instelling waarschijnlijk nog niet aangesloten op SURFconext. Ga terug naar de pagina van de dienst; soms biedt een dienst ook alternatieve manieren om in te loggen.</p>',
-    'question_institution_no_access'    =>      'Mijn instelling geeft geen toegang tot deze dienst, wat nu?',
-    'answer_institution_no_access'      =>      '<p>Het kan zijn dat je instelling wel is aangesloten op SURFconext maar (nog) geen afspraken heeft gemaakt met de dienstaanbieder over het gebruik van deze dienst. Wij zullen je verzoek doorsturen naar de verantwoordelijke binnen jouw instelling die de toegang tot diensten organiseert. Wellicht is jouw verzoek voor je instelling aanleiding om alsnog afspraken met deze dienstaanbieder te maken.</p>',
-    'question_asked_institution_access'  =>      'Ik heb toegang aangevraagd voor mijn instelling, maar mijn instelling geeft nog steeds geen toegang. Waarom niet?',
-    'answer_asked_institution_access'    =>      '<p>Blijkbaar is jouw instelling nog niet tot een overeenkomst met de dienstaanbieder gekomen of, het gebruik van deze dienst is niet wenselijk binnen jouw instelling. SURFnet heeft geen controle over de snelheid waarmee je antwoord of toegang krijgt. Die verantwoordelijkheid en zeggenschap ligt bij de instelling.</p>',
-    'question_cannot_select'            =>      'Ik kan in mijn browser mijn instelling niet selecteren, wat nu?',
-    'answer_cannot_select'              =>      '<p>Het keuzescherm van SURFconext is te gebruiken in de meest gangbare browsers waaronder, Internet Explorer, Firefox, Chrome en Safari. Andere browsers worden mogelijk niet ondersteund. Verder moet je browser het gebruik van cookies en javascript toestaan.</p>',
+    'serviceprovider_link'  => '%suiteName%',
+    'terms_of_service_link' => '<a href="#" target="_blank">Gebruiksvoorwaarden</a>',
 
     // Request Access Form
     'request_access_instructions' => '<h2>Helaas, je hebt geen toegang tot de dienst die je zoekt. Wat nu?</h2>
                                 <p>Wil je toch graag toegang tot deze dienst, vul dan het onderstaande formulier in.
-                                   Wij sturen je verzoek door naar de juiste persoon binnen jouw instelling.</p>',
+                                   Wij sturen je verzoek door naar de juiste persoon binnen jouw %organisationNoun%.</p>',
     'name'                  => 'Naam',
     'name_error'            => 'Vul je naam in',
     'email'                 => 'E-mail',
     'email_error'           => 'Vul je (correcte) e-mailadres in',
-    'institution'           => 'Instelling',
-    'institution_error'     => 'Vul jouw instelling in',
+    'institution'           => '%organisationNoun%',
+    'institution_error'     => 'Vul jouw %organisationNoun% in',
     'comment'               => 'Toelichting',
     'comment_error'         => 'Vul een toelichting in',
     'cancel'                => 'Annuleren',
@@ -103,56 +98,37 @@ Het privacybeleid voor deze dienstverlening is in detail beschreven en na te lez
     'close'                 => 'Sluiten',
 
     'send_confirm'          => 'Je verzoek is verzonden',
-    'send_confirm_desc'     => '<p>SURFnet stuurt je verzoek door aan de juiste persoon binnen jouw instelling. Het is aan deze persoon om actie te ondernemen op basis van jouw verzoek. Het kan zijn dat er nog afspraken gemaakt moeten worden tussen jouw instelling en de dienstaanbieder.</p>
+    'send_confirm_desc'     => '<p>Je verzoek is doorgestuurd naar de juiste persoon binnen jouw %organisationNoun%. Het is aan deze persoon om actie te ondernemen op basis van jouw verzoek. Het kan zijn dat er nog afspraken gemaakt moeten worden tussen jouw %organisationNoun% en de dienstaanbieder.</p>',
 
-    <p>SURFnet faciliteert het doorsturen van je verzoek maar heeft geen controle over de snelheid waarmee je antwoord of toegang krijgt.</p>
-
-    <p>Heb je vragen over je verzoek, neem dan contact op met <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
-
-    // Consent theme EB 5.5.0 and later
+    // Consent page
     'consent_header_title'                    => 'Om in te loggen heeft %arg1% jouw gegevens nodig',
-    'consent_header_text'                     => 'De dienst heeft deze gegevens nodig om goed te kunnen functioneren. De gegevens worden vanuit jouw instelling veilig verstuurd naar %arg1% via <a class="help" data-slidein="about">SURFconext</a>.',
+    'consent_header_text'                     => 'De dienst heeft deze gegevens nodig om goed te kunnen functioneren. De gegevens worden vanuit jouw %organisationNoun% veilig verstuurd naar %arg1% via <a class="help" data-slidein="about">%suiteName%</a>.',
     'consent_privacy_title'                   => 'De volgende gegevens worden doorgestuurd naar %arg1%:',
     'consent_privacy_link'                    => 'Lees het privacybeleid van deze dienst',
     'consent_attributes_correction_link'      => 'Kloppen deze gegevens niet?',
     'consent_attributes_show_more'            => 'Toon alle gegevens',
     'consent_attributes_show_less'            => 'Toon minder gegevens',
-    'consent_attribute_source_voot'           => 'Groepslidmaatschap',
-    'consent_attribute_source_sab'            => 'SURFnet Autorisatie Beheer',
-    'consent_attribute_source_orcid'          => 'ORCID iD',
-    'consent_attribute_source_surfmarket_entitlements' => 'SURFmarket entitlements',
-    'consent_attribute_source_logo_url_voot'  => 'https://static.surfconext.nl/media/aa/voot.png',
-    'consent_attribute_source_logo_url_sab'   => 'https://static.surfconext.nl/media/aa/sab.png',
-    'consent_attribute_source_logo_url_orcid' => 'https://static.surfconext.nl/media/aa/orcid.png',
-    'consent_attribute_source_logo_url_surfmarket_entitlements' => 'https://static.surfconext.nl/media/aa/surfmarket_entitlements.png',
     'consent_buttons_title'                   => 'Ga je akkoord met het doorsturen van deze gegevens?',
     'consent_buttons_ok'                      => 'Ja, ga door naar %arg1%',
     'consent_buttons_nok'                     => 'Nee, ik ga niet akkoord',
-    'consent_footer_text_singular'            => 'Je gebruikt al één andere dienst via SURFconext. <a href="%arg1%" target="_blank">Bekijk hier het overzicht en je profielinformatie.</a>',
-    'consent_footer_text_plural'              => 'Je gebruikt al %arg1% diensten via SURFconext. <a href="%arg2%" target="_blank">Bekijk hier het overzicht en je profielinformatie.</a>',
-    'consent_footer_text_first_consent'       => 'Je gebruikt nog geen diensten via SURFconext. <a href="%arg1%" target="_blank">Bekijk hier je profielinformatie.</a>',
+    'consent_footer_text_singular'            => 'Je gebruikt al één andere dienst via %suiteName%. <a href="%arg1%" target="_blank">Bekijk hier het overzicht en je profielinformatie.</a>',
+    'consent_footer_text_plural'              => 'Je gebruikt al %arg1% diensten via %suiteName%. <a href="%arg2%" target="_blank">Bekijk hier het overzicht en je profielinformatie.</a>',
+    'consent_footer_text_first_consent'       => 'Je gebruikt nog geen diensten via %suiteName%. <a href="%arg1%" target="_blank">Bekijk hier je profielinformatie.</a>',
     'consent_slidein_details_email'           => 'Email',
     'consent_slidein_details_phone'           => 'Telefoon',
-    'consent_slidein_text_contact'            => 'Neem voor vragen hierover contact op met de helpdesk van je instelling. De volgende gegevens zijn bij SURFconext bekend:',
+    'consent_slidein_text_contact'            => 'Neem voor vragen hierover contact op met de helpdesk van je %organisationNoun%. De volgende gegevens zijn bij %suiteName% bekend:',
     'consent_slidein_text_no_support'         => 'Er zijn geen contactgegevens beschikbaar.',
 
     // Consent slidein: Kloppen de getoonde gegevens niet?
     'consent_slidein_correction_title' => 'Kloppen de getoonde gegevens niet?',
-    'consent_slidein_correction_text_idp'  => 'SURFconext ontvangt de gegevens rechtstreeks van jouw instelling en slaat deze zelf niet op. Neem contact op met de helpdesk van je instelling als je gegevens niet kloppen.',
-    'consent_slidein_correction_text_aa'  => 'SURFconext ontvangt de gegevens rechtstreeks van de attribuutbron en slaat deze zelf niet op. Neem contact op met de getoonde attribuutbron als je gegevens niet kloppen. Als je daarbij hulp nodig hebt, kun je contact opnemen met de helpdesk van je eigen instelling.',
+    'consent_slidein_correction_text_idp'  => '%suiteName% ontvangt de gegevens rechtstreeks van jouw %organisationNoun% en slaat deze zelf niet op. Neem contact op met de helpdesk van je %organisationNoun% als je gegevens niet kloppen.',
+    'consent_slidein_correction_text_aa'  => '%suiteName% ontvangt de gegevens rechtstreeks van de attribuutbron en slaat deze zelf niet op. Neem contact op met de getoonde attribuutbron als je gegevens niet kloppen. Als je daarbij hulp nodig hebt, kun je contact opnemen met de helpdesk van je eigen %organisationNoun%.',
     'consent_slidein_correction_details_title' => 'Contactgegevens %arg1%:',
 
-    // Consent slidein: About SURFconext
+    // Consent slidein: About OpenConext
     'consent_slidein_about_text'  => <<<'TXT'
-<h1>Inloggen met SURFconext</h1>
-<img src="/images/about-surfconext.png" alt="SURFconext diagram"/>
-<p>Via SURFconext loggen onderzoekers, medewerkers en studenten met hun eigen instellingsaccount veilig en gemakkelijk in bij clouddiensten van verschillende aanbieders. SURFconext biedt extra privacy-bescherming doordat een minimaal aantal persoonlijke gegevens wordt doorgegeven aan deze clouddiensten.</p>
-<p>Zien waar je al eerder toestemming voor hebt gegeven? Bekijk hier je <a href="%arg1%" target="_blank">SURFconext profielpagina</a>.</p>
-
-<h1>SURFconext is onderdeel van SURF</h1>
-<p>SURF is de ICT-samenwerkingsorganisatie van het onderwijs en onderzoek in Nederland.</p>
-<p>Dankzij SURF beschikken studenten, docenten en onderzoekers in Nederland over de best mogelijke ICT-voorzieningen voor toponderzoek en talentontwikkeling. Meer weten over SURF? Bekijk hier de <a href="https://www.surf.nl/" target="_blank">website van SURF</a>.</p>
-
+<h1>Inloggen met %suiteName%</h1>
+<p>Via %suiteName% loggen personen met hun eigen %accountNoun% veilig en gemakkelijk in bij clouddiensten van verschillende aanbieders. %suiteName% biedt extra privacy-bescherming doordat een minimaal aantal persoonlijke gegevens wordt doorgegeven aan deze clouddiensten.</p>
 TXT
     ,
 
@@ -170,9 +146,7 @@ TXT
     // Error screens
     'error_404'                         => '404 - Pagina niet gevonden',
     'error_404_desc'                    => 'De pagina is niet gevonden.',
-    'error_help_desc'                   => '<p>
-        Bezoek <a href="https://support.surfconext.nl/" target="_blank">de SURFconext support pagina\'s</a> voor ondersteuning bij deze foutmelding. Hier kun je ook vinden hoe je contact kunt opnemen met het supportteam als de fout aanblijft.
-    </p>',
+    'error_help_desc'                   => '<p></p>',
     'error_no_consent'                  => 'Niet mogelijk om verder te gaan naar dienst',
     'error_no_consent_desc'             => 'Deze applicatie kan enkel worden gebruikt wanneer de vermelde informatie wordt gedeeld.<br /><br />
 
@@ -180,24 +154,20 @@ Als je deze applicatie wilt gebruiken moet je:<br />
 <ul><li>de browser herstarten</li>
 <li>opnieuw inloggen</li>
 <li>jouw informatie delen</li></ul>',
-    'error_no_idps'                     => 'Error - Geen instellingen gevonden',
+    'error_no_idps'                     => 'Error - Geen %organisationNounPlural% gevonden',
     'error_no_idps_desc'                => '<p>
-        De dienst die je probeert te benaderen (de &lsquo;Service Provider&rsquo;) is niet toegankelijk via de SURFconext-infrastructuur.<br /><br />
-        Bezoek <a href="https://wiki.surfnet.nl/pages/viewpage.action?pageId=54691917" target="_blank">de SURFconext support pagina\'s</a> voor meer ondersteuning bij deze foutmelding, als je denkt daadwerkelijk toegang te moeten hebben tot deze dienst.
-        <br /><br />
+        De dienst die je probeert te benaderen (de &lsquo;Service Provider&rsquo;) is niet toegankelijk via de %suiteName%-infrastructuur.
     </p>',
     'error_session_lost'                => 'Error - Sessie is verloren gegaan',
     'error_session_lost_desc'           => '<p>
 We weten helaas niet waar je heen wilt. Heb je te lang gewacht? Probeer het dan eerst opnieuw. Accepteert je browser wel cookies? Maak je gebruik van een te oude link of bookmark?<br /><br />
-Bezoek <a href="https://wiki.surfnet.nl/pages/viewpage.action?pageId=52331093" target="_blank">de SURFconext support pagina\'s</a> voor meer ondersteuning bij deze foutmelding. Hier kun je ook vinden hoe je contact kunt opnemen met het supportteam als de fout aanblijft.
-        <br /><br />
     </p>',
 
     'error_authorization_policy_violation'            => 'Error - Geen toegang',
     'error_authorization_policy_violation_desc'       => '<p>
-        Je bent succesvol ingelogd bij jouw instelling, maar je kunt geen gebruik maken van deze dienst omdat je geen toegang hebt. Voor deze dienst (de &lsquo;Service Provider&rsquo;) heeft jouw instelling met <i>autorisatieregels</i> ingesteld dat alleen bepaalde gebruikers toegang krijgen. Neem contact op met de (IT-)servicedesk van je instelling als je vindt dat je wel toegang moet hebben.
+        Je bent succesvol ingelogd bij jouw %organisationNoun%, maar je kunt geen gebruik maken van deze dienst omdat je geen toegang hebt. Voor deze dienst (de &lsquo;Service Provider&rsquo;) heeft jouw %organisationNoun% met <i>autorisatieregels</i> ingesteld dat alleen bepaalde gebruikers toegang krijgen. Neem contact op met de (IT-)servicedesk van je %organisationNoun% als je vindt dat je wel toegang moet hebben.
     </p>',
-    'error_authorization_policy_violation_info'       => 'Bericht van je instelling: ',
+    'error_authorization_policy_violation_info'       => 'Bericht van je %organisationNoun%: ',
     'error_no_message'                  => 'Error - Geen bericht ontvangen',
     'error_no_message_desc'             => 'We verwachtten een bericht, maar we hebben er geen ontvangen. Er is iets fout gegaan. Probeer het alstublieft opnieuw.',
     'error_invalid_acs_location'        => 'De opgegeven "Assertion Consumer Service" is onjuist of bestaat niet.',
@@ -205,33 +175,30 @@ Bezoek <a href="https://wiki.surfnet.nl/pages/viewpage.action?pageId=52331093" t
     'error_invalid_acs_binding_desc'        => 'Het opgegeven of geconfigureerde "Assertion Consumer Service" Binding Type is onjuist of bestaat niet.',
     'error_unsupported_signature_method' => 'Ondertekeningsmethode wordt niet ondersteund',
     'error_unsupported_signature_method_desc' => 'De ondertekeningsmethode %arg1% wordt niet ondersteund, upgrade naar RSA-SHA256 (http://www.w3.org/2001/04/xmldsig-more#rsa-sha256).',
-    'error_unknown_preselected_idp' => 'Error - Instelling is niet gekoppeld aan dienst',
+    'error_unknown_preselected_idp' => 'Error - %organisationNoun% is niet gekoppeld aan dienst',
     'error_unknown_preselected_idp_desc' => '<p>
-        De instelling waarmee je wilt inloggen heeft toegang tot deze dienst niet geactiveerd. Dat betekent dat jij geen gebruik kunt maken van deze dienst via SURFconext. Neem contact op met de helpdesk van jouw instelling als je toegang wilt krijgen tot deze dienst. Geef daarbij aan om welke dienst het gaat (de &lsquo;Service Provider&rsquo;) en waarom je toegang wilt.
+        De %organisationNoun% waarmee je wilt inloggen heeft toegang tot deze dienst niet geactiveerd. Dat betekent dat jij geen gebruik kunt maken van deze dienst via %suiteName%. Neem contact op met de helpdesk van jouw %organisationNoun% als je toegang wilt krijgen tot deze dienst. Geef daarbij aan om welke dienst het gaat (de &lsquo;Service Provider&rsquo;) en waarom je toegang wilt.
     </p>',
     'error_unknown_service_provider'              => 'Error - Kan geen metadata ophalen voor EntityID \'%arg1%\'',
     'error_unknown_service_provider_desc'     => '<p>
         Er kon geen Service Provider worden gevonden met het opgegeven EntityID.
-        Neem contact op met de SURFconext helpdesk op <a href="mailto:help@surfconext.nl">help@surfconext.nl</a>.
     </p>',
 
     'error_unknown_issuer'              => 'Error - Onbekende dienst',
-    'error_unknown_issuer_desc'     => '<p>
-Je aangevraagde dienst kon niet worden gevonden. Bezoek <a href="https://wiki.surfnet.nl/pages/viewpage.action?pageId=53018683" target="_blank">de SURFconext support pagina\'s</a> voor meer ondersteuning bij deze foutmelding.
-    </p>',
+    'error_unknown_issuer_desc'     => '<p>Je aangevraagde dienst kon niet worden gevonden.</p>',
     'error_generic'                     => 'Error - Foutmelding',
     'error_generic_desc'                => '<p>
-Inloggen is niet gelukt en we kunnen je niet precies vertellen waarom. Probeer het eerst eens opnieuw, en bezoek anders <a href="https://wiki.surfnet.nl/pages/viewpage.action?pageId=52331091" target="_blank">de SURFconext support pagina\'s</a> voor ondersteuning bij deze foutmelding. Hier kun je ook vinden hoe je contact kunt opnemen met het supportteam als de fout aanblijft.
+Inloggen is niet gelukt en we kunnen je niet precies vertellen waarom. Probeer het eerst eens opnieuw, en neem anders contact op met het supportteam van uw %organisationNoun%.
     </p>',
     'error_missing_required_fields'     => 'Error - Verplichte velden ontbreken',
     'error_missing_required_fields_desc'=> '<p>
-        Jouw instelling geeft niet de benodigde informatie vrij. Daarom kun je deze applicatie niet gebruiken.
+        Jouw %organisationNoun% geeft niet de benodigde informatie vrij. Daarom kun je deze applicatie niet gebruiken.
     </p>
     <p>
-        Neem alstublieft contact op met jouw instelling. Geef hierbij de onderstaande informatie door.
+        Neem alstublieft contact op met jouw %organisationNoun%. Geef hierbij de onderstaande informatie door.
     </p>
     <p>
-        Omdat je instelling niet de juiste attributen aan SURFconext doorgeeft is het inloggen mislukt. De volgende attributen zijn vereist om succesvol in te loggen op het SURFconext platform:
+        Omdat je %organisationNoun% niet de juiste attributen aan %suiteName% doorgeeft is het inloggen mislukt. De volgende attributen zijn vereist om succesvol in te loggen op het %suiteName% platform:
         <ul>
             <li>UID</li>
             <li>schacHomeOrganization</li>
@@ -240,13 +207,13 @@ Inloggen is niet gelukt en we kunnen je niet precies vertellen waarom. Probeer h
 
     'error_received_error_status_code'     => 'Error - Fout bij Identity Provider',
     'error_received_error_status_code_desc'=> '<p>
-Je instelling heeft je de toegang geweigerd tot deze dienst. Je zult dus contact moeten opnemen met de (IT-)servicedesk van je eigen instelling om te kijken of dit verholpen kan worden.
+Je %organisationNoun% heeft je de toegang geweigerd tot deze dienst. Je zult dus contact moeten opnemen met de (IT-)servicedesk van je eigen %organisationNoun% om te kijken of dit verholpen kan worden.
     </p>',
     'error_received_invalid_response'        => 'Error - Ongeldig antwoord van Identity Provider',
     'error_received_invalid_signed_response' => 'Error - Ongeldige handtekening op antwoord Identity Provider',
     'error_stuck_in_authentication_loop' => 'Error - Je zat vast in een zwart gat',
     'error_stuck_in_authentication_loop_desc' => '<p>
-        Je bent succesvol ingelogd bij je Identity Provider maar de dienst waar je naartoe wilt stuurt je weer terug naar SURFconext. Omdat je succesvol bent ingelogd, stuurt SURFconext je weer naar de dienst, wat resulteert in een oneindig zwart gat. Dit komt waarschijnlijk door een foutje aan de kant van de dienst. Bezoek <a href="https://support.surfconext.nl" target="_blank">de SURFconext support pagina\'s</a> voor meer ondersteuning bij deze foutmelding.
+        Je bent succesvol ingelogd bij je Identity Provider maar de dienst waar je naartoe wilt stuurt je weer terug naar %suiteName%. Omdat je succesvol bent ingelogd, stuurt %suiteName% je weer naar de dienst, wat resulteert in een oneindig zwart gat. Dit komt waarschijnlijk door een foutje aan de kant van de dienst.
     </p>',
 
     /**
@@ -265,12 +232,12 @@ Je instelling heeft je de toegang geweigerd tot deze dienst. Je zult dus contact
     'error_attribute_validator_min'                 => '%arg1% heeft minimaal %arg2% waardes nodig (%arg3% gegeven)',
     'error_attribute_validator_max'                 => '%arg1% heeft maximaal %arg2% waardes (%arg3% gegeven)',
     'error_attribute_validator_regex'               => '\'%arg3%\' voldoet niet aan de voorwaarden voor waardes van dit attribuut (%arg2%)',
-    'error_attribute_validator_not_in_definitions'  => '%arg1% is niet bekend in het SURFconext schema',
+    'error_attribute_validator_not_in_definitions'  => '%arg1% is niet bekend in het schema',
     'error_attribute_validator_allowed'             => '\'%arg3%\' is geen toegestane waarde voor dit attribuut',
     'error_attribute_validator_availability'        => '\'%arg3%\' is a gereserveerde SchacHomeOrganization voor een andere Identity Provider',
 
-    'error_unknown_service'         => 'Error - Deze dienst is niet geregistreerd bij SURFconext.',
-    'error_unknown_service_desc'    => '<p>Deze dienst is niet bekend. Neem contact op met de SURFconext helpdesk op <a href="mailto:help@surfconext.nl">help@surfconext.nl</a></p>',
+    'error_unknown_service'         => 'Error - Deze dienst is niet geregistreerd bij %suiteName%.',
+    'error_unknown_service_desc'    => '<p>Deze dienst is niet bekend.</p>',
 
     'attributes_validation_succeeded' => 'Authenticatie geslaagd',
     'attributes_validation_failed'    => 'Sommige attributen kunnen niet gevalideerd worden',
@@ -280,13 +247,13 @@ Je instelling heeft je de toegang geweigerd tot deze dienst. Je zult dus contact
 
     'attributes' => 'Attributen',
     'validation' => 'Validatie',
-    'idp_debugging_mail_explain' => 'Indien gevraagd door SURFconext,
-                                        gebruik de "Mail naar SURFconext" knop hieronder
-                                        om de informatie op dit scherm naar SURFconext beheer te e-mailen.',
-    'idp_debugging_mail_button' => 'Mail naar SURFconext',
+    'idp_debugging_mail_explain' => 'Indien gevraagd door %suiteName%,
+                                        gebruik de "Mail naar %suiteName%" knop hieronder
+                                        om de informatie op dit scherm naar %suiteName% beheer te e-mailen.',
+    'idp_debugging_mail_button' => 'Mail naar %suiteName%',
 
     // Logout
     'logout' => 'uitloggen',
     'logout_description' => 'Deze applicatie maakt gebruik van centrale login. Hiermee is het mogelijk om met single sign on bij verschillende applicaties in te loggen. Om er 100% zeker van te zijn dat je uitgelogd bent, moet je de browser helemaal afsluiten.',
-    'logout_information_link' => '<a href="https://wiki.surfnet.nl/display/conextsupport/Uitloggen+SURFconext">Meer informatie over veilig uitloggen</a>',
-);
+    'logout_information_link' => '',
+];

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -377,9 +377,17 @@ class EngineBlock_Application_DiContainer extends Pimple
     /**
      * @return string
      */
+    public function getOpenConextSupportUrl()
+    {
+        return (string) $this->container->getParameter('openconext_support_url');
+    }
+
+    /**
+     * @return string
+     */
     public function getOpenConextTermsOfUseUrl()
     {
-        return (string) $this->container->getParameter('openconext_terms_of_use');
+        return (string) $this->container->getParameter('openconext_terms_of_use_url');
     }
 
     /**

--- a/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
@@ -109,9 +109,10 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
             return;
         }
 
+        $settings = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer();
         // Profile url is configurable in application.ini (profile.baseUrl)
         $profileUrl = '#';
-        $configuredUrl = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getProfileBaseUrl();
+        $configuredUrl = $settings->getProfileBaseUrl();
         if (!empty($configuredUrl)) {
             $profileUrl = $configuredUrl;
         }
@@ -128,6 +129,7 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
                 'attributeSources' => $this->getAttributeSources($request->getId()),
                 'consentCount' => $this->_consentService->countAllFor($response->getNameIdValue()),
                 'profileUrl' => $profileUrl,
+                'supportUrl' => $settings->getOpenConextSupportUrl(),
                 'hideHeader' => true,
                 'hideFooter' => true,
             ]

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -123,6 +123,13 @@ services:
         tags:
              - { name: 'twig.extension' }
 
+    engineblock.twig.extension.i18n:
+        class: OpenConext\EngineBlockBundle\Twig\Extensions\Extension\I18n
+        arguments:
+            - "@translator"
+        tags:
+             - { name: 'twig.extension' }
+
     engineblock.twig.extension.locale:
         class: OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Locale
         arguments:

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/I18n.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/I18n.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
+
+use Twig_Extensions_Extension_I18n;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class I18n extends Twig_Extensions_Extension_I18n implements \Twig_Extension_InitRuntimeInterface
+{
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * Returns a list of filters to add to the existing list.
+     *
+     * @return array An array of filters
+     */
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('trans', array($this, 'translateSingular')),
+            new \Twig_SimpleFilter('transchoice', array($this, 'translatePlural')),
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function translateSingular()
+    {
+        $args = func_get_args();
+        return call_user_func_array(
+            [$this->translator, 'trans'],
+            $this->prepareDefaultPlaceholders($args)
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function translatePlural()
+    {
+        $args = func_get_args();
+        return call_user_func_array(
+            [$this->translator, 'transChoice'],
+            $this->prepareDefaultPlaceholders($args)
+        );
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    private function prepareDefaultPlaceholders(array $args)
+    {
+        $args[1]['%suiteName%'] = $this->translator->trans('suite_name');
+        $args[1]['%organisationNoun%'] = $this->translator->trans('organisation_noun');
+        $args[1]['%organisationNounPlural%'] = $this->translator->trans('organisation_noun_plural');
+        $args[1]['%accountNoun%'] = $this->translator->trans('account_noun');
+
+        return $args;
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -181,7 +181,7 @@ Feature:
   Scenario: An SP sends a AuthnRequest transparently for an IdP that doesn't exist
      When I log in at SP "Dummy SP" which attempts to preselect nonexistent IdP "DoesNotExist"
      Then the url should match "/authentication/feedback/unknown-preselected-idp"
-      And I should see "No connection between institution and service"
+      And I should see "No connection between organisation and service"
       And I should see "Timestamp:"
       And I should see "Unique Request Id:"
       And I should see "User Agent:"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
@@ -17,7 +17,7 @@ Feature:
     And I pass through EngineBlock
     And I pass through the IdP
     And I should see "Error - No access"
-    And I should see "Message from your institution:"
+    And I should see "Message from your organisation:"
     And I should see "Students of MyIdP do not have access to this resource"
     And the response should contain "idp-logo.jpg"
 
@@ -28,7 +28,7 @@ Feature:
       And I pass through EngineBlock
       And I pass through the IdP
       And I should see "Error - No access"
-      And I should see "Message from your institution:"
+      And I should see "Message from your organisation:"
 
   Scenario: Access is denied because of an Indeterminate policy
     Given SP "Dummy SP" requires a policy enforcement decision
@@ -37,7 +37,7 @@ Feature:
       And I pass through EngineBlock
       And I pass through the IdP
       And I should see "Error - No access"
-      And I should see "Message from your institution:"
+      And I should see "Message from your organisation:"
 
   Scenario: Access is permitted because of a Permit policy
     Given SP "Dummy SP" requires a policy enforcement decision

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
@@ -93,7 +93,7 @@ Feature:
       And SP "Step Up" is a trusted proxy
       And SP "Step Up" signs its requests
      When I log in at "Step Up"
-     Then I should see "Select an institution to login to the service: Loa SP"
+     Then I should see "Select an organisation to login to the service: Loa SP"
       And I select "AlwaysAuth" on the WAYF
       And I pass through EngineBlock
       And I pass through the IdP

--- a/theme/material/templates/layouts/scripts/default.html.twig
+++ b/theme/material/templates/layouts/scripts/default.html.twig
@@ -88,7 +88,7 @@
 
                     {% if helpLink is defined %}
                     <li>
-                        <a href="{{ helpLink }}" target="_blank">{{ 'help'|trans }}</a>
+                        <a href="{{ helpLink }}" target="_blank">{{ 'help'|trans|capitalize }}</a>
                     </li>
                     {% endif %}
 

--- a/theme/material/templates/modules/Authentication/View/IdentityProvider/help-discover.html.twig
+++ b/theme/material/templates/modules/Authentication/View/IdentityProvider/help-discover.html.twig
@@ -10,45 +10,7 @@
 
 <div class="box">
   <div class="mod-content">
-    <h1>{{ 'help_header'|trans }}</h1>
-    <p>{{ 'help_description'|trans|raw }}</p>
-    <div class="results">
-      <ul id="faq" class="faq">
-          <li class="open">
-              <h3>{{ 'question_screen'|trans }}</h3>
-              {{ 'answer_screen'|trans|raw }}
-          </li>
-          <li>
-              <h3>{{ 'question_surfconext'|trans }}</h3>
-              {{ 'answer_surfconext'|trans|raw }}
-          </li>
-          <li>
-              <h3>{{ 'question_log_in'|trans }}</h3>
-              {{ 'answer_log_in'|trans|raw }}
-          </li>
-          <li>
-              <h3>{{ 'question_security'|trans }}</h3>
-              {{ 'answer_security'|trans|raw }}
-          </li>
-          <li>
-              <h3>{{ 'question_institution_not_listed'|trans }}</h3>
-              {{ 'answer_institution_not_listed'|trans|raw }}
-          </li>
-          <li>
-              <h3>{{ 'question_institution_no_access'|trans }}</h3>
-              {{ 'answer_institution_no_access'|trans|raw }}
-          </li>
-          <li>
-              <h3>{{ 'question_asked_institution_access'|trans }}</h3>
-              {{ 'answer_asked_institution_access'|trans|raw }}
-          </li>
-          <li>
-              <h3>{{ 'question_cannot_select'|trans }}</h3>
-              {{ 'answer_cannot_select'|trans|raw }}
-          </li>
-      </ul>
-    </div>
-
+        {{ 'help_page_content'|trans|raw }}
   </div>
 </div>
 {% endblock %}

--- a/theme/material/templates/modules/Authentication/View/IdentityProvider/request-access.html.twig
+++ b/theme/material/templates/modules/Authentication/View/IdentityProvider/request-access.html.twig
@@ -42,7 +42,7 @@
       </div>
 
       <div class="input">
-        <label for="institution">{{ 'institution'|trans }}:</label>
+        <label for="institution">{{ 'institution'|trans|capitalize }}:</label>
         <input name="institution" type="text" id="institution" value="{{ queryParameters['institution']|default('') }}" />
       </div>
 

--- a/theme/material/templates/modules/Authentication/View/Index/index.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Index/index.html.twig
@@ -11,7 +11,7 @@
         <h1>{{ subHeader }}</h1>
         <dl class="metadata-certificates-list">
             <dt>
-                The Public SAML Signing certificate of the SURFconext IdP
+                The Public SAML Signing certificate of the {{ 'suite_name'|trans }} IdP
             </dt>
             <dd>
                 <ul>
@@ -22,7 +22,7 @@
                 </ul>
             </dd>
             <dt>
-                The Public SAML metadata (the entity descriptor) of the SURFconext IdP Proxy
+                The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} IdP Proxy
             </dt>
             <dd>
                 <ul>
@@ -33,7 +33,7 @@
                 </ul>
             </dd>
             <dt>
-                The Public SAML metadata (the entities descriptor) for all the SURFconext IdPs
+                The Public SAML metadata (the entities descriptor) for all the {{ 'suite_name'|trans }} IdPs
             </dt>
             <dd>
                 <ul>
@@ -48,7 +48,7 @@
                     case you want a custom WAYF for your SP</p>
             </dt>
             <dt>
-                The Public SAML metadata (the entity descriptor) of the SURFconext IdP Proxy for SP
+                The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} IdP Proxy for SP
                 with entityID "urn:example.org". Please replace "urn:example.org" with the entityID
                 of your own SP before testing this metadata request. The resulting metadata will include
                 the public key specific to your Service Provider, which, in the case of key rollover,
@@ -63,11 +63,11 @@
                 </ul>
             </dd>
             <dt>
-                The Public SAML metadata (the entities descriptor) of the SURFconext IdPs which allow
+                The Public SAML metadata (the entities descriptor) of the {{ 'suite_name'|trans }} IdPs which allow
                 access to SP with entityID "urn:example.org". Please replace "urn:example.org" with
                 the entityID of your own SP before testing. The resulting metadata will include all
-                SURFconext IdPs that allow access to the service, as well as the SP metadata, if
-                configured for SURFconext. Please note this information is generated dynamically, so
+                {{ 'suite_name'|trans }} IdPs that allow access to the service, as well as the SP metadata, if
+                configured for {{ 'suite_name'|trans }}. Please note this information is generated dynamically, so
                 the number of available IdPs may change over time.
             </dt>
             <dd>
@@ -94,7 +94,7 @@
                   </ul>
               </dd>
               <dt>
-                  The Public SAML Signing certificate of the SURFconext SP
+                  The Public SAML Signing certificate of the {{ 'suite_name'|trans }} SP
               </dt>
               <dd>
                   <ul>
@@ -105,7 +105,7 @@
                   </ul>
               </dd>
               <dt>
-                  The Public SAML metadata (the entity descriptor) of the SURFconext SP Proxy
+                  The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} SP Proxy
               </dt>
               <dd>
                   <ul>
@@ -122,7 +122,7 @@
           <h1>eduGAIN Metadata</h1>
           <dl class="metadata-certificates-list">
               <dt>
-                  The SURFconext eduGain SAML metadata consists out of all IdPs and SPs that are included of
+                  The {{ 'suite_name'|trans }} eduGain SAML metadata consists out of all IdPs and SPs that are included of
                   the <a href="http://mds.edugain.org/" data-external-link="true" target="_blank">eduGain metadata</a>.
               </dt>
               <dd>

--- a/theme/material/templates/modules/Authentication/View/Proxy/consent-slidein-about.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/consent-slidein-about.html.twig
@@ -3,8 +3,8 @@
   <div class="mod-content">
     <a class="close" href="#">{{ 'slidein_close'|trans }}</a>
     <section>
-        {{ 'consent_slidein_about_text'|trans({'%arg1%': profileUrl})|raw }}
+        {{ 'consent_slidein_about_text'|trans({'%profileUrl%': profileUrl})|raw }}
     </section>
-    <a href="https://support.surfconext.nl/">{{ 'slidein_read_more'|trans }}</a>
+    <a href="{{ supportUrl }}">{{ 'slidein_read_more'|trans }}</a>
   </div>
 </div>

--- a/theme/material/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -133,7 +133,7 @@
                     {% elseif consentCount == 1 %}
                         {{ 'consent_footer_text_singular'|trans({'%arg1%': profileUrl})|raw }}
                     {% else %}
-                        {{ 'consent_footer_text_plural'|trans({'%arg1%%': consentCount, '%arg2%': profileUrl})|raw }}
+                        {{ 'consent_footer_text_plural'|trans({'%arg1%': consentCount, '%arg2%': profileUrl})|raw }}
                     {% endif %}
                 </p>
             </footer>

--- a/theme/material/templates/modules/Authentication/View/Proxy/debug-idp-response.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/debug-idp-response.html.twig
@@ -113,7 +113,7 @@
                     <thead>
                     <tr>
                         <th>
-                            SURFconext Display Name
+                            {{ 'suite_name'|trans }} Display Name
                         </th>
                         <th>
                             {{ 'name'|trans }}

--- a/theme/material/templates/modules/Authentication/View/Proxy/wayf.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/wayf.html.twig
@@ -39,7 +39,7 @@
         {% if rememberChoiceFeature %}
         <div id="rememberChoiceDiv" class="selection mod-results">
             <header>
-                <h2>{{ 'idps_with_access'|trans }}</h2>
+                <h2>{{ 'idps_with_access'|trans|capitalize }}</h2>
                 <form method="post" action="{{ action }}">
                     <label for="rememberChoice">{{ 'remember_choice'|trans }}</label>
                     <input type="checkbox" name="rememberChoice" id="rememberChoice"/>
@@ -48,7 +48,7 @@
             {% else %}
             <div class="selection mod-results">
                 <header>
-                    <h2>{{ 'idps_with_access'|trans }}</h2>
+                    <h2>{{ 'idps_with_access'|trans|capitalize }}</h2>
                 </header>
                 {% endif %}
 
@@ -94,7 +94,7 @@
             <div id="unconnected-idp-picker" class="idp-picker hidden">
                 <div class="selection mod-results">
                     <header>
-                        <h2>{{ 'idps_without_access'|trans }}</h2>
+                        <h2>{{ 'idps_without_access'|trans|capitalize }}</h2>
                     </header>
 
                     <div class="idp-list">


### PR DESCRIPTION
See the upgrade instructions for a detailed description of the
changes. In summary, the following words are dynamically injected into
the translations in order to have a sane set of default translations
not specifically targeted to the educational world:
    
 - %suiteName%:
   - OpenConext (default)
   - SURFconext, ACMEconext (example overrides)


 - %organisationNoun%:
   - organisation/organisatie (default)
   - institution/instelling (example overrides)


 - %organisationNounPlural%:
   - organisations/organisaties (default)
   - institutions/instellingen (example overrides)


 - %accountNoun%:
   - organisation account/organisatieaccount (default)
   - institutional account/instellingsaccount (example overrides)
    
The WAYF help page is a special case because the questions and answers
all have their own translation key, and those questions can be
considered specific to SURFconext. So the help page is now simplified
to just render one single "translatable" blob of HTML. The default
content for the help page is "No help content available" - this
content can of course be overridden in overrides.[lang].php.
    
See: https://www.pivotaltracker.com/story/show/155467582