### PR TITLE
Allow enforcing requesterid on trusted proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ features.
  * References to Janus have been removed #581
  * Remove attribute_aggregation_required metadata setting #572
  * Symfony was upgraded to 2.8.44 to harden against CVE-2018-14773 #582
+ * Add requesterid_required metadata setting to enforce the use of a RequesterId on trusted proxies (#540)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,6 +25,14 @@ feature should be enabled based on the existence (or lack of) source indications
 This changes means that a column was dropped from the `sso_provider_roles_eb5` schema. Running the `Version20180724175453`
 migration takes care of this. Leaving the column in the database should not prove problematic for the time being.
 
+### RequesterId required setting
+The use of a RequesterId can now be enforced on a trusted proxy. To do so, a new metadata flag can be set in the metadata
+repository (Manage).
+
+This change means that a column was added from the `sso_provider_roles_eb5` schema. Running the `Version20180804090135`
+migration takes care of this.
+
+
 ## 5.7 -> 5.8
 
 ### Stored metadata incompatibility

--- a/database/DoctrineMigrations/Version20180804090135.php
+++ b/database/DoctrineMigrations/Version20180804090135.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180610194638 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD requesterid_required TINYINT(1) DEFAULT NULL AFTER attribute_aggregation_required');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP requesterid_required');
+    }
+}

--- a/library/EngineBlock/SamlHelper.php
+++ b/library/EngineBlock/SamlHelper.php
@@ -89,6 +89,12 @@ class EngineBlock_SamlHelper
         $lastRequesterEntityId = end($requesterIds);
 
         if (!$lastRequesterEntityId) {
+            if ($serviceProvider->requesteridRequired) {
+                throw new EngineBlock_Exception_UnknownServiceProvider(
+                    $serviceProvider,
+                    'No RequesterID specified'
+                );
+            }
             return null;
         }
 

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -189,6 +189,14 @@ class PushMetadataAssembler
             'policyEnforcementDecisionRequired'
         );
 
+        $properties += $this->setPathFromObject(
+            array(
+                $connection,
+                'metadata:coin:requesterid_required'
+            ),
+            'requesteridRequired'
+        );
+
         return Utils::instantiate(
             'OpenConext\EngineBlock\Metadata\Entity\ServiceProvider',
             $properties

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
@@ -59,6 +59,9 @@ class CortoDisassembler
         if ($entity->isAttributeAggregationRequired()) {
             $cortoEntity['AttributeAggregationRequired'] = true;
         }
+        if ($entity->requesteridRequired) {
+            $cortoEntity['requesteridRequired'] = true;
+        }
 
         return $cortoEntity;
     }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @package OpenConext\EngineBlock\Metadata\Entity
  * @ORM\Entity
  * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
  */
 class ServiceProvider extends AbstractRole
@@ -100,6 +101,13 @@ class ServiceProvider extends AbstractRole
     public $policyEnforcementDecisionRequired;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="requesterid_required", type="boolean")
+     */
+    public $requesteridRequired;
+
+    /**
      * @var null|RequestedAttribute[]
      *
      * @ORM\Column(name="requested_attributes", type="array")
@@ -157,6 +165,7 @@ class ServiceProvider extends AbstractRole
      * @param null $requestedAttributes
      * @param bool $skipDenormalization
      * @param bool $policyEnforcementDecisionRequired
+     * @param bool $requesteridRequired
      * @param string $manipulation
      * @param AttributeReleasePolicy $attributeReleasePolicy
      * @param string|null $supportUrlEn
@@ -202,6 +211,7 @@ class ServiceProvider extends AbstractRole
         $requestedAttributes = null,
         $skipDenormalization = false,
         $policyEnforcementDecisionRequired = false,
+        $requesteridRequired = false,
         $manipulation = '',
         AttributeReleasePolicy $attributeReleasePolicy = null,
         $supportUrlEn = null,
@@ -248,6 +258,7 @@ class ServiceProvider extends AbstractRole
         $this->requestedAttributes = $requestedAttributes;
         $this->skipDenormalization = $skipDenormalization;
         $this->policyEnforcementDecisionRequired = $policyEnforcementDecisionRequired;
+        $this->requesteridRequired = $requesteridRequired;
         $this->supportUrlEn = $supportUrlEn;
         $this->supportUrlNl = $supportUrlNl;
     }


### PR DESCRIPTION
As per mailinglist discussion:
https://groups.google.com/forum/#!topic/openconext/riXK5xjacIw

Default (current) behaviour:
Trusted proxy sets no requesterId > all attributes are released

New behaviour when 'requesterid_required' is true:
Trusted proxy sets no requesterid > Raise unknown service exception