### PR TITLE
Use the first array value when single attribute value is shown on consent screen

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -73,8 +73,8 @@
                                 <td class="attr-value">
                                     {# Single attribute value #}
                                     {% if attributeValues|length == 1 %}
-                                        {{ attributeValues[0] }}
-                                        {# Multiple attribute values #}
+                                        {{ attributeValues|first }}
+                                    {# Multiple attribute values #}
                                     {% else %}
                                         <ul>
                                             {% for value in attributeValues %}


### PR DESCRIPTION
Since the bugfix of the 'uneven' attribute value and type arrays was
introduced in the codebase. ARP filtering started introducing some
side effects on the consent screen.

This because attribute value and type arrays are filtered, taking extra
care to keep the keys intact. This might result in filtering away value
0, 2 and 3, leaving index 1.

The previous twig solution was not robust in that aspect and always
showed index 0, as that previously always was the first (and only) entry
in the case of a single value attribute.

Now the first filter is used to get the first array entry from the array
regardless of index, fixing the problem.

See: https://www.pivotaltracker.com/story/show/158184179/comments/191135246