### PR TITLE
Prevent multiple generations of transient NameID

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
+++ b/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
@@ -1,6 +1,7 @@
 <?php
 
-use OpenConext\Value\Saml\NameIdFormat;
+use SAML2\Constants;
+use SAML2\XML\saml\NameID;
 
 class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_Filter_Command_Abstract
     implements EngineBlock_Corto_Filter_Command_ResponseModificationInterface,
@@ -30,18 +31,31 @@ class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_F
         $collabPersonIdValue = $user->getCollabPersonId()->getCollabPersonId();
         $this->setCollabPersonId($collabPersonIdValue);
 
-        $resolver = new EngineBlock_Saml2_NameIdResolver();
-        $nameId = $resolver->resolve(
-            $this->_request,
-            $this->_response,
-            $this->_serviceProvider,
-            $this->_collabPersonId
-        );
+        if ($this->_serviceProvider->nameIdFormat === Constants::NAMEID_TRANSIENT) {
+            // The collabPersonIdValue is set as the transient name id format. This will be updated in the output
+            // pipeline.
+            $nameId = NameID::fromArray(
+                array(
+                    'Value' => $collabPersonIdValue,
+                    'Format' => Constants::NAMEID_TRANSIENT,
+                )
+            );
+        } else {
+            // Only use the resolver when dealing with non transient NameID's as they will be overwritten in the output
+            // pipeline. Resulting in a recurring consent screen on successive log-ins.
+            $resolver = new EngineBlock_Saml2_NameIdResolver();
+            $nameId = $resolver->resolve(
+                $this->_request,
+                $this->_response,
+                $this->_serviceProvider,
+                $this->_collabPersonId
+            );
 
-        // To actually set the collabPersonIdValue, override it with the one we just generated. The resolver used the
-        // intended name id format for this purpose (but this is not set yet)
-        if ($nameId->Format == NameIdFormat::UNSPECIFIED) {
-            $nameId->value = $collabPersonIdValue;
+            // To actually set the collabPersonIdValue, override it with the one we just generated. The resolver used the
+            // intended name id format for this purpose (but this is not set yet)
+            if ($nameId->Format == Constants::NAMEFORMAT_UNSPECIFIED) {
+                $nameId->value = $collabPersonIdValue;
+            }
         }
 
         // Adjust the NameID in the OLD response (for consent), set the collab:person uid


### PR DESCRIPTION
The Transient NameID was generated multiple times during the processing
of the SAMLResponse. Resulting in a reoccurring consent screen. Every
time the NameIDResolver creates (and stores) a new transient NameID the
next time we pass consent, EB thinks new consent must be given.

See first bug report from:
https://www.pivotaltracker.com/story/show/154912151/comments/191385599