### PR TITLE
Rename Janus references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ More information about our release strategy can be found in the [Development Gui
 This is mainly a release that consists of fixes of technical debt, longer standing quirks and other maintenance related 
 features.
 
-### New features
+### Bugfixes
+ * Optimize consent viewport on xs #573
+ * Revert suggestion title on WAYF screen #571
+ * Fix SP displayName regression #568 (thanks tvdijen)
+ * Update the IdP placeholder logo reference #574
 
-### Bugfixes and other improvements
+### Chores and other improvements
+ * References to Janus have been removed #581
  * Remove attribute_aggregation_required metadata setting #572
- * Symfony was upgraded to 2.8.44 to harden against CVE-2018-14773
+ * Symfony was upgraded to 2.8.44 to harden against CVE-2018-14773 #582

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,21 @@
 
 ## 5.8 -> 5.9
 
+### Who's Janus?
+All references to Janus have been removed from the EngineBlock codebase and has been substituted with metadata push. 
+This also includes the configuration settings. Be sure to set the correct values in the INI settings for the push 
+mechanism to work.
+
+```
+; old
+engineApi.users.janus.username = "..."
+engineApi.users.janus.password = "..."
+
+; new
+engineApi.users.metadataPush.username = "..."
+engineApi.users.metadataPush.password = "..."
+```
+
 ### Attribute aggregation required setting
 The attribute aggregation was enabled/disabled explicitly in previous releases of Engineblock. This value was based on a
 feature flag set in the metadata repository (Manage). This is no longer required as we can distill whether or not this

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -3,9 +3,9 @@ security:
         in_memory:
             memory:
                 users:
-                    "%api.users.janus.username%":
-                        password: "%api.users.janus.password%"
-                        roles: 'ROLE_API_USER_JANUS'
+                    "%api.users.metadataPush.username%":
+                        password: "%api.users.metadataPush.password%"
+                        roles: 'ROLE_API_USER_METADATA_PUSH'
                     "%api.users.profile.username%":
                         password: "%api.users.profile.password%"
                         roles: 'ROLE_API_USER_PROFILE'

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -139,8 +139,8 @@ database.test.dbname = eb_test
 ;engineApi.password = RANDOM PASSWORD HERE
 
 ;; New API user config, allows for configuration of multiple different users
-;engineApi.users.janus.username = "some user"
-;engineApi.users.janus.password = "some password"
+;engineApi.users.metadataPush.username = "some user"
+;engineApi.users.metadataPush.password = "some password"
 ;engineApi.users.profile.username = "some user"
 ;engineApi.users.profile.password = "some password"
 ;engineApi.users.deprovision.username = "some user"

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -130,8 +130,8 @@ $ymlContent = array(
         // settings.
         'php_settings'                                            => legacyPhpSettingsToYaml($config->get('phpSettings', [])->toArray()),
 
-        'api.users.janus.username'                                => $config->get('engineApi.users.janus.username'),
-        'api.users.janus.password'                                => escapeYamlValue($config->get('engineApi.users.janus.password')),
+        'api.users.metadataPush.username'                         => $config->get('engineApi.users.metadataPush.username'),
+        'api.users.metadataPush.password'                         => escapeYamlValue($config->get('engineApi.users.metadataPush.password')),
         'api.users.profile.username'                              => $config->get('engineApi.users.profile.username'),
         'api.users.profile.password'                              => escapeYamlValue($config->get('engineApi.users.profile.password')),
         'api.users.deprovision.username'                          => $config->get('engineApi.users.deprovision.username'),

--- a/ci/travis/files/engineblock.ini
+++ b/ci/travis/files/engineblock.ini
@@ -17,8 +17,8 @@ engineApi.user = serviceregistry
 engineApi.password = test
 
 ;; New version that allows for multiple different API users
-engineApi.users.janus.username = serviceregistry
-engineApi.users.janus.password = test
+engineApi.users.metadataPush.username = serviceregistry
+engineApi.users.metadataPush.password = test
 engineApi.users.profile.username = profile
 engineApi.users.profile.password = test
 engineApi.users.deprovision.username = deprovision

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,6 @@
         "psr-0": {
             "EngineBlock_": "library/",
             "EngineBlock_Test": "tests/library/",
-            "Janus_": "library/",
             "Pdp_": "library/",
             "AttributeAggregation_": "library/",
             "SurfConext_": "library/",

--- a/docs/attribute_aggregation.md
+++ b/docs/attribute_aggregation.md
@@ -58,7 +58,7 @@ for _x_; the attribute will be omitted).
 
 New sources are added in the Attribute Aggregator,
 according to the instructions in its README. In order
-for it to be configurable in serviceregistry, add it
+for it to be configurable in Manage, add it
 to the list of
 [`janus_attribute_sources`](https://github.com/OpenConext/OpenConext-deploy/blob/2b6e5ef385ec41ceba58d271be049fb6a17b06ac/environments/docker/group_vars/docker.yml#L115-L116).
 Engineblock itself is agnostic of which sources exist

--- a/library/EngineBlock/Saml2/NameIdResolver.php
+++ b/library/EngineBlock/Saml2/NameIdResolver.php
@@ -163,7 +163,7 @@ class EngineBlock_Saml2_NameIdResolver
         }
 
         // So neither a NameIDFormat is explicitly set in the metadata OR a (valid) NameIDPolicy is set in the AuthnRequest
-        // so we check what the SP supports (or what JANUS claims that it supports) and
+        // so we check what the SP supports (or what Manage claims that it supports) and
         // return the least privacy sensitive one.
         if (!empty($spEntityMetadata->supportedNameIdFormats)) {
             foreach ($this->SUPPORTED_NAMEID_FORMATS as $supportedNameIdFormat) {

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -20,11 +20,9 @@ use RuntimeException;
 use stdClass;
 
 /**
- * Class JanusPushMetadataAssembler
- * @package OpenConext\EngineBlock\Metadata\Entity\Assembler
  * @SuppressWarnings(PMD)
  */
-class JanusPushMetadataAssembler
+class PushMetadataAssembler
 {
     public function assemble($connections)
     {

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
@@ -2,7 +2,7 @@
 
 namespace OpenConext\EngineBlockBundle\Controller\Api;
 
-use OpenConext\EngineBlock\Metadata\Entity\Assembler\JanusPushMetadataAssembler;
+use OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataRepository;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiAccessDeniedHttpException;
@@ -60,9 +60,9 @@ class ConnectionsController
             throw new ApiNotFoundHttpException('Metadata push API is disabled');
         }
 
-        if (!$this->authorizationChecker->isGranted(['ROLE_API_USER_JANUS'])) {
+        if (!$this->authorizationChecker->isGranted(['ROLE_API_USER_METADATA_PUSH'])) {
             throw new ApiAccessDeniedHttpException(
-                'Access to the metadata push API requires the role ROLE_API_USER_JANUS'
+                'Access to the metadata push API requires the role ROLE_API_USER_METADATA_PUSH'
             );
         }
 
@@ -74,7 +74,7 @@ class ConnectionsController
             throw new BadApiRequestHttpException('Unrecognized structure for JSON');
         }
 
-        $assembler = new JanusPushMetadataAssembler();
+        $assembler = new PushMetadataAssembler();
         $roles     = $assembler->assemble($body->connections);
         $result    = $this->repository->synchronize($roles);
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
@@ -1,6 +1,6 @@
 parameters:
-    engineblock.functional_testing.service_registry_data_store.dir:           "%kernel.root_dir%/../tmp/eb-fixtures/janus/"
-    engineblock.functional_testing.service_registry_data_store.file:          "%kernel.root_dir%/../tmp/eb-fixtures/janus/entities"
+    engineblock.functional_testing.service_registry_data_store.dir:           "%kernel.root_dir%/../tmp/eb-fixtures/metadata-push/"
+    engineblock.functional_testing.service_registry_data_store.file:          "%kernel.root_dir%/../tmp/eb-fixtures/metadata-push/entities"
     engineblock.functional_testing.features_data_store.file:                  "%kernel.root_dir%/../tmp/eb-fixtures/features.json"
     engineblock.functional_testing.authentication_loop_guard_data_store.file: "%kernel.root_dir%/../tmp/eb-fixtures/authentication-loop-guard.json"
     engineblock.functional_testing.pdp_data_store.file:                       "%kernel.root_dir%/../tmp/eb-fixtures/policy_decision.json"

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
@@ -14,7 +14,7 @@ class ConnectionsControllerTest extends WebTestCase
      * @test
      * @group Api
      * @group Connections
-     * @group Janus
+     * @group MetadataPush
      */
     public function authentication_is_required_for_pushing_metadata()
     {
@@ -27,7 +27,7 @@ class ConnectionsControllerTest extends WebTestCase
      * @test
      * @group Api
      * @group Connections
-     * @group Janus
+     * @group MetadataPush
      *
      * @dataProvider invalidHttpMethodProvider
      * @param string $invalidHttpMethod
@@ -35,8 +35,8 @@ class ConnectionsControllerTest extends WebTestCase
     public function only_post_requests_are_allowed_when_pushing_metadata($invalidHttpMethod)
     {
         $client = $this->makeClient([
-            'username' => $this->getContainer()->getParameter('api.users.janus.username'),
-            'password' => $this->getContainer()->getParameter('api.users.janus.password'),
+            'username' => $this->getContainer()->getParameter('api.users.metadataPush.username'),
+            'password' => $this->getContainer()->getParameter('api.users.metadataPush.password'),
         ]);
 
         $client->request($invalidHttpMethod, 'https://engine-api.vm.openconext.org/api/connections');
@@ -50,14 +50,14 @@ class ConnectionsControllerTest extends WebTestCase
      * @test
      * @group Api
      * @group Connections
-     * @group Janus
+     * @group MetadataPush
      * @group FeatureToggle
      */
     public function cannot_push_metadata_if_feature_is_disabled()
     {
         $client = $this->makeClient([
-            'username' => $this->getContainer()->getParameter('api.users.janus.username'),
-            'password' => $this->getContainer()->getParameter('api.users.janus.password'),
+            'username' => $this->getContainer()->getParameter('api.users.metadataPush.username'),
+            'password' => $this->getContainer()->getParameter('api.users.metadataPush.password'),
         ]);
 
         $this->disableMetadataPushApiFeatureFor($client);
@@ -73,9 +73,9 @@ class ConnectionsControllerTest extends WebTestCase
      * @test
      * @group Api
      * @group Connections
-     * @group Janus
+     * @group MetadataPush
      */
-    public function cannot_push_metadata_if_user_does_not_have_janus_role()
+    public function cannot_push_metadata_if_user_does_not_have_manage_role()
     {
         $client = $this->makeClient([
             'username' => 'no_roles',
@@ -95,7 +95,7 @@ class ConnectionsControllerTest extends WebTestCase
      * @test
      * @group Api
      * @group Connections
-     * @group Janus
+     * @group MetadataPush
      *
      * @dataProvider invalidJsonPayloadProvider
      * @param string $invalidJsonPayload
@@ -103,8 +103,8 @@ class ConnectionsControllerTest extends WebTestCase
     public function cannot_push_invalid_content_to_the_metadata_push_api($invalidJsonPayload)
     {
         $client = $this->makeClient([
-            'username' => $this->getContainer()->getParameter('api.users.janus.username'),
-            'password' => $this->getContainer()->getParameter('api.users.janus.password'),
+            'username' => $this->getContainer()->getParameter('api.users.metadataPush.username'),
+            'password' => $this->getContainer()->getParameter('api.users.metadataPush.password'),
         ]);
 
         $this->enableMetadataPushApiFeatureFor($client);


### PR DESCRIPTION
Instead of using Janus or Manage as an indication for the push API
feature that EngineBlock features, a more generic 'metadata push' nomer
is used.

Also see Pivotal: https://www.pivotaltracker.com/story/show/157912446