### PR TITLE
Show SP name on "No connection between institution and service" page

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,14 @@ the `composer` part above with `bin/composer.phar`. This version is regularly up
 being outdated.
 
 
-### Install database schema
+### Install database schema updates
 
-To install the initial database, just call the 'migrate' script in *bin/*, followed by migration tool introduced in 5.x,
-like so:
+To install possible database updates, call doctrine migrations by using the following console command:
 
-    (cd bin && ./migrate && cd .. && app/console doctrine:migrations:migrate --env=prod)
+    app/console doctrine:migrations:migrate --env=prod
 
 _**Note**:
-EngineBlock requires database settings, without it the install script will not function. Furthermore, this assumes that
+EngineBlock requires database settings, without it doctrine migrate will not function. Furthermore, this assumes that
 the application must use the production settings (`--env=prod`), this could be replaced with `dev` should you run a 
 development version._
 

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -43,6 +43,7 @@ return $overrides + [
     'requestId'             => 'Unique Request ID',
     'identityProvider'      => 'Identity Provider',
     'serviceProvider'       => 'Service Provider',
+    'serviceProviderName'   => 'Service Provider Name',
     'userAgent'             => 'User Agent',
     'ipAddress'             => 'IP Address',
     'statusCode'            => 'Status Code',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -42,6 +42,7 @@ return $overrides + [
     'requestId'             => 'Uniek Request ID',
     'identityProvider'      => 'Identity Provider',
     'serviceProvider'       => 'Service Provider',
+    'serviceProviderName'   => 'Service Provider Naam',
     'userAgent'             => 'User Agent',
     'ipAddress'             => 'IP-adres',
     'statusCode'            => 'Statuscode',

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -1,6 +1,7 @@
 <?php
 
 use OpenConext\EngineBlock\Logger\Handler\FingersCrossed\ManualOrDecoratedActivationStrategy;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
 use OpenConext\EngineBlock\Request\RequestId;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -239,6 +240,7 @@ class EngineBlock_ApplicationSingleton
         // Find the current identity provider
         if (isset($_SESSION['currentServiceProvider'])) {
             $feedbackInfo['serviceProvider'] = $_SESSION['currentServiceProvider'];
+            $feedbackInfo['serviceProviderName'] = $this->getServiceProviderName($_SESSION['currentServiceProvider']);
         }
 
         // @todo  reset this when login is succesful
@@ -398,5 +400,18 @@ class EngineBlock_ApplicationSingleton
     public function getDiContainer()
     {
         return $this->_diContainer;
+    }
+
+    /**
+     * @param string $serviceProviderId
+     * @return string
+     */
+    private function getServiceProviderName($serviceProviderId){
+        try {
+            $serviceProvider = $this->getDiContainer()->getMetadataRepository()->fetchServiceProviderByEntityId($serviceProviderId);
+            return $serviceProvider->getDisplayName($this->getDiContainer()->getLocaleProvider()->getLocale());
+        } catch (EntityNotFoundException $e) {}
+
+        return '';
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -7,7 +7,6 @@ use OpenConext\EngineBlockBundle\Pdp\PolicyDecision;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig_Environment;
 


### PR DESCRIPTION
When a user wants to log into a service that the IdP does not allow,
and the user is presented with an error page "No connection between
institution and service", the entityID of the SP is listed. Now also
the SP name is shown in this message because that's more meaningful.

Also see the [Pivotal issue](https://www.pivotaltracker.com/story/show/149064131)