### PR TITLE
Log the workflow state to the auth logs

### DIFF
--- a/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
+++ b/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
@@ -31,6 +31,7 @@ class AuthenticationLogger
      * @param Entity         $identityProvider
      * @param CollabPersonId $collabPersonId
      * @param array          $proxiedServiceProviders
+     * @param string         $workflowState
      * @param KeyId|null     $keyId
      */
     public function logGrantedLogin(
@@ -38,6 +39,7 @@ class AuthenticationLogger
         Entity $identityProvider,
         CollabPersonId $collabPersonId,
         array $proxiedServiceProviders,
+        $workflowState,
         KeyId $keyId = null
     ) {
         $proxiedServiceProviderEntityIds = array_map(
@@ -57,6 +59,7 @@ class AuthenticationLogger
                 'idp_entity_id'         => $identityProvider->getEntityId()->getEntityId(),
                 'key_id'                => $keyId ? $keyId->getKeyId() : null,
                 'proxied_sp_entity_ids' => $proxiedServiceProviderEntityIds,
+                'workflow_state'        => $workflowState
             ]
         );
     }

--- a/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
+++ b/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
@@ -51,6 +51,7 @@ class AuthenticationLoggerAdapter
             new Entity(new EntityId($identityProvider->entityId), EntityType::IdP()),
             new CollabPersonId($collabPersonId),
             $proxiedSpEntities,
+            $serviceProvider->workflowState,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
@@ -6,6 +6,7 @@ use EngineBlock_UserDirectory;
 use Mockery as m;
 use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
 use OpenConext\EngineBlock\Authentication\Value\KeyId;
+use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\Value\Saml\Entity;
 use OpenConext\Value\Saml\EntityId;
 use OpenConext\Value\Saml\EntityType;
@@ -47,6 +48,7 @@ class AuthenticationLoggerTest extends UnitTest
             'user_id' => $collabPersonIdValue,
             'key_id' => $keyIdValue,
             'proxied_sp_entity_ids' => [$spProxy1EntityId, $spProxy2EntityId],
+            'workflow_state' => AbstractRole::WORKFLOW_STATE_PROD,
         ];
 
         $mockLogger = m::mock('\Psr\Log\LoggerInterface');
@@ -79,6 +81,7 @@ class AuthenticationLoggerTest extends UnitTest
             $identityProvider,
             $collabPersonId,
             [$serviceProviderProxy1, $serviceProviderProxy2],
+            AbstractRole::WORKFLOW_STATE_PROD,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
@@ -4,6 +4,7 @@ namespace OpenConext\EngineBlockBridge\Logger;
 
 use EngineBlock_UserDirectory;
 use Mockery as m;
+use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
@@ -48,6 +49,7 @@ class AuthenticationLoggerAdapterTest extends UnitTest
                             new Entity(new EntityId($spProxy2EntityId), EntityType::SP()),
                         ]
                     ),
+                    AbstractRole::WORKFLOW_STATE_PROD,
                     new ValueObjectEqualsMatcher(new KeyId($keyIdValue)),
                 ]
             )


### PR DESCRIPTION
The workflow state of the SP was chosen to serve as the log value. This
value should always be the same for the IdP. The state is stored in the
'workflow_state' key of the log context.

See: https://www.pivotaltracker.com/story/show/158283204

To test this in the dev vm. Tail  `/var/log/messages` grepping on `EBAUTH`. After authentication you should receive something like:

```
Jun 20 14:53:23 apps EBAUTH[5365]: {"channel":"authentication","level":"INFO","message":"login granted","context":{"login_stamp":"2018-06-20T14:53:23+02:00","user_id":"urn:collab:person:example.com:admin","sp_entity_id":"https:\/\/teams.vm.openconext.org\/shibboleth","idp_entity_id":"http:\/\/mock-idp","key_id":null,"proxied_sp_entity_ids":[],"workflow_state":"prodaccepted"},"extra":{"session_id":"5Y53SRgSPB6yuv1N9UWoQpLjjF2","request_id":"5b2a4e42cdb83"}}
```