### PR TITLE
Fix healthcheck query for test env

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -236,4 +236,4 @@ ui.return_to_sp_link.active = false
 openconext.supportUrlNameId = "https://www.example.org/support/consent"
 
 ; The query used by the Monitor Bundle to verify the database connection is up and running
-openconext.monitor_bundle_health_query = "SELECT version FROM migration_versions LIMIT 1;"
+openconext.monitor_bundle_health_query = "SELECT uuid FROM user LIMIT 1;"


### PR DESCRIPTION
This is a fix to check on another db table then the migration table to
prevent the loadbalancer from returning 503 errors when testing. The
test environment doesn't have a migration table because only the tables
are created from the entities.

https://www.pivotaltracker.com/story/show/158906723