### PR TITLE
Revert suggestion title on wayf screen

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -50,6 +50,7 @@ return $overrides + [
 
     // WAYF
     'search'                    => 'Search for an %organisationNoun%...',
+    'our_suggestion'            => 'Previously chosen:',
     'idps_with_access'          => 'Identity Providers with access',
     'idps_without_access'       => 'Identity Providers without access',
     'log_in_to'                 => 'Select an %organisationNoun% to login to the service:',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -49,6 +49,7 @@ return $overrides + [
 
     // WAYF
     'search'                    => 'Zoek een %organisationNoun%...',
+    'our_suggestion'            => 'Onze suggestie:',
     'idps_with_access'          => '%organisationNounPlural% met toegang',
     'idps_without_access'       => '%organisationNounPlural% zonder toegang',
     'log_in_to'                 => 'Selecteer een %organisationNoun% en login bij',

--- a/theme/material/templates/modules/Authentication/View/Proxy/wayf.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/wayf.html.twig
@@ -32,9 +32,13 @@
 
     <div id="connected-idp-picker">
         <div class="preselection mod-results hidden">
+            <header>
+                <h2>{{ 'our_suggestion'|trans }}<a class="edit" href="#" data-toggle="view" data-toggle-text="{{ 'done'|trans }}">{{ 'edit'|trans }}</a></h2>
+            </header>
             <div class="idp-list">
             </div>
         </div>
+
 
         {% if rememberChoiceFeature %}
         <div id="rememberChoiceDiv" class="selection mod-results">


### PR DESCRIPTION
The testers found a bug in EB 5.7.4. When there's a previously selected IdP, the gray bar above this section ("Eerder gekozen") is missing. This is now fixed.

Also fixes a nitpick: the page <title> is not very beatiful as witnessed from the filenames of these screenshots