### PR TITLE
Test CustomNameId can be set with NameId object

### DIFF
--- a/library/EngineBlock/Corto/Mapper/Legacy/ResponseTranslator.php
+++ b/library/EngineBlock/Corto/Mapper/Legacy/ResponseTranslator.php
@@ -2,6 +2,7 @@
 
 use SAML2\DOMDocumentFactory;
 use SAML2\Response;
+use SAML2\XML\saml\NameID;
 
 /**
  * Class EngineBlock_Corto_Mapper_Legacy_ResponseTranslator
@@ -95,6 +96,12 @@ class EngineBlock_Corto_Mapper_Legacy_ResponseTranslator
             // Does this value have a __t tag? If so, make sure it's namespaces are registered.
             if (is_array($value) && isset($value[EngineBlock_Corto_XmlToArray::TAG_NAME_PFX])) {
                 $value = $this->fromOldFormat($value);
+            }
+
+            // 'setCustomNameId' on the ResponseAnnotationDecorator requires an array representation of the NameID. So
+            // convert it if it's a NameID object.
+            if ($privateVar === 'CustomNameId' && $value instanceof NameID) {
+                $value = ['Value' => $value->value, 'Format' => $value->Format];
             }
 
             $method = 'set' . $privateVar;

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
@@ -117,6 +117,24 @@ Feature:
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonTargetedID"]/saml:AttributeValue/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="NOOT"]'
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="NOOT"]'
 
+  # See: https://www.pivotaltracker.com/story/show/159760842
+  Scenario: The Service Provider can replace the NameID by setting the CustomNameID with an object representation of the NameID
+    Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
+      """
+      $response['__']['CustomNameId'] = \SAML2\XML\saml\NameID::fromArray(['Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient', 'Value' => 'MIES']);
+      """
+     And SP "SP-with-Attribute-Manipulations" uses the Unspecified NameID format
+    When I log in at "SP-with-Attribute-Manipulations"
+     And I select "Dummy-IdP" on the WAYF
+     And I pass through EngineBlock
+     And I pass through the IdP
+    Then I should not see "MIES"
+    When I give my consent
+     And I pass through EngineBlock
+    Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
+     And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonTargetedID"]/saml:AttributeValue/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="MIES"]'
+     And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="MIES"]'
+
   Scenario: The Service Provider cannot have the SubjectID manipulated by manipulating the responseObj using the unspecified NameID Format
     Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
       """


### PR DESCRIPTION
This PR aims to add support for setting NameId objects on the CustomNameId using attribute manipulation.

For now, the added Behat scenario should cause the build to fail, as NameID, set on the CustomNameID field are not yet supported in AM.

More details about the bugfix can be found in Pivotal
https://www.pivotaltracker.com/story/show/159823307