### PR TITLE
Fix error in PDP policy decision error page

### DIFF
--- a/src/OpenConext/EngineBlockBridge/ErrorReporter.php
+++ b/src/OpenConext/EngineBlockBridge/ErrorReporter.php
@@ -75,10 +75,7 @@ class ErrorReporter
         if ($exception instanceof EngineBlock_Corto_Exception_ReceivedErrorStatusCode) {
             $feedback = array_merge($feedback, $exception->getFeedbackInfo());
         } elseif ($exception instanceof EngineBlock_Corto_Exception_PEPNoAccess) {
-            $feedback = array_merge(
-                $feedback,
-                ['error_authorization_policy_decision' => $exception->getPolicyDecision()]
-            );
+            $_SESSION['error_authorization_policy_decision'] = $exception->getPolicyDecision();
         }
 
         $_SESSION['feedbackInfo'] = array_merge(

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -276,9 +276,9 @@ class FeedbackController
         $logo = null;
         $policyDecisionMessage = null;
 
-        if (isset($_SESSION['feedbackInfo']['error_authorization_policy_decision'])) {
+        if (isset($_SESSION['error_authorization_policy_decision'])) {
             /** @var PolicyDecision $policyDecision */
-            $policyDecision = $_SESSION['feedbackInfo']['error_authorization_policy_decision'];
+            $policyDecision = $_SESSION['error_authorization_policy_decision'];
 
             if ($policyDecision->hasLocalizedDenyMessage()) {
                 $policyDecisionMessage = $policyDecision->getLocalizedDenyMessage($locale, 'en');

--- a/theme/material/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
@@ -24,5 +24,6 @@
     {% endif %}
 {% endblock %}
 
-{# The PDP error page should not show the table with the feedback information. #}
+{# The PDP error page should not show the table with the feedback information and back button. #}
 {% block feedbackInfo %}{% endblock %}
+{% block backButton %}{% endblock %}

--- a/theme/material/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
@@ -23,3 +23,6 @@
         {{ 'error_authorization_policy_violation_desc'|trans|raw }}
     {% endif %}
 {% endblock %}
+
+{# The PDP error page should not show the table with the feedback information. #}
+{% block feedbackInfo %}{% endblock %}

--- a/theme/material/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
@@ -20,8 +20,8 @@
 
     {% if policyDecisionMessage is not null %}
         <h2>{{ policyDecisionMessage }}</h2>
-        {{ 'error_authorization_policy_violation_desc'|trans|raw }}
     {% endif %}
+    {{ 'error_authorization_policy_violation_desc'|trans|raw }}
 {% endblock %}
 
 {# The PDP error page should not show the table with the feedback information and back button. #}

--- a/theme/material/templates/modules/Default/View/Error/error.html.twig
+++ b/theme/material/templates/modules/Default/View/Error/error.html.twig
@@ -33,10 +33,12 @@
 
             <p>{{ 'error_help_desc'|trans|raw }}</p>
 
+            {% block backButton %}
             {# @todo make the number of steps in history that the back button makes dynamic, it is not always 2 #}
             <a href="#" id="GoBack" class="c-button" onclick="history.back(-2); return false;">
                 {{ 'go_back'|trans|raw }}
             </a>
+            {% endblock %}
 
             {% if exception is defined %}
                 <div class="l-overflow">

--- a/theme/material/templates/modules/Default/View/Error/error.html.twig
+++ b/theme/material/templates/modules/Default/View/Error/error.html.twig
@@ -11,6 +11,7 @@
             <h1>{% block pageTitle %}{% endblock %}</h1>
             {% block errorMessage %}{% endblock %}
 
+            {% block feedbackInfo %}
             <div class="l-overflow">
                 <table class="comp-table">
                     <thead></thead>
@@ -28,6 +29,7 @@
                     </tbody>
                 </table>
             </div>
+            {% endblock %}
 
             <p>{{ 'error_help_desc'|trans|raw }}</p>
 


### PR DESCRIPTION
PR #529 describes a bug in the policy-decision violation page.

EB5.7 streamlined all error pages: they now all show the 'feedback
info' table. But for PDP errors, the feedbackInfo session entry
contains an object holding the PDP failure - which cannot be cast to
string and should not be shown in the table.

This PR fixes the problem by not storing the PDP object into
'feedbackInfo', so the table can be safely rendered on the PDP error
page.