### PR TITLE
Remove separate test build from ant

### DIFF
--- a/app_dev.php.dist
+++ b/app_dev.php.dist
@@ -10,7 +10,9 @@ require_once __DIR__.'/../app/AppKernel.php';
 
 $request = Request::createFromGlobals();
 
-$kernel = new AppKernel('dev', true);
+$env = (isset($_SERVER['HTTP_USER_AGENT']) && $_SERVER['HTTP_USER_AGENT'] === 'Symfony BrowserKit' ? 'test' : 'dev');
+
+$kernel = new AppKernel($env, true);
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/build.xml
+++ b/build.xml
@@ -178,27 +178,23 @@
 
     <target name="behat-dev">
         <echo message="Preparing the dev env to run in functional testing mode" />
-        <antcall target="enable-test-env"/>
         <antcall target="prepare-env"/>
         <echo message="${line.separator}${line.separator}Running Behat"/>
         <antcall target="run-behat">
             <param name="suite" value="default"/>
         </antcall>
         <echo message="${line.separator}${line.separator}Reverting the dev env to run in normal mode"/>
-        <antcall target="disable-test-env"/>
         <antcall target="prepare-env"/>
     </target>
 
     <target name="behat-dev-wip">
         <echo message="Preparing the dev env to run in functional testing mode" />
-        <antcall target="enable-test-env"/>
         <antcall target="prepare-env"/>
         <echo message="${line.separator}${line.separator}Running Behat"/>
         <antcall target="run-behat">
             <param name="suite" value="wip"/>
         </antcall>
         <echo message="${line.separator}${line.separator}Reverting the dev env to run in normal mode"/>
-        <antcall target="disable-test-env"/>
         <antcall target="prepare-env"/>
     </target>
 
@@ -224,20 +220,6 @@
             <arg line="--suite ${suite} -vv"/>
             <arg line="--format progress"/>
         </exec>
-    </target>
-
-    <target name="enable-test-env"
-            description="Set the environment in app_dev.php test">
-        <replace file="${basedir}/web/app_dev.php"
-                 token="new AppKernel('dev', true)"
-                 value="new AppKernel('test', true)"/>
-    </target>
-
-    <target name="disable-test-env"
-            description="Set the environment in app_dev.php dev">
-        <replace file="${basedir}/web/app_dev.php"
-                 token="new AppKernel('test', true)"
-                 value="new AppKernel('dev', true)"/>
     </target>
 
     <target name="prepare-env"


### PR DESCRIPTION
Ant changed the app_dev.php when starting the tests. So 'dev' was
changed to 'test' to run in test mode. This resulted in a corrupt
app_dev.php when a test failed.