### PR TITLE
Prevent unexpected behaviour when using new manage on old EB

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/JanusPushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/JanusPushMetadataAssembler.php
@@ -411,13 +411,21 @@ class JanusPushMetadataAssembler
             return array();
         }
 
+        $entityIds = array_map(
+            function ($disableConsentConnection) {
+                // Detect manage >=2.0.18. If a type property is present, it
+                // could be set to something other than 'no_consent'.
+                if (isset($disableConsentConnection->type) && $disableConsentConnection->type !== 'no_consent') {
+                    return;
+                }
+
+                return $disableConsentConnection->name;
+            },
+            $connection->disable_consent_connections
+        );
+
         return array(
-            'spsEntityIdsWithoutConsent' => array_map(
-                function ($disableConsentConnection) {
-                    return $disableConsentConnection->name;
-                },
-                $connection->disable_consent_connections
-            )
+            'spsEntityIdsWithoutConsent' => array_filter($entityIds),
         );
     }
 


### PR DESCRIPTION
Before manage 2.0.18, consent should be disabled for all service
providers listed in 'disable_consent_connections'. Starting from the
new version of manage, the objects listed contain a type indicating
default, minimal or no consent.

In order to prevent unexpected behaviour when configuring default or
minimal consent in manage, we now check if the type is present and if
so, read the value to see if it's set to 'no_consent'.