### PR TITLE
Upgrade Symfony to 2.8.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,8 @@ More information about our release strategy can be found in the [Development Gui
 This is mainly a release that consists of fixes of technical debt, longer standing quirks and other maintenance related 
 features.
 
-### Improvements
+### New features
+
+### Bugfixes and other improvements
  * Remove attribute_aggregation_required metadata setting #572
+ * Symfony was upgraded to 2.8.44 to harden against CVE-2018-14773

--- a/composer.lock
+++ b/composer.lock
@@ -2826,16 +2826,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v2.8.41",
+            "version": "v2.8.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "24fc640d544a67869a4106de5fc303c597398629"
+                "reference": "789dc7eb57579185a430e65c5efce4b2d6b6b7b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/24fc640d544a67869a4106de5fc303c597398629",
-                "reference": "24fc640d544a67869a4106de5fc303c597398629",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/789dc7eb57579185a430e65c5efce4b2d6b6b7b1",
+                "reference": "789dc7eb57579185a430e65c5efce4b2d6b6b7b1",
                 "shasum": ""
             },
             "require": {
@@ -2962,7 +2962,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2018-05-25T12:03:11+00:00"
+            "time": "2018-08-01T14:12:49+00:00"
         },
         {
             "name": "twig/extensions",


### PR DESCRIPTION
Symfony was upgraded to 2.8.44 to harden against CVE-2018-14773