### PR TITLE
Make tests Behat 3 compatible on Travis PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,10 @@ branches:
     - release/5.8
     - feature/symfony-upgrade-3.4-retry
 
+after_failure:
+  - cat ~/build/OpenConext/OpenConext-engineblock/app/logs/test/test.log
+  - sudo cat /var/log/syslog
+
 addons:
   hosts:
     - engine.vm.openconext.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ branches:
 
 after_failure:
   - cat ~/build/OpenConext/OpenConext-engineblock/app/logs/test/test.log
-  - sudo cat /var/log/syslog
+  - sudo tail -500 /var/log/syslog
 
 addons:
   hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: php
 
-dist: precise
+dist: xenial
 
 php:
   - 5.6
-#  - 7.0
+  - 7.2
 
 matrix:
   fast_finish: true
-#  allow_failures:
-#  - php: 7.0
-#  - env: COMMAND="functional-tests-wip"
+  allow_failures:
+  - php: 7.2
+  - env: COMMAND="functional-tests-wip"
 
 sudo: true # sudo is required for behat
 
 env:
   matrix:
     - COMMAND="functional-tests"
-#    - COMMAND="functional-tests-wip"
-#    - COMMAND="code-quality-ci"
-#    - COMMAND="security-tests"
-#    - COMMAND="composer-validate"
+    - COMMAND="functional-tests-wip"
+    - COMMAND="code-quality-ci"
+    - COMMAND="security-tests"
+    - COMMAND="composer-validate"
   global:
     - SYMFONY_ENV=test
     - ENGINEBLOCK_ENV=test
@@ -44,14 +44,17 @@ before_script:
   - mkdir -p /tmp/engineblock/cache/test
   - mkdir -p /tmp/engineblock/logs/test
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo apt-get install apache2 libapache2-mod-fastcgi ant
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf; fi
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias ssl
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
-  - sudo cp -f ci/travis/vhost-apache /etc/apache2/sites-available/default-ssl
-  - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default-ssl
+  - sudo cp -f ci/travis/vhost-apache /etc/apache2/sites-available/default-ssl.conf
+  - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default-ssl.conf
+  - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
+  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
+  - sudo a2dissite 000-default
   - sudo a2ensite default-ssl
   - sudo service apache2 restart
   - composer self-update
@@ -70,8 +73,13 @@ branches:
     - feature/symfony-upgrade-3.4-retry
 
 after_failure:
+  - sudo tail -500 /var/log/apache2/error.log
+  - sudo tail -500 /var/log/apache2/access.log
   - cat ~/build/OpenConext/OpenConext-engineblock/app/logs/test/test.log
   - sudo tail -500 /var/log/syslog
+
+services:
+  - mysql
 
 addons:
   hosts:

--- a/ci/travis/vhost-apache
+++ b/ci/travis/vhost-apache
@@ -1,41 +1,47 @@
-<VirtualHost *:443>
-    ServerName engine.vm.openconext.org
+<IfModule mod_ssl.c>
+	<VirtualHost *:443>
+        ServerAdmin webmaster@localhost
+        DocumentRoot %TRAVIS_BUILD_DIR%/web
+        ServerName engine.vm.openconext.org
 
-    SetEnv ENGINEBLOCK_ENV test
-    SetEnv SYMFONY_ENV test
-    SetEnv HTTPS off
+        SetEnv ENGINEBLOCK_ENV test
+        SetEnv SYMFONY_ENV test
+        SetEnv HTTPS off
 
-    DocumentRoot %TRAVIS_BUILD_DIR%/web
+        SSLEngine on
 
-    <Directory "%TRAVIS_BUILD_DIR%/web">
-        Options FollowSymLinks MultiViews ExecCGI
-        AllowOverride All
-        Order Allow,Deny
-        Allow from all
-    </Directory>
+        SSLCertificateFile      /etc/openconext/engine.vm.openconext.org.crt
+        SSLCertificateKeyFile   /etc/openconext/engine.vm.openconext.org.key
 
-    <IfModule mod_rewrite.c>
-        RewriteEngine On
-        RewriteRule ^/php5-fcgi - [L]
-        # If the requested url does not map to a file or directory, then forward it to app.php/URL.
-        # Note that the requested URL MUST be appended because Corto uses the PATH_INFO server variable
-        RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} !-f
-        RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} !-d
-        RewriteRule ^(.*)$ /app.php/$1 [L] # Send the query string to app(_dev).php
-        # Requests to the domain (no query string)
-        RewriteRule ^$ /app.php/ [L]
-    </IfModule>
+        <Directory "%TRAVIS_BUILD_DIR%/web">
+            Options FollowSymLinks MultiViews ExecCGI
+            AllowOverride All
+            Require all granted
+        </Directory>
 
-    # Wire up Apache to use Travis CI's php-fpm.
-    <IfModule mod_fastcgi.c>
-        AddHandler php5-fcgi .php
-        Action php5-fcgi /php5-fcgi
-        Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-        FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
-    </IfModule>
+        <IfModule mod_rewrite.c>
+            RewriteEngine On
+            RewriteRule ^/php5-fcgi - [L]
+            # If the requested url does not map to a file or directory, then forward it to app.php/URL.
+            # Note that the requested URL MUST be appended because Corto uses the PATH_INFO server variable
+            RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} !-f
+            RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} !-d
+            RewriteRule ^(.*)$ /app.php/$1 [L] # Send the query string to app(_dev).php
+            # Requests to the domain (no query string)
+            RewriteRule ^$ /app.php/ [L]
+        </IfModule>
 
-    SSLEngine on
+        # Wire up Apache to use Travis CI's php-fpm.
+        <IfModule mod_fastcgi.c>
+            AddHandler php5-fcgi .php
+            Action php5-fcgi /php5-fcgi
+            Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+            FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
 
-    SSLCertificateFile      /etc/openconext/engine.vm.openconext.org.crt
-    SSLCertificateKeyFile   /etc/openconext/engine.vm.openconext.org.key
-</VirtualHost>
+            <Directory /usr/lib/cgi-bin>
+                Require all granted
+            </Directory>
+        </IfModule>
+
+	</VirtualHost>
+</IfModule>

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "behat/mink-goutte-driver": "~1.0",
         "behat/symfony2-extension": "~2.0",
         "ingenerator/behat-tableassert": "^1.1",
+        "league/flysystem": "^1.0",
         "liip/functional-test-bundle": "^1.7",
         "mockery/mockery": "0.9.4",
         "phake/phake": "2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1dbf6c1d66962132a77f17e428136d63",
+    "content-hash": "842593e880290d93ed5ef3306e320c41",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2699,7 +2699,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -4138,6 +4138,90 @@
             "description": "Assertions for all sorts of tabular data in behat",
             "homepage": "https://github.com/ingenerator/behat-tableassert",
             "time": "2016-09-05T10:39:11+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "1.0.49",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "a63cc83d8a931b271be45148fa39ba7156782ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a63cc83d8a931b271be45148fa39ba7156782ffd",
+                "reference": "a63cc83d8a931b271be45148fa39ba7156782ffd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^3.4",
+                "phpunit/phpunit": "^5.7.10"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "time": "2018-11-23T23:41:29+00:00"
         },
         {
             "name": "liip/functional-test-bundle",

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -225,6 +225,9 @@ class MockIdpContext extends AbstractSubContext
      */
     public function noRegisteredIdentityProviders()
     {
+        // Travis / PHP 5.6 issue requires gc cycle in order to actually clear the fixture
+        // https://www.pivotaltracker.com/story/show/161282428
+        gc_collect_cycles();
         $this->mockIdpRegistry->clear()->save();
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -248,6 +248,9 @@ class MockSpContext extends AbstractSubContext
      */
     public function noRegisteredServiceProviders()
     {
+        // Travis / PHP 5.6 issue requires gc cycle in order to actually clear the fixture
+        // https://www.pivotaltracker.com/story/show/161282428
+        gc_collect_cycles();
         $this->mockSpRegistry->clear()->save();
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
@@ -19,7 +19,7 @@ abstract class AbstractDataStore
     {
         $this->filePath = $filePath;
         $directory = dirname($this->filePath);
-        $adapter = new Local($directory);
+        $adapter = new Local($directory, LOCK_NB);
         $this->fileSystem = new Filesystem($adapter);
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
@@ -43,7 +43,6 @@ abstract class AbstractDataStore
         if ($data === false) {
             throw new RuntimeException('Unable to decode data from: ' . $this->filePath);
         }
-
         return $data;
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
@@ -17,14 +17,18 @@ abstract class AbstractDataStore
 
     public function __construct($filePath)
     {
-        $this->filePath = $filePath;
-        $directory = dirname($this->filePath);
+        $directory = dirname($filePath);
+        $this->filePath = basename($filePath);
         $adapter = new Local($directory, LOCK_NB);
         $this->fileSystem = new Filesystem($adapter);
     }
 
     public function load($default = [])
     {
+        if (!$this->fileSystem->has($this->filePath)) {
+            return $default;
+        }
+
         $fileContents = $this->fileSystem->read($this->filePath);
 
         if ($fileContents === false) {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingAttributeAggregationClient.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingAttributeAggregationClient.php
@@ -109,6 +109,9 @@ final class FunctionalTestingAttributeAggregationClient implements AttributeAggr
     public function returnsAttribute($name, array $values, $source)
     {
         $attributes = $this->dataStore->load();
+        if (is_null($attributes)) {
+            $attributes = [];
+        }
 
         $attributes[] = [
             'name'   => $name,


### PR DESCRIPTION
This PR tries to isolate (and fix) the issue with the failing functional tests on PHP 5.6 builds. Behat 3 on Travis Precice in combination with PHP 5.6 causes weird filesystem issues. Where files written to disk (in the project folder) are not always readable.

The following commits address this issue by leveraging Flysystem. Flysystem can easily be set with different locking strategies.

In addition to using Flysystem, an additional manual call to gc_collect_cycles was required to ensure clearing the fixture files does not fail.

One other task that was included in this PR was the move from Travis (precise) to Travis Xenial. Hoping the filesystem issue would not be present on that platform. This was not the case. But moving away from the already decommissioned Precise was a task that was overdue.

https://www.pivotaltracker.com/story/show/161282428 