### PR TITLE
Filter ACS location URI scheme to prevent XSS vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ branches:
   only:
     - 5.x-dev
     - master
+    - release/5.8
 
 addons:
   hosts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ We will continue to post relevant release notes on the GitHub release page. More
 
 More information about our release strategy can be found in the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes) on the EngineBlock wiki.
 
+## 5.8.4
+A security patch, fixing a possible XSS vulnerability. 
+Described in more detail in #598
+
 ## 5.8.3
 This is a release mainly focussed on the rolling updates. Be aware that 5.8 releases prior to 5.8.3 do have some
 breaking changes in migrations due to the rolling update implementation added in this release . In order to update you

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -235,6 +235,11 @@ ui.return_to_sp_link.active = false
 ; Signature methods explicitly forbidden by EngineBlock, comma-separated.
 ; forbiddenSignatureMethods = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
 
+; Configure which ACS location URI schemes are allowed for incomming AuthnRequests. The settings is configured with
+; with the 'http' and 'https' schems by default. Which are considered safe to use.
+; allowedAcsLocationSchemes[] = "http"
+; allowedAcsLocationSchemes[] = "https"
+
 ; Consent view related settings
 openconext.supportUrlNameId = "https://www.example.org/support/consent"
 

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -236,7 +236,7 @@ ui.return_to_sp_link.active = false
 ; forbiddenSignatureMethods = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
 
 ; Configure which ACS location URI schemes are allowed for incomming AuthnRequests. The settings is configured with
-; with the 'http' and 'https' schems by default. Which are considered safe to use.
+; with the 'http' and 'https' schemes by default. Which are considered safe to use.
 ; allowedAcsLocationSchemes[] = "http"
 ; allowedAcsLocationSchemes[] = "https"
 

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -44,6 +44,7 @@ $forbiddenSignatureMethods = array_filter(
     )
 );
 
+// As a default: ['http', 'https'] is used. See application.ini for more information
 $allowedAcsLocationSchemes = $config->get('allowedAcsLocationSchemes', array('http', 'https'));
 if (!is_array($allowedAcsLocationSchemes)) {
     $allowedAcsLocationSchemes = $allowedAcsLocationSchemes->toArray();

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -44,6 +44,11 @@ $forbiddenSignatureMethods = array_filter(
     )
 );
 
+$allowedAcsLocationSchemes = $config->get('allowedAcsLocationSchemes', array('http', 'https'));
+if (!is_array($allowedAcsLocationSchemes)) {
+    $allowedAcsLocationSchemes = $allowedAcsLocationSchemes->toArray();
+}
+
 /**
  * Convert PHP-ini configuration in EB-ini format to yaml format.
  *
@@ -124,6 +129,9 @@ $ymlContent = array(
 
         // List of signature methods explicitly forbidden by EngineBlock.
         'forbidden_signature_methods'                             => $forbiddenSignatureMethods,
+
+        // List of allowed ACS location URI schemes
+        'allowed_acs_location_schemes'                            => $allowedAcsLocationSchemes,
 
         // Ideally, PHP is configured using the regular PHP configuration in
         // /etc, but EngineBlock supports runtime modification of PHP

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -194,6 +194,8 @@ We somehow lost where you wanted to go. Did you wait too long? If so, try again 
     'error_unknown_service_provider'          => 'Error - Cannot provide metadata for EntityID \'%arg1%\'',
     'error_unknown_service_provider_desc'     => '<p>Your requested service couldn\'t be found.</p>',
 
+    'error_unsupported_acs_location_scheme' => 'Error - Unsupported URI scheme in ACS location',
+
     'error_unknown_issuer'          => 'Error - Unknown service',
     'error_unknown_issuer_desc'     => '<p>
         The service you are trying to log in to is unknown to %suiteName%. Possibly your %organisationNoun% has never enabled access to this service. Please contact the helpdesk of your %organisationNoun% and provide them with the following information:

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -193,6 +193,8 @@ We weten helaas niet waar je heen wilt. Heb je te lang gewacht? Probeer het dan 
         Er kon geen Service Provider worden gevonden met het opgegeven EntityID.
     </p>',
 
+    'error_unsupported_acs_location_scheme' => 'Error - URI scheme van de ACS locatie wordt niet ondersteund',
+
     'error_unknown_issuer'              => 'Error - Onbekende dienst',
     'error_unknown_issuer_desc'     => '<p>Je aangevraagde dienst kon niet worden gevonden.</p>',
     'error_generic'                     => 'Error - Foutmelding',

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -333,6 +333,14 @@ class EngineBlock_Application_DiContainer extends Pimple
     }
 
     /**
+     * @return array
+     */
+    public function getAllowedAcsLocationSchemes()
+    {
+        return (array) $this->container->getParameter('allowed_acs_location_schemes');
+    }
+
+    /**
      * @return bool
      */
     public function isUiOptionReturnToSpActive()

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -2,6 +2,7 @@
 
 use Doctrine\ORM\EntityManager;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Validator\AllowedSchemeValidator;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 
 class EngineBlock_Application_DiContainer extends Pimple
@@ -333,11 +334,11 @@ class EngineBlock_Application_DiContainer extends Pimple
     }
 
     /**
-     * @return array
+     * @return AllowedSchemeValidator
      */
-    public function getAllowedAcsLocationSchemes()
+    public function getAcsLocationSchemeValidator()
     {
-        return (array) $this->container->getParameter('allowed_acs_location_schemes');
+        return $this->container->get('engineblock.validator.allowed_scheme_validator');
     }
 
     /**

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -345,7 +345,6 @@ class EngineBlock_Corto_Adapter
             'ConsentStoreValues' => $settings->isConsentStoreValuesActive(),
             'metadataValidUntilSeconds' => 86400, // This sets the time (in seconds) the entity metadata is valid.
             'forbiddenSignatureMethods' => $settings->getForbiddenSignatureMethods(),
-            'allowedAcsLocationSchemes' => $settings->getAllowedAcsLocationSchemes(),
         ));
 
         $this->configureProxyCertificates($proxyServer);

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -345,6 +345,7 @@ class EngineBlock_Corto_Adapter
             'ConsentStoreValues' => $settings->isConsentStoreValuesActive(),
             'metadataValidUntilSeconds' => 86400, // This sets the time (in seconds) the entity metadata is valid.
             'forbiddenSignatureMethods' => $settings->getForbiddenSignatureMethods(),
+            'allowedAcsLocationSchemes' => $settings->getAllowedAcsLocationSchemes(),
         ));
 
         $this->configureProxyCertificates($proxyServer);

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -55,11 +55,6 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         null                                                        => '_sendHTTPRedirect'
     );
 
-    protected $allowedAcsSchemes = [
-        'http',
-        'https'
-    ];
-
     /**
      * @var array
      */

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -676,7 +676,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
     private function assertValidAcsLocationScheme($acsLocation)
     {
-        if (!$this->acsLocationSchemeValidator->validate($acsLocation)) {
+        if ($acsLocation && !$this->acsLocationSchemeValidator->validate($acsLocation)) {
             throw new EngineBlock_Corto_Module_Bindings_UnsupportedAcsLocationSchemeException(
                 'The received ACS location does not have a valid scheme'
             );

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -55,6 +55,11 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         null                                                        => '_sendHTTPRedirect'
     );
 
+    protected $allowedAcsSchemes = [
+        'http',
+        'https'
+    ];
+
     /**
      * @var array
      */
@@ -131,6 +136,17 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             if (in_array($signatureMethod, $forbiddenSignatureMethods)) {
                 throw new EngineBlock_Corto_Module_Bindings_UnsupportedSignatureMethodException($signatureMethod);
             }
+        }
+
+        // Test if there is an invalid ACS location uri scheme in use
+        $acsLocation = $sspRequest->getAssertionConsumerServiceURL();
+        if ($acsLocation && !in_array($acsLocation, $this->allowedAcsSchemes)) {
+            throw new EngineBlock_Corto_Module_Bindings_UnsupportedAcsLocationSchemeException(
+                sprintf(
+                    'Received AuthnRequest with an invalid ACS location uri scheme: "%s"',
+                    $sspRequest->getAssertionConsumerServiceURL()
+                )
+            );
         }
 
         // check the IssueInstant against our own time to see if the SP's clock is getting out of sync

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -623,7 +623,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         } else if ($sspBinding instanceof HTTPRedirect) {
             if ($sspMessage instanceof Response) {
                 throw new EngineBlock_Corto_Module_Bindings_UnsupportedBindingException(
-                    'May not send a Reponse via HTTP Redirect'
+                    'May not send a response via HTTP redirect'
                 );
             }
 

--- a/library/EngineBlock/Corto/Module/Bindings/UnsupportedAcsLocationSchemeException.php
+++ b/library/EngineBlock/Corto/Module/Bindings/UnsupportedAcsLocationSchemeException.php
@@ -1,0 +1,5 @@
+<?php
+
+class EngineBlock_Corto_Module_Bindings_UnsupportedAcsLocationSchemeException extends EngineBlock_Corto_Module_Bindings_Exception
+{
+}

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/MetadataAssemblerInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/MetadataAssemblerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenConext\EngineBlock\Metadata\Entity\Assembler;
+
+use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
+
+/**
+ * Assembler of EngineBlock roles from external metadata
+ */
+interface MetadataAssemblerInterface
+{
+    /**
+     * @param mixed
+     * @return AbstractRole[]
+     */
+    public function assemble($connections);
+}

--- a/src/OpenConext/EngineBlock/Validator/AllowedSchemeValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/AllowedSchemeValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OpenConext\EngineBlock\Validator;
+
+class AllowedSchemeValidator implements ValidatorInterface
+{
+    /**
+     * @var array
+     */
+    private $allowedAcsLocationSchemes;
+
+    public function __construct(array $allowedAcsLocationSchemes)
+    {
+        $this->allowedAcsLocationSchemes = $allowedAcsLocationSchemes;
+    }
+
+    public function validate($acsLocation)
+    {
+        $parts = parse_url($acsLocation);
+
+        if (!isset($parts['scheme'])) {
+            return false;
+        }
+
+        if ($acsLocation && !in_array($parts['scheme'], $this->allowedAcsLocationSchemes)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/OpenConext/EngineBlock/Validator/ValidatorInterface.php
+++ b/src/OpenConext/EngineBlock/Validator/ValidatorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OpenConext\EngineBlock\Validator;
+
+interface ValidatorInterface
+{
+    /**
+     * @param mixed $input
+     * @return boolean
+     */
+    public function validate($input);
+}

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
@@ -2,7 +2,7 @@
 
 namespace OpenConext\EngineBlockBundle\Controller\Api;
 
-use OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler;
+use OpenConext\EngineBlock\Metadata\Entity\Assembler\MetadataAssemblerInterface;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataRepository;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiAccessDeniedHttpException;
@@ -21,6 +21,11 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 class ConnectionsController
 {
     /**
+     * @var MetadataAssemblerInterface
+     */
+    private $pushMetadataAssembler;
+
+    /**
      * @var AuthorizationCheckerInterface
      */
     private $authorizationChecker;
@@ -36,15 +41,18 @@ class ConnectionsController
     private $repository;
 
     /**
-     * @param AuthorizationCheckerInterface    $authorizationChecker
-     * @param FeatureConfiguration             $featureConfiguration
-     * @param DoctrineMetadataRepository       $repository
+     * @param MetadataAssemblerInterface $assembler
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param FeatureConfiguration $featureConfiguration
+     * @param DoctrineMetadataRepository $repository
      */
     public function __construct(
+        MetadataAssemblerInterface $assembler,
         AuthorizationCheckerInterface $authorizationChecker,
         FeatureConfiguration $featureConfiguration,
         DoctrineMetadataRepository $repository
     ) {
+        $this->pushMetadataAssembler           = $assembler;
         $this->authorizationChecker            = $authorizationChecker;
         $this->featureConfiguration            = $featureConfiguration;
         $this->repository                      = $repository;
@@ -74,8 +82,7 @@ class ConnectionsController
             throw new BadApiRequestHttpException('Unrecognized structure for JSON');
         }
 
-        $assembler = new PushMetadataAssembler();
-        $roles     = $assembler->assemble($body->connections);
+        $roles     = $this->pushMetadataAssembler->assemble($body->connections);
         $result    = $this->repository->synchronize($roles);
 
         return new JsonResponse($result);

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -128,6 +128,21 @@ class FeedbackController
     }
 
     /**
+     * @return Response
+     * @throws \EngineBlock_Exception
+     */
+    public function unsupportedAcsLocationSchemeAction()
+    {
+        return new Response(
+            $this->twig
+                ->render(
+                    '@theme/Authentication/View/Feedback/unsupported-acs-location-scheme.html.twig'
+                ),
+            400
+        );
+    }
+
+    /**
      * @param Request $request
      * @return Response
      * @throws \EngineBlock_Exception

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -30,6 +30,7 @@ use EngineBlock_Corto_Exception_UnknownPreselectedIdp;
 use EngineBlock_Corto_Exception_InvalidAttributeValue;
 use EngineBlock_Corto_Module_Bindings_SignatureVerificationException;
 use EngineBlock_Corto_Module_Bindings_UnableToReceiveMessageException;
+use EngineBlock_Corto_Module_Bindings_UnsupportedAcsLocationSchemeException;
 use EngineBlock_Corto_Module_Bindings_UnsupportedBindingException;
 use EngineBlock_Corto_Module_Bindings_UnsupportedSignatureMethodException;
 use EngineBlock_Corto_Module_Bindings_VerificationException;
@@ -126,6 +127,9 @@ class RedirectToFeedbackPageExceptionListener
             $redirectParams  = [
                 'signature-method' => $exception->getSignatureMethod(),
             ];
+        } elseif ($exception instanceof EngineBlock_Corto_Module_Bindings_UnsupportedAcsLocationSchemeException) {
+            $message         = 'Unsupported URI scheme in ACS location';
+            $redirectToRoute = 'authentication_feedback_unsupported_acs_location_uri_scheme';
         } elseif ($exception instanceof EngineBlock_Corto_Exception_ReceivedErrorStatusCode) {
             $message         = 'Received Error Status Code';
             $redirectToRoute = 'authentication_feedback_received_error_status_code';

--- a/src/OpenConext/EngineBlockBundle/Resources/config/controllers/api.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/controllers/api.yml
@@ -2,6 +2,7 @@ services:
     engineblock.controller.api.connections:
         class: OpenConext\EngineBlockBundle\Controller\Api\ConnectionsController
         arguments:
+            - "@engineblock.metadata.push_metadata_assembler"
             - "@security.authorization_checker"
             - "@engineblock.features"
             - '@engineblock.metadata.repository.doctrine'

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
@@ -28,6 +28,11 @@ authentication_feedback_unsupported_signature_method:
     methods:    [GET]
     defaults:   { _controller: engineblock.controller.authentication.feedback:unsupportedSignatureMethodAction }
 
+authentication_feedback_unsupported_acs_location_uri_scheme:
+    path:       '/unsupported-acs-location-scheme'
+    methods:    [GET]
+    defaults:   { _controller: engineblock.controller.authentication.feedback:unsupportedAcsLocationSchemeAction }
+
 authentication_feedback_unknown_service_provider:
     path:       '/unknown-service-provider'
     methods:    [GET]

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -128,6 +128,12 @@ services:
             - "@doctrine.orm.entity_manager"
             - "@engineblock.repository.service_provider"
             - "@engineblock.repository.identity_provider"
+
+    engineblock.validator.allowed_scheme_validator:
+        class: OpenConext\EngineBlock\Validator\AllowedSchemeValidator
+        arguments:
+            - "%allowed_acs_location_schemes%"
+
     engineblock.twig.extension.debug:
         class: OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Debug
         tags:

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -129,6 +129,12 @@ services:
             - "@engineblock.repository.service_provider"
             - "@engineblock.repository.identity_provider"
 
+    engineblock.metadata.push_metadata_assembler:
+        public: false
+        class: OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler
+        arguments:
+            - "@engineblock.validator.allowed_scheme_validator"
+
     engineblock.validator.allowed_scheme_validator:
         class: OpenConext\EngineBlock\Validator\AllowedSchemeValidator
         arguments:

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AcsTinkering.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AcsTinkering.feature
@@ -9,8 +9,14 @@ Feature:
     And no registered Idps
     And an Identity Provider named "AlwaysAuth"
     And a Service Provider named "Malicious SP"
+    And a Service Provider named "Malconfigured SP"
     And SP "Malicious SP" is set with acs location "javascript:alert('Hello world')"
+    And SP "Malconfigured SP" is set with acs location "sp.example.com"
 
   Scenario: The Malicious SP AuthnRequest is denied by EngineBlock
     Given I log in at "Malicious SP"
+    Then I should see "Error - Unsupported URI scheme in ACS location"
+
+  Scenario: The Malconfigured SP AuthnRequest is denied by EngineBlock
+    Given I log in at "Malconfigured SP"
     Then I should see "Error - Unsupported URI scheme in ACS location"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AcsTinkering.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AcsTinkering.feature
@@ -1,0 +1,16 @@
+Feature:
+  In order to prevent XSS attacks
+  As a user
+  I need EB to filter malicious asc values in AuthnRequests
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+    And no registered SPs
+    And no registered Idps
+    And an Identity Provider named "AlwaysAuth"
+    And a Service Provider named "Malicious SP"
+    And SP "Malicious SP" is set with acs location "javascript:alert('Hello world')"
+
+  Scenario: The Malicious SP AuthnRequest is denied by EngineBlock
+    Given I log in at "Malicious SP"
+    Then I should see "Error - Unsupported URI scheme in ACS location"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -10,6 +10,7 @@ use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockServiceProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockServiceProviderFactory;
 use OpenConext\EngineBlockFunctionalTestingBundle\Service\EngineBlock;
+use SAML2\AuthnRequest;
 
 /**
  * Class MockSpContext
@@ -163,6 +164,22 @@ class MockSpContext extends AbstractSubContext
         /** @var MockServiceProvider $sp */
         $sp = $this->mockSpRegistry->get($spName);
         $this->doSpSignsItsRequests($sp);
+    }
+
+    /**
+     * @Given /^SP "([^"]*)" is set with acs location "([^"]*)"$/
+     */
+    public function spConfiguredWithAcsLocation($spName, $acsLocation)
+    {
+        /** @var MockServiceProvider $sp */
+        $sp = $this->mockSpRegistry->get($spName);
+
+        $request = new AuthnRequest();
+        $request->setIssuer($sp->entityId());
+        $request->setAssertionConsumerServiceURL($acsLocation);
+        $sp->setAuthnRequest($request);
+
+        $this->mockSpRegistry->save();
     }
 
     private function doSpSignsItsRequests(MockServiceProvider $sp)

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace OpenConext\EngineBlock\Tests;
+
+use OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler;
+use OpenConext\EngineBlock\Validator\AllowedSchemeValidator;
+use PHPUnit_Framework_TestCase;
+
+class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
+{
+    private $assembler;
+
+    public function setUp()
+    {
+        $this->assembler = new PushMetadataAssembler(new AllowedSchemeValidator(['http', 'https']));
+    }
+
+    /**
+     * @dataProvider invalidAcsLocations
+     * @expectedException \RuntimeException
+     */
+    public function test_it_rejects_invalid_acs_location_schemes($acsLocation)
+    {
+        $connection = '{
+            "2d96e27a-76cf-4ca2-ac70-ece5d4c49523": {
+                "allow_all_entities": true,
+                "allowed_connections": [],
+                "metadata": {
+                    "AssertionConsumerService": [{
+                        "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                        "Index": "0",
+                        "Location": "%s"
+                    }],
+                    "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                    "NameIDFormats": ["urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent", "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"],
+                    "contacts": [{
+                        "emailAddress": "help@example.org",
+                        "surName": "OpenConext",
+                        "givenName": "Support",
+                        "contactType": "technical"
+                    }, {
+                        "emailAddress": "help@example.org",
+                        "surName": "OpenConext",
+                        "givenName": "Support",
+                        "contactType": "support"
+                    }, {
+                        "emailAddress": "help@example.org",
+                        "surName": "OpenConext",
+                        "givenName": "Support",
+                        "contactType": "administrative"
+                    }],
+                    "description": {
+                        "en": "Test SP",
+                        "nl": "Test SP"
+                    },
+                    "displayName": {
+                        "en": "Test SP",
+                        "nl": "Test SP"
+                    },
+                    "logo": [{
+                        "width": "96",
+                        "url": "https:\/\/static.vm.openconext.org\/media\/conext_logo.png",
+                        "height": "96"
+                    }],
+                    "name": {
+                        "en": "Test SP",
+                        "nl": "Test SP"
+                    }
+                },
+                "name": "https:\/\/serviceregistry.vm.openconext.org\/simplesaml\/module.php\/saml\/sp\/metadata.php\/default-sp",
+                "state": "prodaccepted",
+                "type": "saml20-sp"
+            }
+	    }';
+
+        $input = sprintf($connection, addslashes($acsLocation));
+        $input = json_decode($input);
+
+        $this->assembler->assemble($input);
+    }
+
+    public function invalidAcsLocations()
+    {
+        return [
+            'invalid-scheme' => ['javascript:alert("hello world");'],
+            'no-scheme' => ['www.sp.example.com'],
+        ];
+    }
+}

--- a/theme/material/templates/modules/Authentication/View/Feedback/unsupported-acs-location-scheme.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/unsupported-acs-location-scheme.html.twig
@@ -1,0 +1,7 @@
+{% extends '@theme/Default/View/Error/error.html.twig' %}
+
+{% set wide = true %}
+{% set pageTitle = 'error_unsupported_acs_location_scheme'|trans %}
+{% block pageTitle %}{{ pageTitle }}{% endblock %}
+{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block pageHeading %}{{ pageTitle }}{% endblock %}


### PR DESCRIPTION
There was a possible XSS vulnerability where EB would take the ACS location from a signed AuthnRequest and use that location to send the SAMLResponse. The URI scheme was prone to XSS, as the JS URI scheme was allowed.

The proposed change makes the allowed URI schemes configurable. By default only allowing the `http` and `https` schemes.

The ACS locations that are received from Manage are also validated.

This PR is first targeted at the 5.8 branch.

:warning: Disclaimer, the build fails on the security checker. This is a well-considered decision.