### PR TITLE
Stop overwriting the NameId before giving consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ We will continue to post relevant release notes on the GitHub release page. More
 
 More information about our release strategy can be found in the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes) on the EngineBlock wiki.
 
+## 5.8.6
+**Bugfix**: Stop overwriting the NameId before giving consent #610
+
 ## 5.8.5
 Bugfix for a possible break after giving consent. This release is preventing a crash when the original issuer is null #604   
 

--- a/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
+++ b/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
@@ -1,7 +1,6 @@
 <?php
 
 use SAML2\Constants;
-use SAML2\XML\saml\NameID;
 
 class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_Filter_Command_Abstract
     implements EngineBlock_Corto_Filter_Command_ResponseModificationInterface,
@@ -31,34 +30,13 @@ class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_F
         $collabPersonIdValue = $user->getCollabPersonId()->getCollabPersonId();
         $this->setCollabPersonId($collabPersonIdValue);
 
-        if ($this->_serviceProvider->nameIdFormat === Constants::NAMEID_TRANSIENT) {
-            // The collabPersonIdValue is set as the transient name id format. This will be updated in the output
-            // pipeline.
-            $nameId = NameID::fromArray(
-                array(
-                    'Value' => $collabPersonIdValue,
-                    'Format' => Constants::NAMEID_TRANSIENT,
-                )
-            );
-        } else {
-            // Only use the resolver when dealing with non transient NameID's as they will be overwritten in the output
-            // pipeline. Resulting in a recurring consent screen on successive log-ins.
-            $resolver = new EngineBlock_Saml2_NameIdResolver();
-            $nameId = $resolver->resolve(
-                $this->_request,
-                $this->_response,
-                $this->_serviceProvider,
-                $this->_collabPersonId
-            );
-
-            // To actually set the collabPersonIdValue, override it with the one we just generated. The resolver used the
-            // intended name id format for this purpose (but this is not set yet)
-            if ($nameId->Format == Constants::NAMEID_UNSPECIFIED) {
-                $nameId->value = $collabPersonIdValue;
-            }
-        }
+        $this->_response->setCollabPersonId($collabPersonIdValue);
+        $this->_response->setOriginalNameId($this->_response->getNameId());
 
         // Adjust the NameID in the OLD response (for consent), set the collab:person uid
-        $this->_response->getAssertion()->setNameId($nameId);
+        $this->_response->getAssertion()->setNameId(array(
+            'Value' => $collabPersonIdValue,
+            'Format' => Constants::NAMEID_PERSISTENT,
+        ));
     }
 }

--- a/library/EngineBlock/Corto/Model/Consent.php
+++ b/library/EngineBlock/Corto/Model/Consent.php
@@ -30,18 +30,27 @@ class EngineBlock_Corto_Model_Consent
     private $_databaseConnectionFactory;
 
     /**
+     * A reflection of the eb.run_all_manipulations_prior_to_consent feature flag
+     *
+     * @var bool
+     */
+    private $_amPriorToConsentEnabled;
+
+    /**
      * @param string $tableName
      * @param bool $mustStoreValues
      * @param EngineBlock_Saml2_ResponseAnnotationDecorator $response
      * @param array $responseAttributes
      * @param EngineBlock_Database_ConnectionFactory $databaseConnectionFactory
+     * @param bool $amPriorToConsentEnabled Is the run_all_manipulations_prior_to_consent feature enabled or not
      */
     public function __construct(
         $tableName,
         $mustStoreValues,
         EngineBlock_Saml2_ResponseAnnotationDecorator $response,
         array $responseAttributes,
-        EngineBlock_Database_ConnectionFactory $databaseConnectionFactory
+        EngineBlock_Database_ConnectionFactory $databaseConnectionFactory,
+        $amPriorToConsentEnabled
     )
     {
         $this->_tableName = $tableName;
@@ -49,6 +58,7 @@ class EngineBlock_Corto_Model_Consent
         $this->_response = $response;
         $this->_responseAttributes = $responseAttributes;
         $this->_databaseConnectionFactory = $databaseConnectionFactory;
+        $this->_amPriorToConsentEnabled = $amPriorToConsentEnabled;
     }
 
     public function explicitConsentWasGivenFor(ServiceProvider $serviceProvider) {
@@ -96,6 +106,10 @@ class EngineBlock_Corto_Model_Consent
 
     protected function _getConsentUid()
     {
+        if ($this->_amPriorToConsentEnabled) {
+            $nameIdValue = $this->_response->getOriginalResponse()->getCollabPersonId();
+            return $nameIdValue;
+        }
         return $this->_response->getNameIdValue();
     }
 

--- a/library/EngineBlock/Corto/Model/Consent/Factory.php
+++ b/library/EngineBlock/Corto/Model/Consent/Factory.php
@@ -37,12 +37,21 @@ class EngineBlock_Corto_Model_Consent_Factory
         EngineBlock_Saml2_ResponseAnnotationDecorator $response,
         array $attributes
     ) {
+        // If attribute manipulation was executed before consent, the NameId must be retrieved from the original response
+        // object, in order to ensure correct 'hashed_user_id' generation.
+        $featureConfiguration = EngineBlock_ApplicationSingleton::getInstance()
+            ->getDiContainer()
+            ->getFeatureConfiguration();
+
+        $amPriorToConsent = $featureConfiguration->isEnabled('eb.run_all_manipulations_prior_to_consent');
+
         return new EngineBlock_Corto_Model_Consent(
             $proxyServer->getConfig('ConsentDbTable', 'consent'),
             $proxyServer->getConfig('ConsentStoreValues', true),
             $response,
             $attributes,
-            $this->_databaseConnectionFactory
+            $this->_databaseConnectionFactory,
+            $amPriorToConsent
         );
     }
 }


### PR DESCRIPTION
More details why this change was made can be found [in the Pivotal issue that was filed](https://www.pivotaltracker.com/story/show/162440852).

This PR ensures the correct NameId value is displayed on the consent screen without overwriting the NameId before the output filtering is applied. When EB is configured to run with `run_all_manipulations_prior_to_consent`, then also the correct values are shown on the consent screen.

Note that the build fails on the security checker. This is an acceptable risk at this point. And will be fixed in EB 5.9

This PR targets release `5.8.6` and should also land on `master` (5.9)