### PR TITLE
Remove attribute_aggregation_required metadata setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,10 @@ We will continue to post relevant release notes on the GitHub release page. More
 More information about our release strategy can be found in the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes) on the EngineBlock wiki.
 
 ## Development
+
+## 5.9.0
+This is mainly a release that consists of fixes of technical debt, longer standing quirks and other maintenance related 
+features.
+
+### Improvements
+ * Remove attribute_aggregation_required metadata setting #572

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,15 @@
 # UPGRADE NOTES
 
+## 5.8 -> 5.9
+
+### Attribute aggregation required setting
+The attribute aggregation was enabled/disabled explicitly in previous releases of Engineblock. This value was based on a
+feature flag set in the metadata repository (Manage). This is no longer required as we can distill whether or not this
+feature should be enabled based on the existence (or lack of) source indications on the attribute values.
+
+This changes means that a column was dropped from the `sso_provider_roles_eb5` schema. Running the `Version20180724175453`
+migration takes care of this. Leaving the column in the database should not prove problematic for the time being.
+
 ## 5.7 -> 5.8
 
 ### Stored metadata incompatibility

--- a/database/DoctrineMigrations/Version20180724175453.php
+++ b/database/DoctrineMigrations/Version20180724175453.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180724175453 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP attribute_aggregation_required, CHANGE consent_settings consent_settings LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD attribute_aggregation_required TINYINT(1) DEFAULT NULL, CHANGE consent_settings consent_settings LONGTEXT DEFAULT NULL COLLATE utf8_unicode_ci COMMENT \'(DC2Type:array)\'');
+    }
+}

--- a/docs/attribute_aggregation.md
+++ b/docs/attribute_aggregation.md
@@ -26,9 +26,6 @@ attributeAggregation.password = "secret"
 To use Attribute Aggregation, you configure it in
 Serviceregistry on the SP side.
 
-* First, it is required that the SP has the
-`coin:attribute_aggregation_required` setting enabled in
-Serviceregistry. (We might lift this requirement later.)
 * In the ARP for the SP, each attribute has a 'source'
 column, defauling to IdP. When set to a different value,
 that attribute will be sourced from the Attribute Aggregator.

--- a/library/EngineBlock/Corto/Filter/Command/AttributeAggregator.php
+++ b/library/EngineBlock/Corto/Filter/Command/AttributeAggregator.php
@@ -80,7 +80,7 @@ class EngineBlock_Corto_Filter_Command_AttributeAggregator extends EngineBlock_C
             $serviceProvider = $this->_serviceProvider;
         }
 
-        if (!$serviceProvider->attributeAggregationRequired) {
+        if (!$serviceProvider->isAttributeAggregationRequired()) {
             $this->logger->info("No Attribute Aggregation for " . $serviceProvider->entityId);
             return;
         }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/JanusPushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/JanusPushMetadataAssembler.php
@@ -190,13 +190,6 @@ class JanusPushMetadataAssembler
             ),
             'policyEnforcementDecisionRequired'
         );
-        $properties += $this->setPathFromObject(
-            array(
-                $connection,
-                'metadata:coin:attribute_aggregation_required'
-            ),
-            'attributeAggregationRequired'
-        );
 
         return Utils::instantiate(
             'OpenConext\EngineBlock\Metadata\Entity\ServiceProvider',

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
@@ -56,7 +56,7 @@ class CortoDisassembler
         if ($entity->policyEnforcementDecisionRequired) {
             $cortoEntity['PolicyEnforcementDecisionRequired'] = true;
         }
-        if ($entity->attributeAggregationRequired) {
+        if ($entity->isAttributeAggregationRequired()) {
             $cortoEntity['AttributeAggregationRequired'] = true;
         }
 

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -100,13 +100,6 @@ class ServiceProvider extends AbstractRole
     public $policyEnforcementDecisionRequired;
 
     /**
-     * @var bool
-     *
-     * @ORM\Column(name="attribute_aggregation_required", type="boolean")
-     */
-    public $attributeAggregationRequired;
-
-    /**
      * @var null|RequestedAttribute[]
      *
      * @ORM\Column(name="requested_attributes", type="array")
@@ -164,7 +157,6 @@ class ServiceProvider extends AbstractRole
      * @param null $requestedAttributes
      * @param bool $skipDenormalization
      * @param bool $policyEnforcementDecisionRequired
-     * @param bool $attributeAggregationRequired
      * @param string $manipulation
      * @param AttributeReleasePolicy $attributeReleasePolicy
      * @param string|null $supportUrlEn
@@ -210,7 +202,6 @@ class ServiceProvider extends AbstractRole
         $requestedAttributes = null,
         $skipDenormalization = false,
         $policyEnforcementDecisionRequired = false,
-        $attributeAggregationRequired = false,
         $manipulation = '',
         AttributeReleasePolicy $attributeReleasePolicy = null,
         $supportUrlEn = null,
@@ -257,7 +248,6 @@ class ServiceProvider extends AbstractRole
         $this->requestedAttributes = $requestedAttributes;
         $this->skipDenormalization = $skipDenormalization;
         $this->policyEnforcementDecisionRequired = $policyEnforcementDecisionRequired;
-        $this->attributeAggregationRequired = $attributeAggregationRequired;
         $this->supportUrlEn = $supportUrlEn;
         $this->supportUrlNl = $supportUrlNl;
     }
@@ -300,5 +290,19 @@ class ServiceProvider extends AbstractRole
             $spName = $this->entityId;
         }
         return $spName;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAttributeAggregationRequired()
+    {
+        if (is_null($this->attributeReleasePolicy)) {
+            return false;
+        }
+
+        $rules = $this->attributeReleasePolicy->getRulesWithSourceSpecification();
+
+        return count($rules) > 0;
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -277,7 +277,16 @@ QUERY;
 
     public function requireAttributeAggregationForSp($entityId)
     {
-        $this->getServiceProvider($entityId)->attributeAggregationRequired = true;
+        $arp = $this->getServiceProvider($entityId)->attributeReleasePolicy;
+
+        $rules = [];
+        if ($arp !== null) {
+            $rules = $arp->getAttributeRules();
+        }
+
+        $rules['test'] = [ 'source' => 'no-idp', 'value' => 'test' ];
+
+        $this->getServiceProvider($entityId)->attributeReleasePolicy = new AttributeReleasePolicy($rules);
 
         return $this;
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenConext\EngineBlock\Metadata\Entity\Disassembler;
 
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
@@ -23,7 +24,16 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $serviceProvider->isConsentRequired = false;
         $serviceProvider->skipDenormalization = true;
         $serviceProvider->policyEnforcementDecisionRequired = true;
-        $serviceProvider->attributeAggregationRequired = true;
+
+        // set a non-idp arp rule to enable attribute aggregation
+        $serviceProvider->attributeReleasePolicy = new AttributeReleasePolicy([
+            'name' => [
+                [
+                    'value' => 'value',
+                    'source' => 'source',
+                ],
+            ],
+        ]);
 
         $contact = new ContactPerson('support');
         $contact->emailAddress = 't@t.t';
@@ -45,7 +55,8 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(!$serviceProvider->isConsentRequired    , $cortoServiceProvider['NoConsentRequired']);
         $this->assertEquals($serviceProvider->skipDenormalization   , $cortoServiceProvider['SkipDenormalization']);
         $this->assertEquals($serviceProvider->policyEnforcementDecisionRequired   , $cortoServiceProvider['PolicyEnforcementDecisionRequired']);
-        $this->assertEquals($serviceProvider->attributeAggregationRequired        , $cortoServiceProvider['AttributeAggregationRequired']);
+        $this->assertEquals($serviceProvider->isAttributeAggregationRequired()        , true);
+        $this->assertEquals($serviceProvider->isAttributeAggregationRequired()        , $cortoServiceProvider['AttributeAggregationRequired']);
         $this->assertEquals($contact->contactType, $cortoServiceProvider['ContactPersons'][0]['ContactType']);
         $this->assertEquals($contact->emailAddress, $cortoServiceProvider['ContactPersons'][0]['EmailAddress']);
         $this->assertEquals($contact->telephoneNumber, $cortoServiceProvider['ContactPersons'][0]['TelephoneNumber']);


### PR DESCRIPTION
The attribute aggregator is now only queried when the metadata setting
coin:attribute_aggregation_required is set. This is simplified and
therefore an SP does not require this extra setting to be enabled
anymore.