### PR TITLE
Array of value types and array of values have different size

### DIFF
--- a/library/EngineBlock/Corto/Filter/Abstract.php
+++ b/library/EngineBlock/Corto/Filter/Abstract.php
@@ -3,6 +3,7 @@
 use EngineBlock_Corto_Filter_Command_CollabPersonIdModificationInterface as CollabPersonIdModificationInterface;
 use EngineBlock_Corto_Filter_Command_ResponseAttributeSourcesModificationInterface as ResponseAttributeSourcesModificationInterface;
 use EngineBlock_Corto_Filter_Command_ResponseAttributesModificationInterface as ResponseAttributesModificationInterface;
+use EngineBlock_Corto_Filter_Command_ResponseAttributeValueTypesModificationInterface as ResponseAttributeValueTypesModificationInterface;
 use EngineBlock_Corto_Filter_Command_ResponseModificationInterface as ResponseModificationInterface;
 use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
 use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;
@@ -33,6 +34,8 @@ abstract class EngineBlock_Corto_Filter_Abstract
      * @param IdentityProvider                            $identityProvider
      * @throws EngineBlock_Exception
      * @throws Exception
+     *
+     * @see \EngineBlock_Corto_ProxyServer::callAttributeFilter is where this filter is applied.
      */
     public function filter(
         EngineBlock_Saml2_ResponseAnnotationDecorator &$response,
@@ -91,6 +94,9 @@ abstract class EngineBlock_Corto_Filter_Abstract
             }
             if ($command instanceof ResponseAttributesModificationInterface) {
                 $responseAttributes = $command->getResponseAttributes();
+            }
+            if ($command instanceof ResponseAttributeValueTypesModificationInterface) {
+                $response->getAssertion()->setAttributesValueTypes($command->getResponseAttributeValueTypes());
             }
             if ($command instanceof ResponseAttributeSourcesModificationInterface) {
                 $_SESSION[$request->getId()]['attribute_sources'] = $command->getResponseAttributeSources();

--- a/library/EngineBlock/Corto/Filter/Command/Abstract.php
+++ b/library/EngineBlock/Corto/Filter/Command/Abstract.php
@@ -26,6 +26,11 @@ abstract class EngineBlock_Corto_Filter_Command_Abstract implements EngineBlock_
     protected $_responseAttributes;
 
     /**
+     * @var array
+     */
+    protected $_responseAttributeValueTypes = [];
+
+    /**
      * @var EngineBlock_Saml2_AuthnRequestAnnotationDecorator
      */
     protected $_request;

--- a/library/EngineBlock/Corto/Filter/Command/AttributeReleasePolicy.php
+++ b/library/EngineBlock/Corto/Filter/Command/AttributeReleasePolicy.php
@@ -1,7 +1,8 @@
 <?php
 
-class EngineBlock_Corto_Filter_Command_AttributeReleasePolicy extends EngineBlock_Corto_Filter_Command_Abstract
-    implements EngineBlock_Corto_Filter_Command_ResponseAttributesModificationInterface
+class EngineBlock_Corto_Filter_Command_AttributeReleasePolicy extends EngineBlock_Corto_Filter_Command_Abstract implements
+    EngineBlock_Corto_Filter_Command_ResponseAttributesModificationInterface,
+    EngineBlock_Corto_Filter_Command_ResponseAttributeValueTypesModificationInterface
 {
     /**
      * {@inheritdoc}
@@ -9,6 +10,11 @@ class EngineBlock_Corto_Filter_Command_AttributeReleasePolicy extends EngineBloc
     public function getResponseAttributes()
     {
         return $this->_responseAttributes;
+    }
+
+    public function getResponseAttributeValueTypes()
+    {
+        return $this->_responseAttributeValueTypes;
     }
 
     public function execute()
@@ -36,6 +42,11 @@ class EngineBlock_Corto_Filter_Command_AttributeReleasePolicy extends EngineBloc
 
             $logger->info("Applying attribute release policy for $spEntityId");
             $attributes = $enforcer->enforceArp($arp, $attributes);
+
+            $this->_responseAttributeValueTypes = $enforcer->updateAttributeValueTypes(
+                $attributes,
+                $this->_responseAttributeValueTypes
+            );
         }
 
         $this->_responseAttributes = $attributes;

--- a/library/EngineBlock/Corto/Filter/Command/ResponseAttributeValueTypesModificationInterface.php
+++ b/library/EngineBlock/Corto/Filter/Command/ResponseAttributeValueTypesModificationInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+interface EngineBlock_Corto_Filter_Command_ResponseAttributeValueTypesModificationInterface
+{
+    /**
+     * This command modifies the response attribute value types.
+     *
+     * @return array
+     */
+    public function getResponseAttributeValueTypes();
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeReleasePolicyAndAttributeManipulation.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeReleasePolicyAndAttributeManipulation.feature
@@ -1,0 +1,56 @@
+Feature:
+  In order to be able to influence the released attribute values
+  As an IdP or SP
+  I want to be able to manipulate the response attributes through configured code in combination with attribute manipulation
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+    And no registered SPs
+    And no registered Idps
+    And an Identity Provider named "IdP-with-Attribute-Manipulation"
+    And the IdP "IdP-with-Attribute-Manipulation" sends attribute "urn:mace:dir:attribute-def:eduPersonAffiliation" with values "student,affiliate,member" and xsi:type is "xs:string"
+    And a Service Provider named "SP-with-ARP"
+    And a Service Provider named "SP-with-ARP-and-Attribute-Manipulation"
+    And a Service Provider named "SP-with-Attribute-Manipulation"
+    And SP "SP-with-ARP" allows an attribute named "urn:mace:dir:attribute-def:eduPersonAffiliation" with value "member"
+    And SP "SP-with-ARP-and-Attribute-Manipulation" allows an attribute named "urn:mace:dir:attribute-def:eduPersonAffiliation" with value "student"
+
+  Scenario: The Service Provider can apply arp with attribute manipulation enabled with typed attribute values in combination with ARP
+    Given SP "SP-with-ARP-and-Attribute-Manipulation" has the following Attribute Manipulation:
+      """
+      $attributes['urn:mace:dir:attribute-def:mail'][] = 'john@example.co.uk';
+      """
+    When I log in at "SP-with-ARP-and-Attribute-Manipulation"
+     And I pass through EngineBlock
+     And I pass through the IdP
+     Then the response should not contain "john@example.co.uk"
+    When I give my consent
+     And I pass through EngineBlock
+    Then the url should match "functional-testing/SP-with-ARP-and-Attribute-Manipulation/acs"
+     And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonAffiliation"]/saml:AttributeValue[text()="student"]'
+
+  Scenario: The Service Provider with typed attribute values and ARP
+    When I log in at "SP-with-ARP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "john@example.co.uk"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SP-with-ARP/acs"
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonAffiliation"]/saml:AttributeValue[text()="member"]'
+
+  Scenario: The Service Provider with typed attribute values and attribute manipulations
+    Given SP "SP-with-Attribute-Manipulation" has the following Attribute Manipulation:
+      """
+      $attributes['urn:mace:dir:attribute-def:mail'][] = 'john@example.co.uk';
+      """
+    When I log in at "SP-with-Attribute-Manipulation"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "john@example.co.uk"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SP-with-Attribute-Manipulation/acs"
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonAffiliation"]/saml:AttributeValue[text()="affiliate"]'
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonAffiliation"]/saml:AttributeValue[text()="student"]'
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonAffiliation"]/saml:AttributeValue[text()="member"]'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -158,7 +158,7 @@ class MockIdpContext extends AbstractSubContext
         /** @var MockIdentityProvider $mockIdp */
         $mockIdp = $this->mockIdpRegistry->get($idpName);
         /** @var MockServiceProvider $mockSp */
-        $mockSp  = $this->mockSpRegistry->get($spName);
+        $mockSp = $this->mockSpRegistry->get($spName);
 
         $this->serviceRegistryFixture->allow($mockSp->entityid(), $mockIdp->entityId());
 
@@ -329,6 +329,28 @@ class MockIdpContext extends AbstractSubContext
 
         $mockIdp->setAttribute($attributeName, [$attributeValue]);
 
+        $this->mockIdpRegistry->save();
+    }
+
+    /**
+     * Please provide the attribute values in a a comma separated manner.
+     *
+     * @Given /^the IdP "([^"]*)" sends attribute "([^"]*)" with values "([^"]*)" and xsi:type is "([^"]*)"$/
+     * @param string $idpName
+     * @param string $attributeName
+     * @param $attributeValues
+     * @param $attributeValueType
+     */
+    public function theIdPSendsAttributeWithValuesAndType(
+        $idpName,
+        $attributeName,
+        $attributeValues,
+        $attributeValueType
+    ) {
+        /** @var MockIdentityProvider $mockIdp */
+        $mockIdp = $this->mockIdpRegistry->get($idpName);
+        $explosion = explode(',', $attributeValues);
+        $mockIdp->setAttribute($attributeName, $explosion, $attributeValueType);
         $this->mockIdpRegistry->save();
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
@@ -215,7 +215,17 @@ class MockIdentityProvider extends AbstractMockEntityRole
         $assertions[0]->setAttributes($newAttributes);
     }
 
-    public function setAttribute($attributeName, array $attributeValues)
+    /**
+     * Set an attribute on the assertion.
+     *
+     * You can optionally set the attribute type, effectively
+     * setting the xsi:type attribute on the value element.
+     *
+     * @param $attributeName
+     * @param array $attributeValues
+     * @param bool $attributeType
+     */
+    public function setAttribute($attributeName, array $attributeValues, $attributeType = false)
     {
         $role = $this->getSsoRole();
 
@@ -229,6 +239,11 @@ class MockIdentityProvider extends AbstractMockEntityRole
         $newAttributes[$attributeName] = $attributeValues;
 
         $assertions[0]->setAttributes($newAttributes);
+
+        if ($attributeType) {
+            $arrayTypes = array_fill(0, count($newAttributes), $attributeType);
+            $assertions[0]->setAttributesValueTypes($arrayTypes);
+        }
     }
 
     public function useResponseSigning()


### PR DESCRIPTION
The Pivotal story describes the issue that is being fixed here in greater detail. In short, the attribute value type array needed to be updated to prevent the raising of an exception in the saml2 library.

The first commit adds behat tests that touch this problem. The second commit provides the bugfix for the issue.

The sec checker fails on the recent Symfony CVE's. I'm investigating the impact/benefits of a Symfony upgrade. And might open a new PR with the upgrade.

See: https://www.pivotaltracker.com/story/show/1581841791