### PR TITLE
Remove eduGAIN section from front page

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Index/index.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Index/index.html.twig
@@ -118,23 +118,6 @@
           </dl>
       </div>
 
-      <div class="main">
-          <h1>eduGAIN Metadata</h1>
-          <dl class="metadata-certificates-list">
-              <dt>
-                  The {{ 'suite_name'|trans }} eduGain SAML metadata consists out of all IdPs and SPs that are included of
-                  the <a href="http://mds.edugain.org/" data-external-link="true" target="_blank">eduGain metadata</a>.
-              </dt>
-              <dd>
-                  <ul>
-                      <li><a href="/authentication/proxy/edugain-metadata">Open link</a></li>
-                      {% for keyId in keyPairIds %}
-                      <li><a href="/authentication/proxy/edugain-metadata/key:{{ keyId }}">Open link</a></li>
-                      {% endfor %}
-                  </ul>
-              </dd>
-          </dl>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Just removes the section from the Twig template. Removal of the actual
metadata endpoints will be picked up at a later stage in the refactoring
of EB metadata generation.

See: https://www.pivotaltracker.com/story/show/158439992