### PR TITLE
Fix displayName on WAYF

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -351,7 +351,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
             '@theme/Authentication/View/Proxy/wayf.html.twig',
             [
                 'action' => $action,
-                'greenHeader' => $serviceProvider->getDisplayName(),
+                'greenHeader' => $serviceProvider->getDisplayName($currentLocale),
                 'helpLink' => '/authentication/idp/help-discover?lang=' . $currentLocale,
                 'backLink' => $container->isUiOptionReturnToSpActive(),
                 'cutoffPointForShowingUnfilteredIdps' => $container->getCutoffPointForShowingUnfilteredIdps(),


### PR DESCRIPTION
It always showed the English version, despite the current locale