### PR TITLE
Update the consent reject text

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -147,8 +147,8 @@ TXT
 
     // Consent slidein: Reject
     'consent_slidein_reject_text'  => <<<'TXT'
-<h1>You declined to share your data</h1>
-<p>The service you're logging into requires your data to function. If you do not agree with sharing your data, you cannot use this service. By closing your browser or this tab you fully decline to share the necessary information. If you change your mind after this, please return to the service and you will be asked for permission once again.</p>
+<h1>You don't want to share your data with the service</h1>
+<p>The service you're logging into requires your data to function properly. If you prefer not to share your data, you cannot use this service. By closing your browser or just this tab you prevent your information from being shared with the service. If you change your mind later, please login to the service again and this screen will reappear.</p>
 TXT
     ,
 

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -145,8 +145,8 @@ TXT
 
     // Consent slidein: Reject
     'consent_slidein_reject_text'  => <<<'TXT'
-<h1>Je geeft geen toestemming om gegevens door te sturen</h1>
-<p>De dienst waar je probeert in te loggen heeft jouw gegevens nodig om te kunnen functioneren. Als je hier geen toestemming voor geeft dan kun je geen gebruik maken van deze dienst. Door je browser of dit tabblad af te sluiten geef je geen toestemming voor het doorsturen van gegevens. Als je je hierna bedenkt, log dan opnieuw in bij de dienst; je wordt dan opnieuw gevraagd om toestemming te geven.</p>
+<h1>Je wilt geen gegevens delen met de dienst</h1>
+<p>De dienst waar je probeert in te loggen heeft jouw gegevens nodig om te kunnen functioneren. Als je deze gegevens niet wilt delen dan kun je geen gebruik maken van deze dienst. Door je browser of dit tabblad af te sluiten voorkom je het doorsturen van je gegevens. Als je je hierna bedenkt, log dan opnieuw in bij de dienst; je krijgt dit scherm dan opnieuw te zien.</p>
 TXT
     ,
 


### PR DESCRIPTION
The text is rephrased in order to prevent possible confusion when
minimal consent is rejected.

https://www.pivotaltracker.com/story/show/161508398