### PR TITLE
Make database health query configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ More information about our release strategy can be found in the [Development Gui
 
 ## Development
 
+### Features
+ * A custom database health check is added for the Monitor bundle. #589 
+
 ## 5.8.2
 This is mainly a release that consists of fixes of technical debt, longer standing quirks and other maintenance related 
 features.

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -234,3 +234,6 @@ ui.return_to_sp_link.active = false
 
 ; Consent view related settings
 openconext.supportUrlNameId = "https://www.example.org/support/consent"
+
+; The query used by the Monitor Bundle to verify the database connection is up and running
+openconext.monitor_bundle_health_query = "SELECT version FROM migration_versions LIMIT 1;"

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -222,7 +222,8 @@ $ymlContent = array(
             $config->get(
                 'attributeDefinitionFile', $projectRoot . 'application/configs/attributes-v2.2.0.json'
             )
-        )
+        ),
+        'monitor_database_health_check_query'                     => $config->get('openconext.monitor_bundle_health_query', '')
     )
 );
 

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "63a7ed00a1887e490cf3f846089665f1",
@@ -1358,16 +1358,16 @@
         },
         {
             "name": "openconext/monitor-bundle",
-            "version": "1.0.0",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Monitor-bundle.git",
-                "reference": "b9be093828385e857ff23a106b4429155d7f8d58"
+                "reference": "1455a292376a03e28465195202c572aa243f0ddb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Monitor-bundle/zipball/b9be093828385e857ff23a106b4429155d7f8d58",
-                "reference": "b9be093828385e857ff23a106b4429155d7f8d58",
+                "url": "https://api.github.com/repos/OpenConext/Monitor-bundle/zipball/1455a292376a03e28465195202c572aa243f0ddb",
+                "reference": "1455a292376a03e28465195202c572aa243f0ddb",
                 "shasum": ""
             },
             "require": {
@@ -1399,7 +1399,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "description": "A Symfony2 bundle that facilitates health and info endpoints to a Symfony application",
+            "description": "A Symfony 3 bundle that facilitates health and info endpoints to a Symfony application. The bundle is backwards compatible with Symfony 2 projects.",
             "keywords": [
                 "OpenConext",
                 "health",
@@ -1407,7 +1407,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2017-12-07T14:41:46+00:00"
+            "time": "2018-08-16T13:07:30+00:00"
         },
         {
             "name": "openconext/saml-value-object",

--- a/src/OpenConext/EngineBlockBundle/HealthCheck/DoctrineConnectionHealthCheck.php
+++ b/src/OpenConext/EngineBlockBundle/HealthCheck/DoctrineConnectionHealthCheck.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\HealthCheck;
+
+use Doctrine\ORM\EntityManager;
+use Exception;
+use OpenConext\EngineBlock\Assert\Assertion;
+use OpenConext\MonitorBundle\HealthCheck\HealthCheckInterface;
+use OpenConext\MonitorBundle\HealthCheck\HealthReportInterface;
+use OpenConext\MonitorBundle\Value\HealthReport;
+
+/**
+ * Test if there is a working database connection.
+ */
+class DoctrineConnectionHealthCheck implements HealthCheckInterface
+{
+    /**
+     * @var EntityManager|null
+     */
+    private $entityManager;
+
+    /**
+     * @var string
+     */
+    private $query;
+
+    public function __construct($query)
+    {
+        Assertion::nonEmptyString($query, 'health check query');
+        $this->query = $query;
+    }
+
+    /**
+     * Run the doctrine connection health check.
+     *
+     * @param HealthReportInterface $report
+     * @return HealthReportInterface
+     */
+    public function check(HealthReportInterface $report)
+    {
+        // Was the entityManager injected? When it is not the project does not use Doctrine ORM
+        if (!is_null($this->entityManager)) {
+            try {
+                $this->entityManager->getConnection()->exec($this->query);
+            } catch (Exception $e) {
+                // On error close the connection to prevent sleeping processes
+                $this->entityManager->getConnection()->close();
+                return HealthReport::buildStatusDown('Unable to execute a query on the database.');
+            }
+        }
+
+        return $report;
+    }
+
+    /**
+     * @param EntityManager $entityManager
+     */
+    public function setEntityManager(EntityManager $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -1,4 +1,13 @@
 services:
+    openconext.monitor.database_health_check:
+        class: OpenConext\EngineBlockBundle\HealthCheck\DoctrineConnectionHealthCheck
+        arguments:
+            - "%monitor_database_health_check_query%"
+        calls:
+            - [ setEntityManager, ['@?doctrine.orm.entity_manager']]
+        tags:
+            - { name: openconext.monitor.health_check }
+
     engineblock.minimum_execution_time_on_invalid_received_response:
         class: OpenConext\EngineBlockBundle\Value\ExecutionTime
         factory: [ OpenConext\EngineBlockBundle\Value\ExecutionTime, "of" ]


### PR DESCRIPTION
The monitor_database_health_check_query ini config is used to set the
Symfony yml param, which is included in the monitor config that was
added to the services.yml file.

By default a sensible query is set in the application.ini, this can be
overridden if so desired by the end user.

Todo:
 * [x] Update composer.json / composer.lock once the monitor-bundle is approved & released