### PR TITLE
Load initialize() when the page has been completely loaded

### DIFF
--- a/theme/material/javascripts/application.js
+++ b/theme/material/javascripts/application.js
@@ -133,4 +133,4 @@ function showElement(element) {
     element.className = element.className.replace(pattern, '');
 }
 
-initialize();
+window.onload = initialize();


### PR DESCRIPTION
Occasionally, users get the JavaScript-error "Uncaught TypeError: Cannot read property 'className' of undefined".
Some research showed that this occurs when the DOM-structure has not been loaded completely at script execution. This PR should prevent this (admittely somewhat edgecase) from happening.

![js_error](https://user-images.githubusercontent.com/841045/39998974-fd4f5a58-5787-11e8-8575-f51e901eec18.png)