### PR TITLE
Improve the error message from MultilingualValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ More information about our release strategy can be found in the [Development Gui
 ### Features
  * Portuguese language support and other language related work #615 #612 thanks @domgon and @tvdijen!
 
+### Improvements
+ * Improve the error message from MultilingualValue #597
+
 ## 5.8.6
 **Bugfix**: Stop overwriting the NameId before giving consent #610
 
@@ -25,13 +28,13 @@ This is a release mainly focused on the rolling updates. Be aware that 5.8 relea
 breaking changes in migrations due to the rolling update implementation added in this release . In order to update you
 should skip releases <5.8.3. 
 
+### Chores and other improvements
+ * Symfony was upgrade from version 2.8 to 3.4. This required the upgrade of quite some other (mainly dev) dependencies. #590
+
 ### Features
  * A custom database health check is added for the Monitor bundle. #589
  * A feature toggle to disallow users on attribute violations is added. #591
  * Add Rolling update support #595
-
-### Chores and other improvements
- * Symfony was upgrade from version 2.8 to 3.4. This required the upgrade of quite some other (mainly dev) dependencies. #590
 
 ## 5.8.2
 This is mainly a release that consists of fixes of technical debt, longer standing quirks and other maintenance related 

--- a/src/OpenConext/EngineBlock/Metadata/MultilingualValue.php
+++ b/src/OpenConext/EngineBlock/Metadata/MultilingualValue.php
@@ -18,8 +18,20 @@ class MultilingualValue
      */
     public function __construct($value, $language)
     {
-        Assertion::string($value);
-        Assertion::string($language);
+        Assertion::string(
+            $value,
+            sprintf(
+                'The \'value\' of a MultilingualValue should be a string. "%s" given',
+                var_export($value, true)
+            )
+        );
+        Assertion::string(
+            $language,
+            sprintf(
+                'The \'language\' of a MultilingualValue should be a string. "%s" given',
+                var_export($language, true)
+            )
+        );
 
         $this->value = $value;
         $this->language = $language;

--- a/src/OpenConext/EngineBlock/Metadata/MultilingualValue.php
+++ b/src/OpenConext/EngineBlock/Metadata/MultilingualValue.php
@@ -20,17 +20,11 @@ class MultilingualValue
     {
         Assertion::string(
             $value,
-            sprintf(
-                'The \'value\' of a MultilingualValue should be a string. "%s" given',
-                var_export($value, true)
-            )
+            'The \'value\' of a MultilingualValue should be a string'
         );
         Assertion::string(
             $language,
-            sprintf(
-                'The \'language\' of a MultilingualValue should be a string. "%s" given',
-                var_export($language, true)
-            )
+            'The \'language\' of a MultilingualValue should be a string'
         );
 
         $this->value = $value;


### PR DESCRIPTION
In some cases this error message is raised in the logs, and the generic
error message does not help to identify the actual problem.

Before: 'Value "<NULL>" expected to be string, type NULL given.'
After: 'The 'value' of a MultilingualValue should be a string. "%s" given'