### PR TITLE
Fix requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ramsey/uuid": "^3.3.0",
         "sensio/generator-bundle": "^3.0",
         "guzzlehttp/guzzle": "^6.0",
+        "liip/functional-test-bundle": "^1.7",
         "openconext/monitor-bundle": "^1.0",
         "swiftmailer/swiftmailer": "^5.4",
         "symfony/swiftmailer-bundle": "^2.6",
@@ -47,7 +48,6 @@
         "mockery/mockery": "0.9.4",
         "phpunit/phpunit": "^5.6",
         "sebastian/version": "^2.0",
-        "liip/functional-test-bundle": "^1.7",
         "ingenerator/behat-tableassert": "^1.1"
     },
     "scripts": {


### PR DESCRIPTION
When running bin/composer.phar install --no-dev:

PHP Fatal error:  Class 'Liip\FunctionalTestBundle\LiipFunctionalTestBundle' not found in /apps/components/engineblock/OpenConext-engineblock-5.7.0/app/AppKernel.php on line 37

It is actually a requirement