### PR TITLE
Fix 'enable-test-env' to work out-of-the-box

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -186,15 +186,15 @@
     <target name="enable-test-env"
             description="Set the environment in app_dev.php test">
         <replace file="${basedir}/web/app_dev.php"
-                 token="new AppKernel('dev', false)"
-                 value="new AppKernel('test', false)"/>
+                 token="new AppKernel('dev', true)"
+                 value="new AppKernel('test', true)"/>
     </target>
 
     <target name="disable-test-env"
             description="Set the environment in app_dev.php dev">
         <replace file="${basedir}/web/app_dev.php"
-                 token="new AppKernel('test', false)"
-                 value="new AppKernel('dev', false)"/>
+                 token="new AppKernel('test', true)"
+                 value="new AppKernel('dev', true)"/>
     </target>
 
     <target name="prepare-env"


### PR DESCRIPTION
The app_dev.php file provisioned by OpenConext-deploy (with ENV=dev)
has debugging enabled (true) but the build.xml enable-test-env and
disable-test-env tasks expected the debugging flag to be false.

With this change, the behat-dev task will work without modification of
build.xml or app_dev.php.