### PR TITLE
Prevent unfiltered results in cached metadata repository

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
@@ -68,6 +68,8 @@ class CachedDoctrineMetadataRepository implements MetadataRepositoryInterface
     {
         $this->repository->appendFilter($filter);
 
+        $this->clearResultsCache();
+
         return $this;
     }
 
@@ -79,7 +81,23 @@ class CachedDoctrineMetadataRepository implements MetadataRepositoryInterface
     {
         $this->repository->appendVisitor($visitor);
 
+        $this->clearResultsCache();
+
         return $this;
+    }
+
+    /**
+     * Reset the results cache.
+     *
+     * The cache is only valid for a specific combination of filters and
+     * visitors. If a filter or visitor is appended, the previously cached
+     * results are discarded by calling this method. In practice,
+     * visitor/filter setup is only done in the beginning of the request so
+     * resetting the cache has little impact on the total number of queries.
+     */
+    private function clearResultsCache()
+    {
+        $this->cache = array();
     }
 
     /**

--- a/tests/unit/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepositoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepositoryTest.php
@@ -6,7 +6,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mockery;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\Filter\FilterInterface;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\DisableDisallowedEntitiesInWayfVisitor;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -58,5 +60,27 @@ class CachedDoctrineMetadataRepositoryTest extends PHPUnit_Framework_TestCase
 
         $repository = new CachedDoctrineMetadataRepository($doctrineRepository);
         $repository->fetchServiceProviderByEntityId('test');
+    }
+
+    public function testAppendVisitor()
+    {
+        $doctrineRepository = Mockery::mock('OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataRepository');
+        $doctrineRepository->shouldReceive('appendVisitor');
+
+        $repository = new CachedDoctrineMetadataRepository($doctrineRepository);
+        $repository->appendVisitor(
+            Mockery::mock(VisitorInterface::class)
+        );
+    }
+
+    public function testAppendFilter()
+    {
+        $doctrineRepository = Mockery::mock('OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataRepository');
+        $doctrineRepository->shouldReceive('appendFilter');
+
+        $repository = new CachedDoctrineMetadataRepository($doctrineRepository);
+        $repository->appendFilter(
+            Mockery::mock(FilterInterface::class)
+        );
     }
 }


### PR DESCRIPTION
Cached results are only valid for a specific combination of filters
and visitors. If a filter or visitor is appended, the previously
cached results should be discarded. In practice, visitor/filter setup
is only done in the beginning of the request so resetting the cache
has little impact on the total number of queries.

While no bug has been found in EB5.7 (all queries are executed after
setting up the filters) not solving this issue in the repository will
open the door for future bugs if some metadata is queried before
setting up the filters.