### PR TITLE
Prevent adding empty 'return' hidden input field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ features.
  * Revert suggestion title on WAYF screen #571
  * Fix SP displayName regression #568 (thanks tvdijen)
  * Update the IdP placeholder logo reference #574
+ * Prevent adding empty 'return' hidden input field #584
 
 ### Chores and other improvements
  * References to Janus have been removed #581

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -580,7 +580,13 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             $this->validateXml($xml);
 
             $extra = '';
-            $extra .= method_exists($message, 'getReturn')? '<input type="hidden" name="return" value="'     . htmlspecialchars($message->getReturn()) . '">' : '';
+
+            // If the processed assertion consumer service is set on the response, it is posted back to the SP using the
+            // the 'return' hidden form field.
+            if (method_exists($message, 'getReturn') && !empty(trim($message->getReturn()))) {
+                $extra .= '<input type="hidden" name="return" value="' . htmlspecialchars($message->getReturn()) . '">';
+            }
+
             $extra .= $sspMessage->getRelayState()           ? '<input type="hidden" name="RelayState" value="' . htmlspecialchars($sspMessage->getRelayState()) . '">' : '';
 
             $encodedMessage = htmlspecialchars(base64_encode($xml));

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -278,6 +278,34 @@ HTML;
     }
 
     /**
+     * @Then /^The process form should have the "([^"]*)" field$/
+     */
+    public function iSeeACertainFormFieldOnTheProcessForm($formFieldName)
+    {
+        $selector = 'input[name="' . $formFieldName . '"]';
+        $mink = $this->getMainContext()->getMinkContext()->getSession()->getPage();
+        $formField = $mink->find('css', $selector);
+
+        if (!$formField) {
+            throw new RuntimeException(sprintf('The %s form field should have been on the form.', $formFieldName));
+        }
+    }
+
+    /**
+     * @Then /^The process form should not have the "([^"]*)" field$/
+     */
+    public function iDoNotSeeACertainFormFieldOnTheProcessForm($formFieldName)
+    {
+        $selector = 'input[name="' . $formFieldName . '"]';
+        $mink = $this->getMainContext()->getMinkContext()->getSession()->getPage();
+        $formField = $mink->find('css', $selector);
+
+        if (!is_null($formField)) {
+            throw new RuntimeException(sprintf('The %s form field should not have been on the form.', $formFieldName));
+        }
+    }
+
+    /**
      * @Then /^I should see the "Request access" button$/
      */
     public function iSeeTheRequestAccessButton()

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SingleSignOn.feature
@@ -22,3 +22,10 @@ Feature:
     When I log in at "SSO-Foobar"
     Then I should see "SSO-Foobar"
      And I should see "SSO-IdP"
+
+  Scenario: EngineBlock should not add the return parameter to the process form when no processedAssertionConsumerService is available
+    When I log in at "SSO-SP"
+     And I select "SSO-IdP" on the WAYF
+    Then The process form should have the "SAMLRequest" field
+     And The process form should not have the "return" field
+     And The process form should not have the "RelayState" field


### PR DESCRIPTION
The return field is filled with the 'return' value that can optionally
be set by the ProcessedAssertionConsumer or AssertionConsumer. When
sending the SAML response using the POST binding, EB now tests if the
setReturn method exists on the SamlMessage which is of the annotated
type in most cases. The method usually exists, so even tho the setter
for 'return' might have never been called, it was still added.

The fix consists of an additional test if the return is not empty.

A simple behat test was added that verifies the return form field is not
added when it should not be.

See https://www.pivotaltracker.com/story/show/159466469