### PR TITLE
Fix the idp placeholder logo

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -418,7 +418,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
             $wayfIdp = array(
                 'Name_nl'   => $this->getNameNl($identityProvider, $additionalInfo),
                 'Name_en'   => $this->getNameEn($identityProvider, $additionalInfo),
-                'Logo'      => $identityProvider->logo ? $identityProvider->logo->url : '/media/idp-logo-not-found.png',
+                'Logo'      => $identityProvider->logo ? $identityProvider->logo->url : '/images/placeholder.png',
                 'Keywords'  => $this->getKeywords($identityProvider),
                 'Access'    => $identityProvider->enabledInWayf || $isDebugRequest ? '1' : '0',
                 'ID'        => md5($identityProvider->entityId),


### PR DESCRIPTION
The 'idp-logo-not-found.png' logo is set with a wrong path. This is now
replaced with a placeholder image.

See [Pivotal](https://www.pivotaltracker.com/story/show/158685306)