### PR TITLE
Catch SSO endpoint [ab|mis]use earlier

### DIFF
--- a/src/OpenConext/EngineBlock/Exception/InvalidBindingException.php
+++ b/src/OpenConext/EngineBlock/Exception/InvalidBindingException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Exception;
+
+class InvalidBindingException extends RuntimeException
+{
+}

--- a/src/OpenConext/EngineBlock/Exception/InvalidRequestMethodException.php
+++ b/src/OpenConext/EngineBlock/Exception/InvalidRequestMethodException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Exception;
+
+class InvalidRequestMethodException extends RuntimeException
+{
+}

--- a/src/OpenConext/EngineBlock/Validator/RequestValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/RequestValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Validator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface RequestValidator
+{
+    public function isValid(Request $request);
+}

--- a/src/OpenConext/EngineBlock/Validator/SsoRequestValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/SsoRequestValidator.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Validator;
+
+use Exception;
+use OpenConext\EngineBlock\Exception\InvalidBindingException;
+use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
+use SAML2\Binding;
+use SAML2\HTTPPost;
+use SAML2\HTTPRedirect;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The SsoRequestValidator verifies valid requests on the SSO endpoint
+ *
+ * Valid requests method / binding combinations for SSO are:
+ *
+ *  | SAML Binding     | Request method | Parameter name |
+ *  | ---------------- | -------------- | -------------- |
+ *  | HttpRedirect     | GET            | SAMLRequest    |
+ *  | HTTPPost         | POST           | SAMLRequest    |
+ */
+class SsoRequestValidator implements RequestValidator
+{
+    private $supportedRequestMethods = [Request::METHOD_GET, Request::METHOD_POST];
+
+    public function isValid(Request $request)
+    {
+        $requestMethod = $request->getMethod();
+        // Defense in depth; anything other than POST and GET are probably already rejected at routing time.
+        if (!in_array($requestMethod, $this->supportedRequestMethods)) {
+            // Only Redirect binding is supported for Single Sign On
+            throw new InvalidRequestMethodException(
+                sprintf('The HTTP request method "%s" is not supported on this SAML SSO endpoint', $requestMethod)
+            );
+        }
+        try {
+            $binding = Binding::getCurrentBinding();
+        } catch (Exception $e) {
+            throw new InvalidBindingException(
+                sprintf('No SAMLRequest parameter was found in the HTTP "%s" request parameters', $requestMethod),
+                0,
+                $e
+            );
+        }
+        if (!($binding instanceof HTTPRedirect || $binding instanceof HTTPPost)) {
+            // We only support HTTP Redirect binding
+            throw new InvalidBindingException(
+                sprintf('The binding type "%s" is not supported on this SAML SSO endpoint', get_class($binding))
+            );
+        }
+        return true;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -22,6 +22,7 @@ use EngineBlock_ApplicationSingleton;
 use EngineBlock_Corto_Adapter;
 use Exception;
 use OpenConext\EngineBlock\Service\RequestAccessMailer;
+use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
 use OpenConext\Value\Saml\Entity;
 use OpenConext\Value\Saml\EntityId;
@@ -62,28 +63,37 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
      */
     private $session;
 
+    /**
+     * @var RequestValidator
+     */
+    private $requestValidator;
+
     public function __construct(
         EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton,
         Twig_Environment $twig,
         LoggerInterface $loggerInterface,
         RequestAccessMailer $requestAccessMailer,
-        Session $session
+        Session $session,
+        RequestValidator $validator
     ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
         $this->twig = $twig;
         $this->logger = $loggerInterface;
         $this->requestAccessMailer = $requestAccessMailer;
         $this->session = $session;
+        $this->requestValidator = $validator;
     }
 
     /**
+     * @param Request $request
      * @param null|string $keyId
      * @param null|string $idpHash
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
-     * @throws Exception
      */
-    public function singleSignOnAction($keyId = null, $idpHash = null)
+    public function singleSignOnAction(Request $request, $keyId = null, $idpHash = null)
     {
+        $this->requestValidator->isValid($request);
+
         $cortoAdapter = new EngineBlock_Corto_Adapter();
 
         if ($keyId !== null) {

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -73,18 +73,27 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
         Twig_Environment $twig,
         LoggerInterface $loggerInterface,
         RequestAccessMailer $requestAccessMailer,
-        Session $session,
-        RequestValidator $validator
+        RequestValidator $validator,
+        Session $session
     ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
         $this->twig = $twig;
         $this->logger = $loggerInterface;
         $this->requestAccessMailer = $requestAccessMailer;
-        $this->session = $session;
         $this->requestValidator = $validator;
+        $this->session = $session;
     }
 
     /**
+     * The SSO action
+     *
+     *  Currently supported request method / binding combinations for SSO are:
+     *
+     *  | SAML Binding     | Request method | Parameter name |
+     *  | ---------------- | -------------- | -------------- |
+     *  | HttpRedirect     | GET            | SAMLRequest    |
+     *  | HTTPPost         | POST           | SAMLRequest    |
+     *
      * @param Request $request
      * @param null|string $keyId
      * @param null|string $idpHash

--- a/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
@@ -12,6 +12,7 @@ services:
             - "@twig"
             - "@engineblock.compat.logger"
             - "@engineblock.service.request_access_mailer"
+            - "@engineblock.validator.sso_request_validator"
             - "@session"
 
     engineblock.controller.authentication.index:

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -141,6 +141,9 @@ services:
         arguments:
             - "%allowed_acs_location_schemes%"
 
+    engineblock.validator.sso_request_validator:
+            class: OpenConext\EngineBlock\Validator\SsoRequestValidator
+
     engineblock.twig.extension.debug:
         class: OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Debug
         tags:

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyControllerApiTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyControllerApiTest.php
@@ -7,7 +7,7 @@ use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 
-class AttributeReleasePolicyControllerTest extends WebTestCase
+class AttributeReleasePolicyControllerApiTest extends WebTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -5,6 +5,7 @@ namespace OpenConext\EngineBlock\Tests;
 use OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler;
 use OpenConext\EngineBlock\Validator\AllowedSchemeValidator;
 use PHPUnit_Framework_TestCase;
+use RuntimeException;
 
 class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
 {
@@ -17,10 +18,11 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider invalidAcsLocations
-     * @expectedException \RuntimeException
      */
     public function test_it_rejects_invalid_acs_location_schemes($acsLocation)
     {
+        $this->expectException(\RuntimeException::class);
+
         $connection = '{
             "2d96e27a-76cf-4ca2-ac70-ece5d4c49523": {
                 "allow_all_entities": true,

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/VerifyShibMdScopingAllowsEduPersonPrincipalNameTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/VerifyShibMdScopingAllowsEduPersonPrincipalNameTest.php
@@ -222,12 +222,11 @@ class EngineBlock_Test_Corto_Filter_Command_VerifyShibMdScopingAllowsEduPersonPr
         $this->assertTrue($invalidScopeIsLogged);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Exception_InvalidAttributeValue
-     * @expectedExceptionMessage eduPersonPrincipalName attribute value "openconext.org" is not allowed by configured ShibMdScopes for IdP "OpenConext"
-     */
     public function testEduPersonPrincipalNameNotInRegexpScopeThrowsException()
     {
+        $this->expectException(EngineBlock_Corto_Exception_InvalidAttributeValue::class);
+        $this->expectExceptionMessage('eduPersonPrincipalName attribute value "openconext.org" is not allowed by configured ShibMdScopes for IdP "OpenConext"');
+
         $scope          = new ShibMdScope();
         $scope->regexp  = true;
         $scope->allowed = '.*\.noconext\.org';

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/VerifyShibMdScopingAllowsSchacHomeOrganisationTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/VerifyShibMdScopingAllowsSchacHomeOrganisationTest.php
@@ -196,12 +196,12 @@ class EngineBlock_Test_Corto_Filter_Command_VerifyShibMdScopingAllowsSchacHomeOr
         $this->assertTrue($invalidScopeIsLogged);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Exception_InvalidAttributeValue
-     * @expectedExceptionMessage schacHomeOrganization attribute value "OpenConext" is not allowed by configured ShibMdScopes for IdP "OpenConext"
-     */
+
     public function testSchacHomeOrganizationNotInRegexpScopeThrowsException()
     {
+        $this->expectException(EngineBlock_Corto_Exception_InvalidAttributeValue::class);
+        $this->expectExceptionMessage('schacHomeOrganization attribute value "OpenConext" is not allowed by configured ShibMdScopes for IdP "OpenConext"');
+
         $scope          = new ShibMdScope();
         $scope->regexp  = true;
         $scope->allowed = '.*\.noconext\.org';

--- a/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use SAML2\Constants;
 use SAML2\Response;
@@ -23,11 +24,10 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends PHPUnit_Framework_TestC
         $this->bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Module_Bindings_UnsupportedBindingException
-     */
     public function testResponseRedirectIsNotSupported()
     {
+        $this->expectException(EngineBlock_Corto_Module_Bindings_UnsupportedBindingException::class);
+
         $response = new EngineBlock_Saml2_ResponseAnnotationDecorator(new Response());
         $response->setDeliverByBinding(Constants::BINDING_HTTP_REDIRECT);
 
@@ -37,7 +37,7 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends PHPUnit_Framework_TestC
 
     /**
      * Provides a list of paths to response xml files and certificate files
-     * 
+     *
      * @return array
      */
     public function responseProvider()

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/Metadata/ServiceReplacerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/Metadata/ServiceReplacerTest.php
@@ -52,12 +52,11 @@ class EngineBlock_Test_ServiceReplacerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedBinding, $this->entity->singleSignOnServices);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception
-     * @expectedExceptionMessage No service 'singleSignOnServices' is configured in EngineBlock metadata
-     */
     public function testMissingServiceMetadataThrowsException()
     {
+        $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
+        $this->expectExceptionMessage('No service \'singleSignOnServices\' is configured in EngineBlock metadata');
+
         unset($this->proxyEntity->singleSignOnServices);
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
 
@@ -68,42 +67,39 @@ class EngineBlock_Test_ServiceReplacerTest extends PHPUnit_Framework_TestCase
         unset($this->proxyEntity->singleSignOnServices);
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::OPTIONAL);
     }
-    /**
-     * @expectedException EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception
-     * @expectedExceptionMessage Service 'SingleSignOnService' in EngineBlock metadata is not an array
-     */
+
     public function testInvalidServiceMetadataThrowsException()
     {
+        $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
+        $this->expectExceptionMessage('Service \'SingleSignOnService\' in EngineBlock metadata is not an array');
+
         $this->proxyEntity->singleSignOnServices = false;
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception
-     * @expectedExceptionMessage Service 'SingleSignOnService' configured without a Binding in EngineBlock metadata
-     */
     public function testMissingServiceBindingMetadataThrowsException()
     {
+        $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
+        $this->expectExceptionMessage('Service \'SingleSignOnService\' configured without a Binding in EngineBlock metadata');
+
         unset($this->proxyEntity->singleSignOnServices[0]->binding);
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception
-     * @expectedExceptionMessage Service 'SingleSignOnService' has an invalid binding 'foo' configured in EngineBlock metadata
-     */
     public function testInvalidServiceBindingMetadataThrowsException()
     {
+        $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
+        $this->expectExceptionMessage('Service \'SingleSignOnService\' has an invalid binding \'foo\' configured in EngineBlock metadata');
+
         $this->proxyEntity->singleSignOnServices[0]->binding = 'foo';
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception
-     * @expectedExceptionMessage No 'singleSignOnServices' service bindings configured in EngineBlock metadata
-     */
     public function testNoValidServiceBindingsFoundInMetadataThrowsException()
     {
+        $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
+        $this->expectExceptionMessage('No \'singleSignOnServices\' service bindings configured in EngineBlock metadata');
+
         $this->proxyEntity->singleSignOnServices = array();
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
     }

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/ProcessConsentTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/ProcessConsentTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use OpenConext\EngineBlock\Metadata\MetadataRepository\InMemoryMetadataRepository;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\InMemoryMetadataRepository;
 use SAML2\Assertion;
 use SAML2\AuthnRequest;
 use SAML2\Response;
@@ -34,12 +34,11 @@ class EngineBlock_Test_Corto_Module_Service_ProcessConsentTest extends PHPUnit_F
         $this->mockGlobals();
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Module_Services_SessionLostException
-     * @expectedExceptionMessage Session lost after consent
-     */
     public function testSessionLostExceptionIfNoSession()
     {
+        $this->expectException(EngineBlock_Corto_Module_Services_SessionLostException::class);
+        $this->expectExceptionMessage('Session lost after consent');
+
         $processConsentService = $this->factoryService();
 
         unset($_SESSION['consent']);
@@ -47,22 +46,21 @@ class EngineBlock_Test_Corto_Module_Service_ProcessConsentTest extends PHPUnit_F
         $processConsentService->serve(null);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Module_Services_SessionLostException
-     * @expectedExceptionMessage Stored response for ResponseID 'test' not found
-     */
     public function testSessionLostExceptionIfPostIdNotInSession()
     {
+        $this->expectException(EngineBlock_Corto_Module_Services_SessionLostException::class);
+        $this->expectExceptionMessage('Stored response for ResponseID \'test\' not found');
+
         unset($_SESSION['consent']['test']);
 
         $processConsentService = $this->factoryService();
         $processConsentService->serve(null);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_Exception_NoConsentProvided
-     */
-    public function testRedirectToFeedbackPageIfConsentNotInPost() {
+    public function testRedirectToFeedbackPageIfConsentNotInPost()
+    {
+        $this->expectException(EngineBlock_Corto_Exception_NoConsentProvided::class);
+
         $processConsentService = $this->factoryService();
 
         unset($_POST['consent']);

--- a/tests/library/EngineBlock/Test/Corto/XmlToArrayTest.php
+++ b/tests/library/EngineBlock/Test/Corto/XmlToArrayTest.php
@@ -121,12 +121,11 @@ SAML
         $this->assertEquals($expectedOutput, $xmlConverter->attributesToArray($attributes));
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_XmlToArray_Exception
-     * @expectedExceptionMessage Missing attribute name
-     */
     public function testAttributeNameIsRequired()
     {
+        $this->expectException(EngineBlock_Corto_XmlToArray_Exception::class);
+        $this->expectExceptionMessage('Missing attribute name');
+
         $xmlConverter = new EngineBlock_Corto_XmlToArray();
         $attributes = array(array());
         $xmlConverter->attributesToArray($attributes);
@@ -147,12 +146,11 @@ SAML
         $this->assertEquals(array(), $output['example']);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_XmlToArray_Exception
-     * @expectedExceptionMessage AttributeValue collection is not an array
-     */
     public function testAttributeValueCollectionShouldBeAnArray()
     {
+        $this->expectException(EngineBlock_Corto_XmlToArray_Exception::class);
+        $this->expectExceptionMessage('AttributeValue collection is not an array');
+
         $xmlConverter = new EngineBlock_Corto_XmlToArray();
         $attributes = array(
             array(
@@ -163,12 +161,11 @@ SAML
         $xmlConverter->attributesToArray($attributes);
     }
 
-    /**
-     * @expectedException EngineBlock_Corto_XmlToArray_Exception
-     * @expectedExceptionMessage AttributeValue is not an array
-     */
     public function testAttributeValueShouldBeAnArray()
     {
+        $this->expectException(EngineBlock_Corto_XmlToArray_Exception::class);
+        $this->expectExceptionMessage('AttributeValue is not an array');
+
         $xmlConverter = new EngineBlock_Corto_XmlToArray();
         $attributes = array(
             array(
@@ -181,8 +178,6 @@ SAML
         $xmlConverter->attributesToArray($attributes);
     }
 
-    /**
-     */
     public function testAttributeValueIsSkippedWhenEmpty()
     {
         $xmlConverter = new EngineBlock_Corto_XmlToArray();

--- a/tests/unit/OpenConext/EngineBlock/Metadata/AttributeReleasePolicyTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/AttributeReleasePolicyTest.php
@@ -90,7 +90,7 @@ class AttributeReleasePolicyTest extends PHPUnit_Framework_TestCase
 
     public function testInvalidArpWithSourceSpecification()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         new AttributeReleasePolicy(
             array(

--- a/tests/unit/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepositoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepositoryTest.php
@@ -45,7 +45,7 @@ class CachedDoctrineMetadataRepositoryTest extends PHPUnit_Framework_TestCase
         $doctrineRepository = Mockery::mock('OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataRepository');
         $doctrineRepository->shouldReceive('findIdentityProviderByEntityId');
 
-        $this->setExpectedException('OpenConext\\EngineBlock\\Metadata\\MetadataRepository\\EntityNotFoundException');
+        $this->expectException(EntityNotFoundException::class);
 
         $repository = new CachedDoctrineMetadataRepository($doctrineRepository);
         $repository->fetchIdentityProviderByEntityId('test');
@@ -56,7 +56,7 @@ class CachedDoctrineMetadataRepositoryTest extends PHPUnit_Framework_TestCase
         $doctrineRepository = Mockery::mock('OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataRepository');
         $doctrineRepository->shouldReceive('findServiceProviderByEntityId');
 
-        $this->setExpectedException('OpenConext\\EngineBlock\\Metadata\\MetadataRepository\\EntityNotFoundException');
+        $this->expectException(EntityNotFoundException::class);
 
         $repository = new CachedDoctrineMetadataRepository($doctrineRepository);
         $repository->fetchServiceProviderByEntityId('test');

--- a/tests/unit/OpenConext/EngineBlock/Validator/SsoRequestValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/SsoRequestValidatorTest.php
@@ -3,15 +3,8 @@
 namespace OpenConext\EngineBlock\Validator;
 
 use Mockery as m;
-use OpenConext\EngineBlock\Authentication\Model\User;
-use OpenConext\EngineBlock\Authentication\Repository\ConsentRepository;
-use OpenConext\EngineBlock\Authentication\Repository\UserDirectory;
-use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
-use OpenConext\EngineBlock\Authentication\Value\CollabPersonUuid;
-use OpenConext\EngineBlockBundle\Authentication\Entity\SamlPersistentId;
-use OpenConext\EngineBlockBundle\Authentication\Entity\ServiceProviderUuid;
-use OpenConext\EngineBlockBundle\Authentication\Repository\SamlPersistentIdRepository;
-use OpenConext\EngineBlockBundle\Authentication\Repository\ServiceProviderUuidRepository;
+use OpenConext\EngineBlock\Exception\InvalidBindingException;
+use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
 use PHPUnit_Framework_TestCase as TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -59,12 +52,11 @@ class SsoRequestValidatorTest extends TestCase
         $this->assertTrue($this->validator->isValid($request));
     }
 
-    /**
-     * @expectedException \OpenConext\EngineBlock\Exception\InvalidRequestMethodException
-     * @expectedExceptionMessage The HTTP request method "PATCH" is not supported on this SAML SSO endpoint
-     */
     public function test_post_binding_is_not_supported()
     {
+        $this->expectException(InvalidRequestMethodException::class);
+        $this->expectExceptionMessage('The HTTP request method "PATCH" is not supported on this SAML SSO endpoint');
+
         $request = m::mock(Request::class);
         $request
             ->shouldReceive('getMethod')
@@ -73,12 +65,11 @@ class SsoRequestValidatorTest extends TestCase
         $this->validator->isValid($request);
     }
 
-    /**
-     * @expectedException \OpenConext\EngineBlock\Exception\InvalidBindingException
-     * @expectedExceptionMessage No SAMLRequest parameter was found in the HTTP "GET" request parameters
-     */
     public function test_used_invalid_binding()
     {
+        $this->expectException(InvalidBindingException::class);
+        $this->expectExceptionMessage('No SAMLRequest parameter was found in the HTTP "GET" request parameters');
+
         // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
         $_SERVER['REQUEST_METHOD'] = 'GET';
         // Even though we are handling a AuthNRequest, the binding is based on a get parameter named SAMLRequest
@@ -92,12 +83,11 @@ class SsoRequestValidatorTest extends TestCase
         $this->validator->isValid($request);
     }
 
-    /**
-     * @expectedException \OpenConext\EngineBlock\Exception\InvalidBindingException
-     * @expectedExceptionMessage The binding type "SAML2\HTTPArtifact" is not supported on this SAML SSO endpoint
-     */
     public function test_used_unsupported_binding()
     {
+        $this->expectException(InvalidBindingException::class);
+        $this->expectExceptionMessage('The binding type "SAML2\HTTPArtifact" is not supported on this SAML SSO endpoint');
+
         // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
         $_SERVER['REQUEST_METHOD'] = 'GET';
         // EB does not support artifact binding

--- a/tests/unit/OpenConext/EngineBlock/Validator/SsoRequestValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/SsoRequestValidatorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace OpenConext\EngineBlock\Validator;
+
+use Mockery as m;
+use OpenConext\EngineBlock\Authentication\Model\User;
+use OpenConext\EngineBlock\Authentication\Repository\ConsentRepository;
+use OpenConext\EngineBlock\Authentication\Repository\UserDirectory;
+use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
+use OpenConext\EngineBlock\Authentication\Value\CollabPersonUuid;
+use OpenConext\EngineBlockBundle\Authentication\Entity\SamlPersistentId;
+use OpenConext\EngineBlockBundle\Authentication\Entity\ServiceProviderUuid;
+use OpenConext\EngineBlockBundle\Authentication\Repository\SamlPersistentIdRepository;
+use OpenConext\EngineBlockBundle\Authentication\Repository\ServiceProviderUuidRepository;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class SsoRequestValidatorTest extends TestCase
+{
+    /**
+     * @var SsoRequestValidator
+     */
+    private $validator;
+
+    public function setUp()
+    {
+        $this->validator = new SsoRequestValidator();
+
+        // PHPunit does not reset the superglobals on each run.
+        unset($_GET['SAMLRequest']);
+        unset($_GET['AuhtNRequest']);
+        unset($_GET['SAMLart']);
+        unset($_POST['SAMLRequest']);
+    }
+
+    public function test_happy_flow_get()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET['SAMLRequest'] = 'loremipsum';
+
+        $request = m::mock(Request::class);
+        $request
+            ->shouldReceive('getMethod')
+            ->andReturn(Request::METHOD_GET);
+        $this->assertTrue($this->validator->isValid($request));
+    }
+
+    public function test_happy_flow_post()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['SAMLRequest'] = 'loremipsum';
+
+        $request = m::mock(Request::class);
+        $request
+            ->shouldReceive('getMethod')
+            ->andReturn(Request::METHOD_POST);
+        $this->assertTrue($this->validator->isValid($request));
+    }
+
+    /**
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidRequestMethodException
+     * @expectedExceptionMessage The HTTP request method "PATCH" is not supported on this SAML SSO endpoint
+     */
+    public function test_post_binding_is_not_supported()
+    {
+        $request = m::mock(Request::class);
+        $request
+            ->shouldReceive('getMethod')
+            ->andReturn(Request::METHOD_PATCH);
+
+        $this->validator->isValid($request);
+    }
+
+    /**
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidBindingException
+     * @expectedExceptionMessage No SAMLRequest parameter was found in the HTTP "GET" request parameters
+     */
+    public function test_used_invalid_binding()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        // Even though we are handling a AuthNRequest, the binding is based on a get parameter named SAMLRequest
+        $_GET['AuhtNRequest'] = 'loremipsum';
+
+        $request = m::mock(Request::class);
+        $request
+            ->shouldReceive('getMethod')
+            ->andReturn(Request::METHOD_GET);
+
+        $this->validator->isValid($request);
+    }
+
+    /**
+     * @expectedException \OpenConext\EngineBlock\Exception\InvalidBindingException
+     * @expectedExceptionMessage The binding type "SAML2\HTTPArtifact" is not supported on this SAML SSO endpoint
+     */
+    public function test_used_unsupported_binding()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        // EB does not support artifact binding
+        $_GET['SAMLart'] = 'loremipsum';
+
+        $request = m::mock(Request::class);
+        $request
+            ->shouldReceive('getMethod')
+            ->andReturn(Request::METHOD_GET);
+
+        $this->validator->isValid($request);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/AttributeRuleTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/AttributeRuleTest.php
@@ -34,7 +34,7 @@ class AttributeRuleTest extends TestCase
      */
     public function rule_name_must_be_set()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         AttributeRule::from(null, 'value', 'source');
     }
 
@@ -43,7 +43,7 @@ class AttributeRuleTest extends TestCase
      */
     public function rule_value_must_be_set()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         AttributeRule::from('name', null, 'source');
     }
 
@@ -52,7 +52,7 @@ class AttributeRuleTest extends TestCase
      */
     public function rule_source_must_be_set()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         AttributeRule::from('name', 'value', null);
     }
 

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/RequestTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/RequestTest.php
@@ -137,7 +137,7 @@ class RequestTest extends TestCase
      */
     public function request_subject_must_be_set()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Request::from('sp-entity-id', NULL, [], []);
     }
 
@@ -146,7 +146,7 @@ class RequestTest extends TestCase
      */
     public function request_sp_entity_id_must_be_set()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Request::from(NULL,'subject-id', [], []);
     }
 
@@ -155,7 +155,7 @@ class RequestTest extends TestCase
      */
     public function request_attributes_must_be_of_type_dto()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Request::from('sp-entity-id', 'subject', [], [['invalid']]);
     }
 }

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/ResponseTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/ResponseTest.php
@@ -56,7 +56,7 @@ class ResponseTest extends TestCase
      */
     public function response_data_must_be_an_array()
     {
-        $this->setExpectedException(InvalidAttributeAggregationResponseException::class);
+        $this->expectException(InvalidAttributeAggregationResponseException::class);
         Response::fromData(NULL);
     }
 
@@ -65,7 +65,7 @@ class ResponseTest extends TestCase
      */
     public function response_attribute_must_have_a_name()
     {
-        $this->setExpectedException(InvalidAttributeAggregationResponseException::class);
+        $this->expectException(InvalidAttributeAggregationResponseException::class);
         Response::fromData([
           [
             'values' => [],
@@ -79,7 +79,7 @@ class ResponseTest extends TestCase
      */
     public function response_attribute_must_have_values_property()
     {
-        $this->setExpectedException(InvalidAttributeAggregationResponseException::class);
+        $this->expectException(InvalidAttributeAggregationResponseException::class);
         Response::fromData([
           [
             'name' => 'name',
@@ -93,7 +93,7 @@ class ResponseTest extends TestCase
      */
     public function response_attribute_must_have_a_source()
     {
-        $this->setExpectedException(InvalidAttributeAggregationResponseException::class);
+        $this->expectException(InvalidAttributeAggregationResponseException::class);
         Response::fromData([
           [
             'name' => 'name',

--- a/tests/unit/OpenConext/EngineBlockBundle/EventListener/ExecutionTimeTrackerEventListenerTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/EventListener/ExecutionTimeTrackerEventListenerTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
-class ExecutionTimeTrackerTest extends TestCase
+class ExecutionTimeTrackerEventListenerTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
Logging of incorrect requests on the SSO endpoint where quite cryptic. Often resulting in a generic 500 error page with a log entry reading: `Unable to find the current binding.`. 

This PR aims to improve the error reporting portion of this problem. The actual better user-facing error handling is addressed in an upcoming PR. This PR introduces a request validator that is used upon entry of the SSO controller action. It tests if a supported request method is used (GET is currently supported exclusively) and if the correct binding is used (HTTP binding is expected).

If the request does not match these criteria, a meaningfull exception is thrown. Either reflecting the use of an usupported request method. Or in the case of an usuported SAML request binding, will report which binding was attempted.

https://www.pivotaltracker.com/story/show/164121560