### PR TITLE
Downgrade unsupported ACS location to a warning for now.

### DIFF
--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -677,9 +677,10 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
     private function assertValidAcsLocationScheme($acsLocation)
     {
         if ($acsLocation && !$this->acsLocationSchemeValidator->validate($acsLocation)) {
-            throw new EngineBlock_Corto_Module_Bindings_UnsupportedAcsLocationSchemeException(
-                'The received ACS location does not have a valid scheme'
-            );
+            $this->_logger->warning(sprintf('The received ACS location "%s" does not have a valid scheme', $acsLocation));
+//            throw new EngineBlock_Corto_Module_Bindings_UnsupportedAcsLocationSchemeException(
+//                'The received ACS location does not have a valid scheme'
+//            );
         }
     }
 

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -678,9 +678,6 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
     {
         if ($acsLocation && !$this->acsLocationSchemeValidator->validate($acsLocation)) {
             $this->_logger->warning(sprintf('The received ACS location "%s" does not have a valid scheme', $acsLocation));
-//            throw new EngineBlock_Corto_Module_Bindings_UnsupportedAcsLocationSchemeException(
-//                'The received ACS location does not have a valid scheme'
-//            );
         }
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AcsTinkering.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AcsTinkering.feature
@@ -1,3 +1,4 @@
+@SKIP
 Feature:
   In order to prevent XSS attacks
   As a user


### PR DESCRIPTION
Even though our bar is not that high (just needs to start with
'http:' or 'https:'), there's stuff out there that does not meet
this bar. Log it first so we can get that fixed before we block
it.