### PR TITLE
Support old and new NameId style in AM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,9 @@ branches:
   only:
     - 5.x-dev
     - master
+    - release/5.5
+    - release/5.5.2
+    - release/5.6
 
 addons:
   hosts:

--- a/library/EngineBlock/Saml2/NameIdResolver.php
+++ b/library/EngineBlock/Saml2/NameIdResolver.php
@@ -37,8 +37,8 @@ class EngineBlock_Saml2_NameIdResolver
         $collabPersonId
     ) {
         $customNameId = $response->getCustomNameId();
-        if (!empty($customNameId)) {
-            return NameID::fromArray($customNameId);
+        if (!is_null($customNameId)) {
+            return $customNameId;
         }
 
         $nameIdFormat = $this->_getNameIdFormat($request, $destinationMetadata);

--- a/library/EngineBlock/Saml2/ResponseAnnotationDecorator.php
+++ b/library/EngineBlock/Saml2/ResponseAnnotationDecorator.php
@@ -3,6 +3,7 @@
 use SAML2\Assertion;
 use SAML2\EncryptedAssertion;
 use SAML2\Response;
+use SAML2\XML\saml\NameID;
 
 /**
  * Annotate the response with our own metadata
@@ -29,7 +30,7 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     protected $originalIssuer;
 
     /**
-     * @var null|\SAML2\XML\saml\NameID
+     * @var null|NameID
      */
     protected $originalNameId;
 
@@ -49,7 +50,7 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     protected $collabPersonId;
 
     /**
-     * @var array
+     * @var NameID
      */
     protected $customNameId;
 
@@ -80,7 +81,7 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     }
 
     /**
-     * @return \SAML2\XML\saml\NameID|null The name identifier of the assertion.
+     * @return NameID|null The name identifier of the assertion.
      */
     public function getNameId()
     {
@@ -159,17 +160,30 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     }
 
     /**
-     * @param null|\SAML2\XML\saml\NameID $originalNameId
+     * @param array|NameID|null $originalNameId
      * @return $this
+     * @throws EngineBlock_Exception
      */
     public function setOriginalNameId($originalNameId)
     {
+        // This is added to support old style manipulation code where NameID is represented as an array
+        if (is_array($originalNameId)) {
+            $originalNameId = NameID::fromArray($originalNameId);
+        }
+
+        if (!$originalNameId instanceof NameID && !is_null($originalNameId)) {
+            throw new EngineBlock_Exception(
+                'An unsupported type for OriginalNameId was provided. It can either be array, NameID or null'
+            );
+        }
+
         $this->originalNameId = $originalNameId;
+
         return $this;
     }
 
     /**
-     * @return null|\SAML2\XML\saml\NameID
+     * @return null|NameID
      */
     public function getOriginalNameId()
     {
@@ -177,17 +191,29 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     }
 
     /**
-     * @param array $customNameId
+     * @param $customNameId
      * @return $this
+     * @throws EngineBlock_Exception
      */
-    public function setCustomNameId(array $customNameId)
+    public function setCustomNameId($customNameId)
     {
+        // This is added to support old style manipulation code where NameID is represented as an array
+        if (is_array($customNameId)) {
+            $customNameId = NameID::fromArray($customNameId);
+        }
+
+        if (!$customNameId instanceof NameID && !is_null($customNameId)) {
+            throw new EngineBlock_Exception(
+                'An unsupported type for CustomNameId was provided. It can either be array, NameID or null'
+            );
+        }
+
         $this->customNameId = $customNameId;
         return $this;
     }
 
     /**
-     * @return array
+     * @return NameID
      */
     public function getCustomNameId()
     {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
@@ -117,6 +117,24 @@ Feature:
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonTargetedID"]/saml:AttributeValue/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="NOOT"]'
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="NOOT"]'
 
+  Scenario: The Service Provider can handle NameID value objects
+    Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
+      """
+      $nameId = new \SAML2\XML\saml\NameID();
+      $nameId->Format = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient';
+      $nameId->value = 'NOOT';
+      $response['__']['CustomNameId'] = $nameId;
+      """
+    When I log in at "SP-with-Attribute-Manipulations"
+    And I select "Dummy-IdP" on the WAYF
+    And I pass through EngineBlock
+    And I pass through the IdP
+    When I give my consent
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonTargetedID"]/saml:AttributeValue/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="NOOT"]'
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="NOOT"]'
+
   Scenario: The Service Provider cannot have the SubjectID manipulated by manipulating the responseObj using the unspecified NameID Format
     Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
       """
@@ -154,6 +172,3 @@ Feature:
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonTargetedID"]/saml:AttributeValue/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]'
      And the response should not match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" and text()="NOOT"]'
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]'
-
-#
-#  Scenario: Sp and IdP attribute manipulations

--- a/tests/library/EngineBlock/Test/Saml2/NameIdResolverTest.php
+++ b/tests/library/EngineBlock/Test/Saml2/NameIdResolverTest.php
@@ -70,7 +70,73 @@ class EngineBlock_Test_Saml2_NameIdResolverTest extends PHPUnit_Framework_TestCa
 
         // Test
         $this->assertEquals(NameID::fromArray($nameId), $resolvedNameID, 'CustomNameId is used');
+        $this->assertEquals(NameID::fromArray($nameId), $this->response->getCustomNameId());
     }
+
+    public function testSetCustomNameIdWithObject()
+    {
+        // Input
+        $nameId = new NameID();
+        $nameId->value = 'test-value';
+        $nameId->Format = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient';
+
+        $this->response->setCustomNameId($nameId);
+
+        // Run
+        $resolvedNameID = $this->resolver->resolve($this->request, $this->response, $this->serviceProvider, $this->collabPersonId);
+
+        // Test
+        $this->assertEquals($nameId, $resolvedNameID, 'CustomNameId is used');
+        $this->assertEquals($nameId, $this->response->getCustomNameId());
+    }
+
+    public function testSetCustomNameIdCanBeNull()
+    {
+        $this->response->setCustomNameId(null);
+        $this->assertNull($this->response->getCustomNameId());
+    }
+
+    public function testSetCustomNameIdThrowsError()
+    {
+        $this->expectException(EngineBlock_Exception::class);
+        $this->expectExceptionMessage('An unsupported type for CustomNameId was provided. It can either be array, NameID or null');
+        $this->response->setCustomNameId('Throw exception');
+    }
+
+    public function testSetOriginalNameIdFromArray()
+    {
+        $nameId = array(
+            'Format' => '',
+            'Value' => '',
+        );
+        $this->response->setOriginalNameId($nameId);
+        $this->assertEquals(NameID::fromArray($nameId), $this->response->getOriginalNameId());
+    }
+
+    public function testSetOriginalNameIdWithObject()
+    {
+        $nameId = new NameID();
+        $nameId->value = 'test-value';
+        $nameId->Format = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient';
+
+        $this->response->setOriginalNameId($nameId);
+
+        $this->assertEquals($nameId, $this->response->getOriginalNameId());
+    }
+
+    public function testSetOriginalNameIdCanBeNull()
+    {
+        $this->response->setOriginalNameId(null);
+        $this->assertNull($this->response->getOriginalNameId());
+    }
+
+    public function testSetOriginalNameIdThrowsError()
+    {
+        $this->expectException(EngineBlock_Exception::class);
+        $this->expectExceptionMessage('An unsupported type for OriginalNameId was provided. It can either be array, NameID or null');
+        $this->response->setOriginalNameId('Throw exception');
+    }
+
 
     public function testNameIdPolicyInAuthnRequest()
     {


### PR DESCRIPTION
The old style (array format) and new style (object of type NameID) are
 now supported in the ResponseAnnotationDecorator.

For more context see [Pivotal](https://www.pivotaltracker.com/story/show/155705429)

:information_source: Note that the build fails on the Security Checker. `paragonie/random_compat` can be patched (which is done in version 5.7) but is postponed for version 5.6 as we are not vulnerable.