### PR TITLE
Add functional tests for scoped AuthnRequest

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -500,4 +500,18 @@ class MockSpContext extends AbstractSubContext
             ->displayUnconnectedIdpsForSp($sp->entityId(), false)
             ->save();
     }
+
+    /**
+     * @Given /^SP "([^"]*)" scopes its request to IDP "([^"]*)"$/
+     */
+    public function spAuthnRequestScopedToIdp($spName, $idpName)
+    {
+        /** @var MockServiceProvider $mockSp */
+        $mockSp = $this->mockSpRegistry->get($spName);
+        $mockIdp = $this->mockIdpRegistry->get($idpName);
+
+        $mockSp->addIdpToScope($mockIdp->entityId());
+
+        $this->mockSpRegistry->save();
+    }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOnWithScoping.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOnWithScoping.feature
@@ -1,0 +1,29 @@
+Feature:
+  In order for a service provider to pre-select one or more IDPs
+  As EngineBlock
+  I want to limit the available IDPs in the WAYF based on the scoping in the AuthnRequest
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+      And no registered SPs
+      And no registered Idps
+      And an Identity Provider named "IDP1"
+      And an Identity Provider named "IDP2"
+      And an Identity Provider named "IDP3"
+      And an Identity Provider named "IDP4"
+      And a Service Provider named "SP"
+
+  Scenario: The AuthnRequest is scoped to a single IDP
+    Given SP "SP" scopes its request to IDP "IDP1"
+    When I log in at "SP"
+     And I pass through EngineBlock
+    Then the url should match "functional-testing/IDP1/sso"
+
+  Scenario: The AuthnRequest is scoped to multiple IDPs
+    Given SP "SP" scopes its request to IDP "IDP3"
+      And SP "SP" scopes its request to IDP "IDP4"
+    When I log in at "SP"
+    Then I should not see "IDP1"
+    Then I should not see "IDP2"
+    Then I should see "IDP3"
+    Then I should see "IDP4"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockServiceProvider.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockServiceProvider.php
@@ -127,6 +127,25 @@ class MockServiceProvider extends AbstractMockEntityRole
         $this->descriptor->Extensions['SAMLRequest']->setIsPassive(true);
     }
 
+    /**
+     * @param string $idpEntityId
+     */
+    public function addIdpToScope($idpEntityId)
+    {
+        $scope = $this->getScoping();
+        $scope[] = $idpEntityId;
+
+        $this->descriptor->Extensions['SAMLRequest']->setIDPList($scope);
+    }
+
+    /**
+     * @return array
+     */
+    public function getScoping()
+    {
+        return $this->descriptor->Extensions['SAMLRequest']->getIDPList();
+    }
+
     protected function getRoleClass()
     {
         return SPSSODescriptor::class;


### PR DESCRIPTION
Scoped authn requests should limit the selection of available IDPs in
the WAYF, or pre-select an IDP if only a single IDP is scoped.