### PR TITLE
Filter AA response

### DIFF
--- a/src/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/Response.php
+++ b/src/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/Response.php
@@ -40,7 +40,11 @@ final class Response
         $attributes = [];
 
         foreach ($jsonData as $attributeData) {
-            $attributes[] = self::parseAggregatedAttribute($attributeData);
+            $attribute = self::parseAggregatedAttribute($attributeData);
+            if (!$attribute) {
+                continue;
+            }
+            $attributes[] = $attribute;
         }
 
         $response = new self;
@@ -50,8 +54,8 @@ final class Response
     }
 
     /**
-     * @param array $jsonData
-     * @return AggregatedAttribute
+     * @param array $attributeData
+     * @return AggregatedAttribute|null
      */
     private static function parseAggregatedAttribute(array $attributeData)
     {
@@ -67,9 +71,17 @@ final class Response
             throw new InvalidAttributeAggregationResponseException('Missing aggregated attribute source');
         }
 
+        // All values must be string. See: https://www.pivotaltracker.com/story/show/162197380
+        $values = (array) $attributeData['values'];
+        foreach ($values as $value) {
+            if (!is_string($value)) {
+                return null;
+            }
+        }
+
         return AggregatedAttribute::from(
             (string) $attributeData['name'],
-            (array) $attributeData['values'],
+            $values,
             (string) $attributeData['source']
         );
     }

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/AttributeAggregationClientTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/AttributeAggregationClientTest.php
@@ -67,4 +67,38 @@ class AttributeAggregationClientTest extends TestCase
         $this->assertEquals('urn:x-surfnet:surfnet.nl:sab:role:Coordinerend-SURF-Contactpersoon', $response->attributes[0]->values[1]);
         $this->assertEquals('sab', $response->attributes[0]->source);
     }
+
+    /**
+     * @test
+     */
+    public function an_attributeaggregation_client_parses_the_aggregator_response_and_filters_non_string_values()
+    {
+        $request = Request::from(
+            'sp-entity-id',
+            'subject',
+            [],
+            [
+                AttributeRule::from('name', 'value', 'source'),
+                AttributeRule::from('name', 'value', 'source'),
+            ]
+        );
+
+        $responseFixture = file_get_contents(__DIR__ . '/fixture/success-response-with-epti.json');
+
+        $mockHandler = new MockHandler([
+            new GuzzleResponse(200, [], $responseFixture)
+        ]);
+
+        $guzzle = new Client(['handler' => $mockHandler]);
+
+        $client = new AttributeAggregationClient(new HttpClient($guzzle), 'https://attr.at/api');
+        $response = $client->aggregate($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertCount(2, $response->attributes);
+        $this->assertEquals('urn:mace:dir:attribute-def:eduPersonEntitlement', $response->attributes[0]->name);
+        $this->assertEquals('urn:x-surfnet:surfnet.nl:sab:role:SURFwireless-beheerder', $response->attributes[0]->values[0]);
+        $this->assertEquals('urn:x-surfnet:surfnet.nl:sab:role:Coordinerend-SURF-Contactpersoon', $response->attributes[0]->values[1]);
+        $this->assertEquals('sab', $response->attributes[0]->source);
+    }
 }

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/fixture/success-response-with-epti.json
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/fixture/success-response-with-epti.json
@@ -1,0 +1,32 @@
+[
+   {
+      "name": "urn:mace:dir:attribute-def:eduPersonEntitlement",
+      "values": [
+         "urn:x-surfnet:surfnet.nl:sab:role:SURFwireless-beheerder",
+         "urn:x-surfnet:surfnet.nl:sab:role:Coordinerend-SURF-Contactpersoon"
+      ],
+      "source": "sab"
+   },
+   {
+      "name": "urn:mace:dir:attribute-def:isMemberOf",
+      "values": [
+         "urn:collab:group:surfnet.nl:crowd-surfnet",
+         "urn:collab:group:test.surfteams.nl:nl:surfnet:diensten:surflabs"
+      ],
+      "source": "voot"
+   },
+   {
+      "name": "urn:mace:dir:attribute-def:eduPersonTargetedID",
+      "values": [
+         {
+            "Format": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+            "SPProvidedID": null,
+            "value": "Bladiebla",
+            "NameQualifier": "https:\/\/idp.123.tld\/idp\/shibboleth",
+            "SPNameQualifier": "https:\/\/engine.123.tld",
+            "element": {}
+         }
+      ],
+      "source": "idp"
+   }
+]


### PR DESCRIPTION
AA response values that are non-string should be filtered out of the
AA client response. The EPTI caused this problem to surface. See the
ticket below for more information.

See: https://www.pivotaltracker.com/story/show/162197380