### PR TITLE
Actually show the collab name id on consent

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
+++ b/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
@@ -1,6 +1,6 @@
 <?php
 
-use SAML2\Constants;
+use OpenConext\Value\Saml\NameIdFormat;
 
 class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_Filter_Command_Abstract
     implements EngineBlock_Corto_Filter_Command_ResponseModificationInterface,
@@ -37,6 +37,12 @@ class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_F
             $this->_serviceProvider,
             $this->_collabPersonId
         );
+
+        // To actually set the collabPersonIdValue, override it with the one we just generated. The resolver used the
+        // intended name id format for this purpose (but this is not set yet)
+        if ($nameId->Format == NameIdFormat::UNSPECIFIED) {
+            $nameId->value = $collabPersonIdValue;
+        }
 
         // Adjust the NameID in the OLD response (for consent), set the collab:person uid
         $this->_response->getAssertion()->setNameId($nameId);


### PR DESCRIPTION
When unspecified name id is set for the SP, the wrong name id value
was displayed on the consent screen. This fix sets the correct name id
value for display on consent.

See: the second bugreport from: https://www.pivotaltracker.com/story/show/154912151/comments/191385599