### PR TITLE
Show explanation when no attributes required

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -116,6 +116,7 @@ HTML
     'consent_attributes_correction_link'      => 'Are your details incorrect?',
     'consent_attributes_show_more'            => 'Show more information',
     'consent_attributes_show_less'            => 'Show less information',
+    'consent_no_attributes_text'              => 'This service requires no information from your institution.',
     'consent_buttons_title'                   => 'Do you agree with sharing this data?',
     'consent_buttons_ok'                      => 'Yes, proceed to %arg1%',
     'consent_buttons_ok_minimal'              => 'Proceed to %arg1%',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -113,6 +113,7 @@ HTML
     'consent_attributes_correction_link'      => 'Kloppen deze gegevens niet?',
     'consent_attributes_show_more'            => 'Toon alle gegevens',
     'consent_attributes_show_less'            => 'Toon minder gegevens',
+    'consent_no_attributes_text'              => 'Voor deze dienst zijn geen gegevens van jouw instelling nodig.',
     'consent_buttons_title'                   => 'Ga je akkoord met het doorsturen van deze gegevens?',
     'consent_buttons_ok'                      => 'Ja, ga door naar %arg1%',
     'consent_buttons_ok_minimal'              => 'Ga door naar %arg1%',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -103,6 +103,7 @@ HTML
     'consent_attributes_correction_link'      => 'Os seus detalhes estão incorrectos?',
     'consent_attributes_show_more'            => 'Mostrar mais informação',
     'consent_attributes_show_less'            => 'Mostrar menos informação',
+    'consent_no_attributes_text'              => 'Este serviço não requer informações da sua instituição',
     'consent_buttons_title'                   => 'Concorda com a partilha desta informação?',
     'consent_buttons_ok'                      => 'Sim, prossiga para %arg1%',
     'consent_buttons_ok_minimal'              => 'Prossiga para %arg1%',

--- a/theme/material/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -32,6 +32,8 @@
                 {% endif %}
             </header>
 
+            {% if attributes|length > 0 %}
+
             <section class="privacy">
                 <h2>{{ 'consent_privacy_title'|trans({'%arg1%': spName}) }}</h2>
             </section>
@@ -147,6 +149,58 @@
                     {% endfor %}
                 </table>
             </section>
+
+            {% else %}
+            {# There are no attributes requested by the SP #}
+
+            <section class="privacy">
+                <h2>{{ 'consent_no_attributes_text'|trans }}</h2>
+            </section>
+
+            <section class="attributes">
+                <table class="comp-table attributes">
+
+                    {% for attributeSource, attributes in attributesBySource %}
+                        {% if attributeSource == 'engineblock' %}
+                        <tbody data-attr-source="{{ attributeSource }}">
+                        <tr class="source-info">
+                            <td colspan="2">
+
+                                    <img width="30" height="30" src="{{ defaultLogo }}"
+                                         alt=""/>
+                                    <h2>{{ 'suite_name'|trans }}</h2>
+                                    <a class="small" href="{{ nameIdSupportUrl }}" target="_blank">{{ 'consent_name_id_support_link'|trans }}</a>
+
+                            </td>
+                        </tr>
+                        {% endif %}
+
+                        {% for attributeIdentifier, attributeValues in attributes %}
+
+                            {% if attributeSource == 'engineblock' %}
+                                <tr>
+                                    <td class="attr-name" data-identifier="{{ attributeIdentifier }}">{{ 'consent_name_id_label'|trans }}</td>
+                                    <td class="attr-value" data-identifier="{{ attributeIdentifier }}">
+
+                                        {% spaceless %}
+                                            {% if nameIdIsPersistent %}
+                                                <a class="help tooltip" title="{{ 'consent_name_id_value_tooltip'|trans({'%arg1%': 'suite_name'|trans }) }}" href="#">
+                                            {% endif %}
+                                            <span>{{ attributeValues }}</span>
+                                            {% if nameIdIsPersistent %}
+                                                </a>
+                                            {% endif %}
+                                        {% endspaceless %}
+                                    </td>
+                                </tr>
+                            {% endif %}
+                        {% endfor %}
+                        </tbody>
+                    {% endfor %}
+                </table>
+            </section>
+
+            {% endif %}
 
             {% if showConsentExplanation and consentSettings.consentExplanationIn(app.request.locale, spEntityId) %}
             <section class="idp-consent-explanation">


### PR DESCRIPTION
For some SPs, no attributes are sent from IdP to SP (only NameID). In
those cases, the information below the IdP is missing (which is logical
because no attributes are sent). This PR adds the new text and displays
it in the consent template when no attributes are present.

https://www.pivotaltracker.com/story/show/163524882