### PR TITLE
Show an error code on error page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_script:
   - sudo cp -f ci/travis/vhost-apache /etc/apache2/sites-available/default-ssl.conf
   - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default-ssl.conf
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
+  - sed -i 's,128M,1024M,' ~/build/OpenConext/OpenConext-engineblock/application/configs/application.ini
   - sudo chown -R travis:travis /var/lib/apache2/fastcgi
   - sudo a2dissite 000-default
   - sudo a2ensite default-ssl

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -47,7 +47,7 @@ return $overrides + [
     'userAgent'             => 'User Agent',
     'ipAddress'             => 'IP Address',
     'statusCode'            => 'Status Code',
-    'artCode'               => 'ART code',
+    'artCode'               => 'ART Code',
     'statusMessage'         => 'Status Message',
     'attributeName'         => 'Attribute Name',
     'attributeValue'        => 'Attribute Value',

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -47,7 +47,7 @@ return $overrides + [
     'userAgent'             => 'User Agent',
     'ipAddress'             => 'IP Address',
     'statusCode'            => 'Status Code',
-    'artCode'               => 'ART Code',
+    'artCode'               => 'Error Code',
     'statusMessage'         => 'Status Message',
     'attributeName'         => 'Attribute Name',
     'attributeValue'        => 'Attribute Value',

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -47,6 +47,7 @@ return $overrides + [
     'userAgent'             => 'User Agent',
     'ipAddress'             => 'IP Address',
     'statusCode'            => 'Status Code',
+    'artCode'               => 'ART code',
     'statusMessage'         => 'Status Message',
     'attributeName'         => 'Attribute Name',
     'attributeValue'        => 'Attribute Value',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -46,7 +46,7 @@ return $overrides + [
     'userAgent'             => 'User Agent',
     'ipAddress'             => 'IP-adres',
     'statusCode'            => 'Statuscode',
-    'artCode'               => 'ART-code',
+    'artCode'               => 'Foutcode',
     'statusMessage'         => 'Statusbericht',
     'attributeName'         => 'Attribuutnaam',
     'attributeValue'        => 'Attribuutwaarde',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -46,6 +46,7 @@ return $overrides + [
     'userAgent'             => 'User Agent',
     'ipAddress'             => 'IP-adres',
     'statusCode'            => 'Statuscode',
+    'artCode'               => 'ART-code',
     'statusMessage'         => 'Statusbericht',
     'attributeName'         => 'Attribuutnaam',
     'attributeValue'        => 'Attribuutwaarde',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -41,6 +41,7 @@ return $overrides + [
     'userAgent'             => 'Agente do Utilizador',
     'ipAddress'             => 'Endereço IP',
     'statusCode'            => 'Código de Estado',
+    'artCode'               => 'ART code',
     'statusMessage'         => 'Mensagem de Estado',
     'attributeName'         => 'Nome do Atributo',
     'attributeValue'        => 'Valor do Atributo',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -41,7 +41,7 @@ return $overrides + [
     'userAgent'             => 'Agente do Utilizador',
     'ipAddress'             => 'Endereço IP',
     'statusCode'            => 'Código de Estado',
-    'artCode'               => 'ART code',
+    'artCode'               => 'Código de ART',
     'statusMessage'         => 'Mensagem de Estado',
     'attributeName'         => 'Nome do Atributo',
     'attributeValue'        => 'Valor do Atributo',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -41,7 +41,7 @@ return $overrides + [
     'userAgent'             => 'Agente do Utilizador',
     'ipAddress'             => 'Endereço IP',
     'statusCode'            => 'Código de Estado',
-    'artCode'               => 'Código de ART',
+    'artCode'               => 'Código de Erro',
     'statusMessage'         => 'Mensagem de Estado',
     'attributeName'         => 'Nome do Atributo',
     'attributeValue'        => 'Valor do Atributo',

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -3,6 +3,7 @@
 use OpenConext\EngineBlock\Logger\Handler\FingersCrossed\ManualOrDecoratedActivationStrategy;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
 use OpenConext\EngineBlock\Request\RequestId;
+use OpenConext\EngineBlockBundle\Exception\Art;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -204,7 +205,7 @@ class EngineBlock_ApplicationSingleton
 
         // Store some valuable debug info in session so it can be displayed on feedback pages
         session_start();
-        $this->getSession()->set('feedbackInfo', $this->collectFeedbackInfo());
+        $this->getSession()->set('feedbackInfo', $this->collectFeedbackInfo($exception));
 
         // flush all messages in queue, something went wrong!
         $this->flushLog('An error was caught');
@@ -213,9 +214,10 @@ class EngineBlock_ApplicationSingleton
     }
 
     /**
+     * @param Exception $exception
      * @return array
      */
-    public function collectFeedbackInfo()
+    public function collectFeedbackInfo(Exception $exception)
     {
         if (isset($_SERVER['HTTP_USER_AGENT'])) {
             $userAgent = $_SERVER['HTTP_USER_AGENT'];
@@ -235,6 +237,7 @@ class EngineBlock_ApplicationSingleton
         $feedbackInfo['requestId'] = $logRequestId;
         $feedbackInfo['userAgent'] = $userAgent;
         $feedbackInfo['ipAddress'] = $this->getClientIpAddress();
+        $feedbackInfo['artCode'] = Art::forException($exception);
 
         // @todo  reset this when login is succesful
         // Find the current identity provider

--- a/library/EngineBlock/Attributes/Definition/Denormalizer.php
+++ b/library/EngineBlock/Attributes/Definition/Denormalizer.php
@@ -17,7 +17,11 @@ class EngineBlock_Attributes_Definition_Denormalizer
 
                 if (!isset($definitions[$attributeName])) {
                     throw new EngineBlock_Exception(
-                        "Unable to resolve definition for '$attributeName', path: " . join(' > ', $aliases)
+                        sprintf(
+                            'Unable to resolve definition for "%s", path: "%s"',
+                            $attributeName,
+                            join(' > ', $aliases)
+                        )
                     );
                 }
 

--- a/library/EngineBlock/Attributes/Validator/Factory.php
+++ b/library/EngineBlock/Attributes/Validator/Factory.php
@@ -43,7 +43,7 @@ class EngineBlock_Attributes_Validator_Factory
         $validator = $this->create($validatorName, $attributeName, $validatorOptions);
 
         if (!$validator) {
-            throw new EngineBlock_Exception("Unable to find validator for $validatorName.");
+            throw new EngineBlock_Exception(sprintf('Unable to find validator for "%s"', $validatorName));
         }
 
         return $validator;

--- a/library/EngineBlock/Attributes/Validator/Type.php
+++ b/library/EngineBlock/Attributes/Validator/Type.php
@@ -101,7 +101,9 @@ class EngineBlock_Attributes_Validator_Type extends EngineBlock_Attributes_Valid
                 break;
 
             default:
-                throw new EngineBlock_Exception("Unknown validate option '{$this->_options}' for attribute validation");
+                throw new EngineBlock_Exception(
+                    sprintf('Unknown validate option "%s" for attribute validation', $this->_options)
+                );
         }
         return true;
     }

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -508,7 +508,10 @@ class EngineBlock_Corto_Adapter
         $engineServiceProvider = $proxyServer->getRepository()->findServiceProviderByEntityId($spEntityId);
         if (!$engineServiceProvider) {
             throw new EngineBlock_Exception(
-                "Unable to find EngineBlock configured as Service Provider. No '$spEntityId' in repository!"
+                sprintf(
+                    "Unable to find EngineBlock configured as Service Provider. No '%s' in repository!",
+                    $spEntityId
+                )
             );
         }
 

--- a/library/EngineBlock/Corto/Filter/Command/Factory.php
+++ b/library/EngineBlock/Corto/Filter/Command/Factory.php
@@ -10,7 +10,7 @@ class EngineBlock_Corto_Filter_Command_Factory
         $class = 'EngineBlock_Corto_Filter_Command_' . $name;
 
         if (!class_exists($class)) {
-            throw new EngineBlock_Exception('Filter command ' . $name . ' does not exist');
+            throw new EngineBlock_Exception(sprintf('Filter command "%s" does not exist', $name));
         }
 
         return new $class();

--- a/library/EngineBlock/Corto/Filter/Command/RunAttributeManipulations.php
+++ b/library/EngineBlock/Corto/Filter/Command/RunAttributeManipulations.php
@@ -16,7 +16,7 @@ class EngineBlock_Corto_Filter_Command_RunAttributeManipulations extends EngineB
     function __construct($type)
     {
         if (!in_array($type, array(self::TYPE_SP, self::TYPE_IDP, self::TYPE_REQUESTER_SP))) {
-            throw new \EngineBlock_Exception("Invalid type for Attribute Manipulation: '$type'");
+            throw new EngineBlock_Exception(sprintf('Invalid type for Attribute Manipulation: "%s"', $type));
         }
         $this->_type = $type;
     }
@@ -64,7 +64,9 @@ class EngineBlock_Corto_Filter_Command_RunAttributeManipulations extends EngineB
             $serviceProvider = $entity;
         }
         else {
-            throw new EngineBlock_Exception('Attribute Manipulator encountered an unexpected type: ' . $this->_type);
+            throw new EngineBlock_Exception(
+                sprintf('Attribute Manipulator encountered an unexpected type: "%s"', $this->_type)
+            );
         }
 
         // Try entity specific file based manipulation from Service Registry

--- a/library/EngineBlock/Corto/Filter/Command/ValidateAllowedConnection.php
+++ b/library/EngineBlock/Corto/Filter/Command/ValidateAllowedConnection.php
@@ -9,8 +9,11 @@ class EngineBlock_Corto_Filter_Command_ValidateAllowedConnection extends EngineB
     {
         if (!$this->_serviceProvider->isAllowed($this->_identityProvider->entityId)) {
             throw new EngineBlock_Corto_Exception_InvalidConnection(
-                "Disallowed response by SP configuration. " .
-                "Response from IdP '{$this->_identityProvider->entityId}' to SP '{$this->_serviceProvider->entityId}'"
+                sprintf(
+                    'Disallowed response by SP configuration. Response from IdP "%s" to SP "%s"',
+                    $this->_identityProvider->entityId,
+                    $this->_serviceProvider->entityId
+                )
             );
         }
     }

--- a/library/EngineBlock/Corto/Filter/Command/ValidateRequiredAttributes.php
+++ b/library/EngineBlock/Corto/Filter/Command/ValidateRequiredAttributes.php
@@ -34,9 +34,11 @@ class EngineBlock_Corto_Filter_Command_ValidateRequiredAttributes extends Engine
 
         if ($validationResult->hasErrors()) {
             throw new EngineBlock_Corto_Exception_MissingRequiredFields(
-                'Errors validating attributes' .
-                    ' errors: '     . print_r($validationResult->getErrors(), true) .
-                    ' attributes: ' . print_r($this->_responseAttributes, true)
+                sprintf(
+                    'Errors validating attributes errors: "%s" attributes: "%s"',
+                    print_r($validationResult->getErrors(), true),
+                    print_r($this->_responseAttributes, true)
+                )
             );
         }
     }

--- a/library/EngineBlock/Corto/Model/Consent.php
+++ b/library/EngineBlock/Corto/Model/Consent.php
@@ -155,7 +155,7 @@ class EngineBlock_Corto_Model_Consent
         /** @var $statement PDOStatement */
         if (!$statement->execute($parameters)) {
             throw new EngineBlock_Corto_Module_Services_Exception(
-                "Error storing consent: " . var_export($statement->errorInfo(), true),
+                sprintf('Error storing consent: "%s"', var_export($statement->errorInfo(), true)),
                 EngineBlock_Exception::CODE_CRITICAL
             );
         }
@@ -195,7 +195,7 @@ class EngineBlock_Corto_Model_Consent
             return true;
         } catch (PDOException $e) {
             throw new EngineBlock_Corto_ProxyServer_Exception(
-                "Consent retrieval failed! Error: " . $e->getMessage(),
+                sprintf('Consent retrieval failed! Error: "%s"', $e->getMessage()),
                 EngineBlock_Exception::CODE_ALERT
             );
         }

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -166,7 +166,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
         if (!$serviceProvider instanceof ServiceProvider) {
             throw new EngineBlock_Corto_Module_Bindings_Exception(
-                "Requesting entity '$spEntityId' is not a Service Provider"
+                sprintf("Requesting entity '%s' is not a Service Provider", $spEntityId)
             );
         }
 
@@ -266,7 +266,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         $sspResponse = $sspBinding->receive();
         if (!($sspResponse instanceof Response)) {
             throw new EngineBlock_Corto_Module_Bindings_Exception(
-                'Unsupported Message received: ' . get_class($sspResponse),
+                sprintf('Unsupported Message received: "%s"', get_class($sspResponse)),
                 EngineBlock_Exception::CODE_NOTICE
             );
         }
@@ -292,7 +292,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         // We only support HTTP-POST binding for Responses
         if (!$sspBinding instanceof HTTPPost) {
             throw new EngineBlock_Corto_Module_Bindings_UnsupportedBindingException(
-                'Unsupported Binding used: ' . get_class($sspBinding),
+                sprintf('Unsupported Binding used: "%s"', get_class($sspBinding)),
                 EngineBlock_Exception::CODE_NOTICE
             );
         }
@@ -367,7 +367,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
                 // the user.
                 if ($sspResponse->isSuccess()) {
                     throw new ResponseProcessingFailedException(
-                        sprintf('Response processing failed: %s', $exception->getMessage()), null, $exception
+                        sprintf('Response processing failed: "%s"', $exception->getMessage()), null, $exception
                     );
                 }
 
@@ -405,7 +405,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
             } catch (Exception $exception) {
                 throw new ResponseProcessingFailedException(
-                    sprintf('Response processing failed: %s', $exception->getMessage()), null, $exception
+                    sprintf('Response processing failed: "%s"', $exception->getMessage()), null, $exception
                 );
             }
 
@@ -484,7 +484,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         );
 
         throw new EngineBlock_Corto_Exception_UnknownIssuer(
-            "Issuer '{$messageIssuer}' is not a known remote entity? (please add SP to Remote Entities)",
+            sprintf('Issuer "%s" is not a known remote entity? (please add SP to Remote Entities)', $messageIssuer),
             $messageIssuer,
             $destination
         );
@@ -514,7 +514,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         );
 
         throw new EngineBlock_Corto_Exception_UnknownIssuer(
-            "Issuer '{$messageIssuer}' is not a known remote entity? (please add IdP to Remote Entities)",
+            sprintf('Issuer "%s" is not a known remote entity? (please add IdP to Remote Entities)', $messageIssuer),
             $messageIssuer,
             $destination
         );
@@ -666,7 +666,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
         if (!$sspMessage instanceof AuthnRequest) {
             throw new EngineBlock_Corto_Module_Bindings_Exception(
-                'Unsupported Message type: ' . get_class($sspMessage)
+                sprintf('Unsupported Message type: "%s"', get_class($sspMessage))
             );
         }
 

--- a/library/EngineBlock/Corto/Module/Service/Metadata/ServiceReplacer.php
+++ b/library/EngineBlock/Corto/Module/Service/Metadata/ServiceReplacer.php
@@ -82,14 +82,14 @@ class EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer
             }
 
             throw new EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception(
-                "No service '$serviceName' is configured in EngineBlock metadata"
+                sprintf('No service "%s" is configured in EngineBlock metadata', $serviceName)
             );
         }
 
         $services = $proxyEntity->$serviceName;
         if (!is_array($services)) {
             throw new EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception(
-                "Service '$this->serviceName' in EngineBlock metadata is not an array"
+                sprintf('Service "%s" in EngineBlock metadata is not an array', $this->serviceName)
             );
         }
 
@@ -97,7 +97,7 @@ class EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer
 
         if (count($supportedBindings) === 0 && $required == self::REQUIRED) {
             throw new EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception(
-                "No '$serviceName' service bindings configured in EngineBlock metadata"
+                sprintf('No "%s" service bindings configured in EngineBlock metadata', $serviceName)
             );
         }
 
@@ -115,14 +115,18 @@ class EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer
         foreach($services as $serviceInfo) {
             if (!isset($serviceInfo->binding)) {
                 throw new EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception(
-                    "Service '$this->serviceName' configured without a Binding in EngineBlock metadata"
+                    sprintf('Service "%s" configured without a Binding in EngineBlock metadata', $this->serviceName)
                 );
             }
 
             $binding = $serviceInfo->binding;
             if (!in_array($binding, $this->knownBindings)) {
                 throw new EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception(
-                    "Service '$this->serviceName' has an invalid binding '$binding' configured in EngineBlock metadata"
+                    sprintf(
+                        'Service "%s" has an invalid binding "%s" configured in EngineBlock metadata',
+                        $this->serviceName,
+                        $binding
+                    )
                 );
             }
 

--- a/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
@@ -43,7 +43,7 @@ class EngineBlock_Corto_Module_Service_ProcessConsent
         }
         if (!isset($_SESSION['consent'][$_POST['ID']]['response'])) {
             throw new EngineBlock_Corto_Module_Services_SessionLostException(
-                "Stored response for ResponseID '{$_POST['ID']}' not found"
+                sprintf('Stored response for ResponseID "%s" not found', $_POST['ID'])
             );
         }
         /** @var Response|EngineBlock_Saml2_ResponseAnnotationDecorator $response */

--- a/library/EngineBlock/Corto/Module/Services.php
+++ b/library/EngineBlock/Corto/Module/Services.php
@@ -56,7 +56,12 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
         }
 
         throw new EngineBlock_Corto_Module_Services_Exception(
-            "Unable to load service '$serviceName' (resolved to '$resolvedServiceName') tried className '$className'!"
+            sprintf(
+                'Unable to load service "%s" (resolved to "%s") tried className "%s"!',
+                $serviceName,
+                $resolvedServiceName,
+                $className
+            )
         );
     }
 

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -259,7 +259,7 @@ class EngineBlock_Corto_ProxyServer
 
         if (!isset($this->_keyPairs[$keyId])) {
             throw new EngineBlock_Corto_ProxyServer_Exception(
-                "Unknown key id '{$keyId}'"
+                sprintf('Unknown key id "%s"', $keyId)
             );
         }
         return $this->_keyPairs[$keyId];
@@ -269,7 +269,7 @@ class EngineBlock_Corto_ProxyServer
     {
         if (!isset($this->_serviceToControllerMapping[$serviceName])) {
             throw new EngineBlock_Corto_ProxyServer_Exception(
-                "Unable to map service '$serviceName' to a controller!"
+                sprintf('Unable to map service "%s" to a controller!', $serviceName)
             );
         }
 
@@ -355,7 +355,7 @@ class EngineBlock_Corto_ProxyServer
             $this->getLogger()->notice(sprintf('Unable to map remote IdpMD5 "%s" to a remote entity.', $remoteIdPMd5));
 
             throw new EngineBlock_Corto_Exception_UnknownPreselectedIdp(
-                "Unable to map remote IdpMD5 '$remoteIdPMd5' to a remote entity!",
+                sprintf('Unable to map remote IdpMD5 "%s" to a remote entity!', $remoteIdPMd5),
                 $remoteIdPMd5
             );
         }
@@ -737,8 +737,11 @@ class EngineBlock_Corto_ProxyServer
         $spRequestId = $authnRequestRepository->findLinkedRequestId($requestId);
         if ($spRequestId === null) {
             throw new EngineBlock_Corto_Module_Services_SessionLostException(
-                "Trying to find a AuthnRequest (we made and sent) with id '$requestId' but it is not known in this session? ".
-                "This could be an unsolicited Response (which we do not support) but more likely the user lost their session",
+                sprintf(
+                    'Trying to find a AuthnRequest (we made and sent) with id "%s" but it is not known in this session? '.
+                    'This could be an unsolicited Response (which we do not support) but more likely the user lost their session',
+                    $requestId
+                ),
                 EngineBlock_Corto_ProxyServer_Exception::CODE_NOTICE
             );
         }
@@ -982,7 +985,7 @@ class EngineBlock_Corto_ProxyServer
             }
         }
 
-        throw new EngineBlock_Corto_ProxyServer_Exception("Unable to map URL '$url' to EngineBlock URL");
+        throw new EngineBlock_Corto_ProxyServer_Exception(sprintf('Unable to map URL "%s" to EngineBlock URL', $url));
     }
 
     /**
@@ -1024,7 +1027,7 @@ class EngineBlock_Corto_ProxyServer
         else if (!empty($certificates['privateFile'])) {
                 if (!file_exists($certificates['privateFile'])) {
                     throw new EngineBlock_Corto_ProxyServer_Exception(
-                        'Private key PEM not found at: '.$certificates['privateFile']
+                        sprintf('Private key PEM not found at: "%s"', $certificates['privateFile'])
                     );
                 }
                 $privateKeyPem = file_get_contents($certificates['privateFile']);
@@ -1039,8 +1042,11 @@ class EngineBlock_Corto_ProxyServer
         $privateKey = openssl_pkey_get_private($privateKeyPem);
         if ($privateKey === false) {
             throw new EngineBlock_Corto_ProxyServer_Exception(
-                "Current entity ['certificates']['private'] value is NOT a valid PEM formatted SSL private key?!? ".
-                "Value: '$privateKeyPem'"
+                sprintf(
+                    "Current entity ['certificates']['private'] value is NOT a valid PEM formatted SSL private key? ".
+                    "Value: '%s'",
+                    $privateKeyPem
+                )
             );
         }
         return $privateKey;

--- a/library/EngineBlock/Corto/XmlToArray.php
+++ b/library/EngineBlock/Corto/XmlToArray.php
@@ -180,7 +180,10 @@ class EngineBlock_Corto_XmlToArray
         $foldingOptionSet = xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
         if (!$foldingOptionSet) {
             throw new EngineBlock_Corto_XmlToArray_Exception(
-                "Unable to set XML_OPTION_CASE_FOLDING on parser object? Error message: " . xml_error_string(xml_get_error_code($parser)),
+                sprintf(
+                    'Unable to set XML_OPTION_CASE_FOLDING on parser object? Error message: "%s"',
+                    xml_error_string(xml_get_error_code($parser))
+                ),
                 EngineBlock_Corto_XmlToArray_Exception::CODE_ERROR
             );
         }
@@ -191,11 +194,17 @@ class EngineBlock_Corto_XmlToArray
             $errorCode = xml_get_error_code($parser);
             $errorMessage = xml_error_string($errorCode);
             throw new EngineBlock_Corto_XmlToArray_Exception(
-                'Error parsing incoming XML. ' . PHP_EOL .
-                'Error code: ' . $errorCode . PHP_EOL .
-                'Error message: ' . $errorMessage . PHP_EOL .
-                'Last libXML error: ' . var_export(libxml_get_last_error(), true) . PHP_EOL .
-                'XML: ' . $xml
+                sprintf(
+                    'Error parsing incoming XML. '.PHP_EOL.
+                    'Error code: "%s"'.PHP_EOL.
+                    'Error message: "%s"'.PHP_EOL.
+                    'Last libXML error: "%s"'.PHP_EOL.
+                    'XML: "%s"',
+                    $errorCode,
+                    $errorMessage,
+                    var_export(libxml_get_last_error(), true),
+                    $xml
+                )
             );
         }
 
@@ -338,7 +347,11 @@ class EngineBlock_Corto_XmlToArray
 
         if ($level > self::MAX_RECURSION_LEVEL) {
             throw new EngineBlock_Corto_XmlToArray_Exception(
-                'Recursion threshold exceed on element: ' . $elementName . ' for hashvalue: ' . var_export($hash, true)
+                sprintf(
+                    'Recursion threshold exceed on element: "%s" for hashvalue: "%s"',
+                    $elementName,
+                    var_export($hash, true)
+                )
             );
         }
         if ($hash == self::PLACEHOLDER_VALUE) {
@@ -368,7 +381,11 @@ class EngineBlock_Corto_XmlToArray
             }
             else {
                 throw new EngineBlock_Corto_XmlToArray_Exception(
-                    "Value for key '$key' unrecognized (key naming error?)! Value" . print_r($value, true)
+                    sprintf(
+                        'Value for key "%s" unrecognized (key naming error?)! Value "%s"',
+                        $key,
+                        print_r($value, true)
+                    )
                 );
             }
         }

--- a/library/EngineBlock/Saml2/Container.php
+++ b/library/EngineBlock/Saml2/Container.php
@@ -45,19 +45,23 @@ final class EngineBlock_Saml2_Container extends AbstractContainer
 
     public function redirect($url, $data = array())
     {
-        throw new BadMethodCallException(sprintf(
-            "%s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
-            __CLASS__,
-            __METHOD__
-        ));
+        throw new BadMethodCallException(
+            sprintf(
+                '"%s":"%s" may not be called in the Surfnet\\SamlBundle as it doesn\'t work with Symfony2',
+                __CLASS__,
+                __METHOD__
+            )
+        );
     }
 
     public function postRedirect($url, $data = array())
     {
-        throw new BadMethodCallException(sprintf(
-            "%s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
-            __CLASS__,
-            __METHOD__
-        ));
+        throw new BadMethodCallException(
+            sprintf(
+                '"%s":"%s" may not be called in the Surfnet\\SamlBundle as it doesn\'t work with Symfony2"',
+                __CLASS__,
+                __METHOD__
+            )
+        );
     }
 }

--- a/library/EngineBlock/Saml2/MessageSerializer.php
+++ b/library/EngineBlock/Saml2/MessageSerializer.php
@@ -60,7 +60,7 @@ class EngineBlock_Saml2_MessageSerializer
         );
 
         if (!isset($mapping[$class])) {
-            throw new Exception('Unknown Message Type' . $class);
+            throw new Exception(sprintf('Unknown Message Type "%s"', $class));
         }
 
         return $mapping[$class];

--- a/library/EngineBlock/Saml2/NameIdResolver.php
+++ b/library/EngineBlock/Saml2/NameIdResolver.php
@@ -174,7 +174,10 @@ class EngineBlock_Saml2_NameIdResolver
         }
 
         throw new EngineBlock_Exception(
-            "Whoa, SP '{$spEntityMetadata->entityId}' has no NameIDFormat set, did send a (valid) NameIDPolicy and has no supported NameIDFormats set... I give up..." ,
+            sprintf(
+                'Whoa, SP "%s" has no NameIDFormat set, did send a (valid) NameIDPolicy and has no supported NameIDFormats set... I give up...',
+                $spEntityMetadata->entityId
+            ),
             EngineBlock_Exception::CODE_NOTICE
         );
     }
@@ -237,7 +240,7 @@ class EngineBlock_Saml2_NameIdResolver
         $result = $statement->fetchAll();
 
         if (count($result) > 1) {
-            throw new EngineBlock_Exception('Multiple SP UUIDs found? For: SP: ' . $spEntityId);
+            throw new EngineBlock_Exception(sprintf('Multiple SP UUIDs found? For SP: "%s"', $spEntityId));
         }
 
         return isset($result[0]['uuid']) ? $result[0]['uuid'] : false;
@@ -261,7 +264,11 @@ class EngineBlock_Saml2_NameIdResolver
         $result = $statement->fetchAll();
         if (count($result) > 1) {
             throw new EngineBlock_Exception(
-                'Multiple persistent IDs found? For: SPUUID: ' . $serviceProviderUuid . ' and user UUID: ' . $userUuid
+                sprintf(
+                    'Multiple persistent IDs found? For: SP UUID: "%s" and user UUID: "%s"',
+                    $serviceProviderUuid,
+                    $userUuid
+                )
             );
         }
         return isset($result[0]['persistent_id']) ? $result[0]['persistent_id'] : false;
@@ -300,7 +307,7 @@ class EngineBlock_Saml2_NameIdResolver
         $user = $userDirectory->findUserBy($collabPersonId);
 
         if (!$user) {
-            throw new EngineBlock_Exception('No users found for collabPersonId: ' . $collabPersonId);
+            throw new EngineBlock_Exception(sprintf('No users found for collabPersonId: "%s"', $collabPersonId));
         }
 
         return $user->getCollabPersonUuid()->getUuid();

--- a/library/EngineBlock/X509/CertificateFactory.php
+++ b/library/EngineBlock/X509/CertificateFactory.php
@@ -17,14 +17,14 @@ class EngineBlock_X509_CertificateFactory
         $pemString = file_get_contents($filePath);
 
         if (!$pemString) {
-            throw new EngineBlock_Exception("Unable to read file at path '$filePath'.");
+            throw new EngineBlock_Exception(sprintf('Unable to read file at path "%s"', $filePath));
         }
 
         try {
             $certificate = $this->fromString($pemString);
         } catch (Exception $e) {
             throw new EngineBlock_Exception(
-                "File at '$filePath' does not contain a valid certificate.",
+                sprintf('File at "%s" does not contain a valid certificate.', $filePath),
                 EngineBlock_Exception::CODE_ERROR,
                 $e
             );
@@ -45,7 +45,7 @@ class EngineBlock_X509_CertificateFactory
 
         if (!$opensslCertificate) {
             throw new EngineBlock_Exception(
-                "Unable to read X.509 certificate from content: '$x509CertificateContent'"
+                sprintf('Unable to read X.509 certificate from content: "%s"', $x509CertificateContent)
             );
         }
 

--- a/library/EngineBlock/X509/PrivateKey.php
+++ b/library/EngineBlock/X509/PrivateKey.php
@@ -9,11 +9,11 @@ class EngineBlock_X509_PrivateKey
     function __construct($filePath)
     {
         if (!file_exists($filePath)) {
-            throw new EngineBlock_Exception("Private key file '$filePath' does not exist.");
+            throw new EngineBlock_Exception(sprintf('Private key file "%s" does not exist.', $filePath));
         }
 
         if (!is_readable($filePath)) {
-            throw new EngineBlock_Exception("Private key file '$filePath' exists but is not readable.");
+            throw new EngineBlock_Exception(sprintf('Private key file "%s" exists but is not readable.', $filePath));
         }
 
         $this->_filePath = $filePath;

--- a/library/EngineBlock/Xml/Validator.php
+++ b/library/EngineBlock/Xml/Validator.php
@@ -30,7 +30,7 @@ class EngineBlock_Xml_Validator
         $schemaXml = @file_get_contents($this->_schemaLocation);
         if ($schemaXml === false) {
             throw new EngineBlock_Exception(
-                'Failed validating XML, schema url could not be opened: "' . $this->_schemaLocation . '"'
+                sprintf('Failed validating XML, schema url could not be opened: "%s"', $this->_schemaLocation)
             );
         }
 
@@ -44,7 +44,11 @@ class EngineBlock_Xml_Validator
             $parsedErrorMessage = preg_replace('/\{[^}]*\}/', '', $errorMessage);
             echo '<pre>' . htmlentities(EngineBlock_Corto_XmlToArray::formatXml($xml)) . '</pre>';
             throw new EngineBlock_Exception(
-                "Metadata XML doesn't validate against schema at '$schemaXml', gives error:: '$parsedErrorMessage'"
+                sprintf(
+                    'Metadata XML doesn\'t validate against schema at "%s", gives error: "%s"',
+                    $schemaXml,
+                    $parsedErrorMessage
+                )
             );
         }
     }

--- a/src/OpenConext/EngineBlock/Http/Exception/AccessDeniedException.php
+++ b/src/OpenConext/EngineBlock/Http/Exception/AccessDeniedException.php
@@ -8,7 +8,7 @@ class AccessDeniedException extends HttpException
 {
     public function __construct($resource, $code = 0, Exception $previous = null)
     {
-        $message = sprintf("Access denied to resource '%s': are you properly authorized?", $resource);
+        $message = sprintf('Access denied to resource "%s": are you properly authorized?', $resource);
 
         parent::__construct($message, $code, $previous);
     }

--- a/src/OpenConext/EngineBlock/Http/HttpClient.php
+++ b/src/OpenConext/EngineBlock/Http/HttpClient.php
@@ -68,7 +68,7 @@ final class HttpClient
         }
 
         if ($statusCode < 200 || $statusCode >= 300) {
-            throw new UnreadableResourceException(sprintf('Resource could not be read (status code %d)', $statusCode));
+            throw new UnreadableResourceException(sprintf('Resource could not be read (status code "%d")', $statusCode));
         }
 
         try {
@@ -109,7 +109,7 @@ final class HttpClient
         }
 
         if ($statusCode < 200 || $statusCode >= 300) {
-            throw new UnreadableResourceException(sprintf('Resource could not be read (status code %d)', $statusCode));
+            throw new UnreadableResourceException(sprintf('Resource could not be read (status code "%d")', $statusCode));
         }
 
         try {

--- a/src/OpenConext/EngineBlock/Http/JsonResponseParser.php
+++ b/src/OpenConext/EngineBlock/Http/JsonResponseParser.php
@@ -53,7 +53,7 @@ final class JsonResponseParser
                 $errorMessage = 'Unknown error';
             }
 
-            throw new InvalidJsonException((sprintf('Unable to parse JSON data: %s', $errorMessage)));
+            throw new InvalidJsonException((sprintf('Unable to parse JSON data: "%s"', $errorMessage)));
         }
 
         return $data;

--- a/src/OpenConext/EngineBlock/Metadata/AttributeReleasePolicy.php
+++ b/src/OpenConext/EngineBlock/Metadata/AttributeReleasePolicy.php
@@ -34,12 +34,12 @@ class AttributeReleasePolicy
     {
         foreach ($attributeRules as $key => $rules) {
             if (!is_string($key)) {
-                throw new \InvalidArgumentException('Invalid key: ' . var_export($key, true));
+                throw new \InvalidArgumentException(sprintf('Invalid key: "%s"', var_export($key, true)));
             }
 
             if (!is_array($rules)) {
                 throw new \InvalidArgumentException(
-                    "Invalid values for attribute '$key', not an array: " . var_export($rules, true)
+                    sprintf('Invalid values for attribute "%s", not an array: "%s"', $key, var_export($rules, true))
                 );
             }
 
@@ -61,7 +61,11 @@ class AttributeReleasePolicy
         if (is_array($rule)) {
             if (!isset($rule['value'])) {
                 throw new \InvalidArgumentException(
-                    "Invalid value for attribute '$key', rule must contain a 'value' key, got: " . var_export($rule, true)
+                    sprintf(
+                        'Invalid value for attribute "%s", rule must contain a value key, got: "%s"',
+                        $key,
+                        var_export($rule, true)
+                    )
                 );
             }
 
@@ -72,7 +76,7 @@ class AttributeReleasePolicy
 
         if (!is_string($value)) {
             throw new \InvalidArgumentException(
-                "Invalid value for attribute '$key', not a string: " . var_export($value, true)
+                sprintf('Invalid value for attribute "%s", not a string: "%s"', $key, var_export($value, true))
             );
         }
     }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -139,8 +139,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         }
 
         throw new RuntimeException(
-            "Unrecognized type: '{$connection->type}'"
-            . var_export($connection, true)
+            sprintf('Unrecognized type: "%s" "%s"', $connection->type, var_export($connection, true))
         );
     }
 

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/AbstractMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/AbstractMetadataRepository.php
@@ -62,7 +62,7 @@ abstract class AbstractMetadataRepository implements MetadataRepositoryInterface
         $serviceProvider = $this->findServiceProviderByEntityId($entityId);
 
         if (!$serviceProvider) {
-            throw new EntityNotFoundException("Service Provider '$entityId' not found in InMemoryMetadataRepository");
+            throw new EntityNotFoundException(sprintf('Service Provider "%s" not found in InMemoryMetadataRepository', $entityId));
         }
 
         return $serviceProvider;
@@ -78,7 +78,9 @@ abstract class AbstractMetadataRepository implements MetadataRepositoryInterface
         $identityProvider = $this->findIdentityProviderByEntityId($entityId);
 
         if (!$identityProvider) {
-            throw new EntityNotFoundException("Identity Provider '$entityId' not found in InMemoryMetadataRepository");
+            throw new EntityNotFoundException(
+                sprintf('Identity Provider "%s" not found in InMemoryMetadataRepository', $entityId)
+            );
         }
 
         return $identityProvider;

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/CachedDoctrineMetadataRepository.php
@@ -110,7 +110,7 @@ class CachedDoctrineMetadataRepository implements MetadataRepositoryInterface
         $serviceProvider = $this->findServiceProviderByEntityId($entityId);
 
         if (!$serviceProvider) {
-            throw new EntityNotFoundException("Service Provider '$entityId' not found in database");
+            throw new EntityNotFoundException(sprintf('Service Provider "%s" not found in database', $entityId));
         }
 
         return $serviceProvider;
@@ -125,7 +125,7 @@ class CachedDoctrineMetadataRepository implements MetadataRepositoryInterface
         $identityProvider = $this->findIdentityProviderByEntityId($entityId);
 
         if (!$identityProvider) {
-            throw new EntityNotFoundException("Identity Provider '$entityId' not found in database");
+            throw new EntityNotFoundException(sprintf('Identity Provider "%s" not found in database', $entityId));
         }
 
         return $identityProvider;

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/DoctrineMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/DoctrineMetadataRepository.php
@@ -137,7 +137,7 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
         }
 
         if (count($result) > 1) {
-            throw new RuntimeException('Multiple Identity Providers found for entityId: ' . $entityId);
+            throw new RuntimeException(sprintf('Multiple Identity Providers found for entityId: "%s"', $entityId));
         }
 
         $identityProvider = reset($result);
@@ -166,7 +166,7 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
         }
 
         if (count($result) > 1) {
-            throw new RuntimeException('Multiple Identity Providers found for entityId MD5 hash: ' . $hash);
+            throw new RuntimeException(sprintf('Multiple Identity Providers found for entityId MD5 hash: "%s"', $hash));
         }
 
         return reset($result)['entityId'];
@@ -192,7 +192,7 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
         }
 
         if (count($result) > 1) {
-            throw new RuntimeException('Multiple Service Providers found for entityId: ' . $entityId);
+            throw new RuntimeException(sprintf('Multiple Service Providers found for entityId: "%s"', $entityId));
         }
 
         $serviceProvider = reset($result);
@@ -291,7 +291,9 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
                     continue;
                 }
 
-                throw new RuntimeException('Unsupported role provided to synchonization: ' . var_export($role, true));
+                throw new RuntimeException(
+                    sprintf('Unsupported role provided to synchonization: "%s"', var_export($role, true))
+                );
             }
 
             if ($idpsToBeRemoved) {

--- a/src/OpenConext/EngineBlock/Metadata/X509/X509CertificateFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/X509/X509CertificateFactory.php
@@ -22,13 +22,13 @@ class X509CertificateFactory
         $pemString = file_get_contents($filePath);
 
         if (!$pemString) {
-            throw new RuntimeException("Unable to read file at path '$filePath'.");
+            throw new RuntimeException(sprintf('Unable to read file at path "%s".', $filePath));
         }
 
         try {
             $certificate = $this->fromString($pemString);
         } catch (Exception $e) {
-            throw new RuntimeException("File at '$filePath' does not contain a valid certificate.", 0, $e);
+            throw new RuntimeException(sprintf('File at "%s" does not contain a valid certificate.', $filePath), 0, $e);
         }
         return $certificate;
     }
@@ -46,7 +46,7 @@ class X509CertificateFactory
 
         if (!$opensslCertificate) {
             throw new RuntimeException(
-                "Unable to read X.509 certificate from content: '$x509CertificateContent'"
+                sprintf('Unable to read X.509 certificate from content: "%s"', $x509CertificateContent)
             );
         }
 

--- a/src/OpenConext/EngineBlock/Metadata/X509/X509PrivateKey.php
+++ b/src/OpenConext/EngineBlock/Metadata/X509/X509PrivateKey.php
@@ -22,11 +22,11 @@ class X509PrivateKey
     public function __construct($filePath)
     {
         if (!file_exists($filePath)) {
-            throw new RuntimeException("Private key file '$filePath' does not exist.");
+            throw new RuntimeException(sprintf('Private key file "%s" does not exist.', $filePath));
         }
 
         if (!is_readable($filePath)) {
-            throw new RuntimeException("Private key file '$filePath' exists but is not readable.");
+            throw new RuntimeException(sprintf('Private key file "%s" exists but is not readable.', $filePath));
         }
 
         $this->filePath = $filePath;

--- a/src/OpenConext/EngineBlockBridge/ErrorReporter.php
+++ b/src/OpenConext/EngineBlockBridge/ErrorReporter.php
@@ -85,7 +85,7 @@ class ErrorReporter
 
         $this->session->set('feedbackInfo', array_merge(
             $feedback,
-            $this->engineBlockApplicationSingleton->collectFeedbackInfo()
+            $this->engineBlockApplicationSingleton->collectFeedbackInfo($exception)
         ));
 
         // flush all messages in queue, something went wrong!

--- a/src/OpenConext/EngineBlockBundle/Configuration/FeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/FeatureConfiguration.php
@@ -33,14 +33,23 @@ class FeatureConfiguration implements FeatureConfigurationInterface
     public function isEnabled($featureKey)
     {
         if (!$this->hasFeature($featureKey)) {
-            throw new LogicException(sprintf(
-                'Cannot state if feature "%s" is enabled as it does not exist. Please ensure that you configured it '
-                . 'correctly or verify with hasFeature() that the feature exists. Features configured: %s',
-                $featureKey,
-                implode(', ', array_map(function (Feature $feature) {
-                    return $feature->getFeatureKey();
-                }, $this->features))
-            ));
+            $features = implode(
+                ', ',
+                array_map(
+                    function (Feature $feature) {
+                        return $feature->getFeatureKey();
+                    },
+                    $this->features
+                )
+            );
+            throw new LogicException(
+                sprintf(
+                    'Cannot state if feature "%s" is enabled as it does not exist. Please ensure that you configured it '
+                    .'correctly or verify with hasFeature() that the feature exists. Features configured: "%s"',
+                    $featureKey,
+                    $features
+                )
+            );
         }
 
         return $this->features[$featureKey]->isEnabled();

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionController.php
@@ -170,7 +170,7 @@ final class DeprovisionController
         } catch (InvalidArgumentException $e) {
             throw new ApiNotFoundHttpException(
                 sprintf(
-                    'User ID is not valid: %s',
+                    'User ID is not valid: "%s"',
                     $e->getMessage()
                 )
             );

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/CollabPersonIdType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/CollabPersonIdType.php
@@ -27,10 +27,13 @@ class CollabPersonIdType extends Type
         }
 
         if (!$value instanceof CollabPersonId) {
-            throw new ConversionException(sprintf(
-                'Value %s must be null or an instance of CollabPersonId to be able to convert it to a database value',
-                is_object($value) ? get_class($value) : (string) $value
-            ));
+            throw new ConversionException(
+                sprintf(
+                    'Value "%s" must be null or an instance of CollabPersonId to be able to ' .
+                    'convert it to a database value',
+                    is_object($value) ? get_class($value) : (string)$value
+                )
+            );
         }
 
         return $value->getCollabPersonId();

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/CollabPersonUuidType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/CollabPersonUuidType.php
@@ -24,10 +24,13 @@ class CollabPersonUuidType extends Type
         }
 
         if (!$value instanceof CollabPersonUuid) {
-            throw new ConversionException(sprintf(
-                'Value %s must be null or an instance of CollabPersonUuid to be able to convert it to a database value',
-                is_object($value) ? get_class($value) : (string) $value
-            ));
+            throw new ConversionException(
+                sprintf(
+                    'Value "%s" must be null or an instance of CollabPersonUuid to be able to ' .
+                    'convert it to a database value',
+                    is_object($value) ? get_class($value) : (string)$value
+                )
+            );
         }
 
         return $value->getUuid();

--- a/src/OpenConext/EngineBlockBundle/Exception/Art.php
+++ b/src/OpenConext/EngineBlockBundle/Exception/Art.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Exception;
+
+use Exception;
+
+/**
+ * Art (Alberts-Renterghem-Tuck)
+ *
+ * A numeric error code that is calculated over the exception message, that is
+ * included on the error page. The art-code can assist the support desk in
+ * recognizing errors (based on the art-code). When calculating the art-code,
+ * text between quotes (single and double) are stripped out. Assuming text
+ * between quotes is variable text for example, containing the name of an SP.
+ *
+ * Example:
+ *
+ * Exception with message:
+ *  Unable to verify the Foo of "Bar"
+ *
+ * Is transformed to:
+ *  Unable to verify the Foo of
+ *
+ * And the art-code is calculated over that string, resulting in something like:
+ * 32193
+ */
+class Art
+{
+    /**
+     * @param Exception $exception
+     * @return string
+     */
+    public static function forException(Exception $exception)
+    {
+        return self::calculateArt(get_class($exception), $exception->getMessage());
+    }
+
+    /**
+     * @param string $className
+     * @param string $message
+     * @return string
+     */
+    private static function calculateArt($className, $message)
+    {
+        $message = self::stripVariableArgumentsFromMessage($message);
+
+        return substr(abs(crc32(md5($className . $message))), 0, 5);
+    }
+
+    /**
+     * Strip variable arguments from exception messages.
+     *
+     * Some exception messages are formatted using sprintf, and result in a
+     * unique art-code for each distinct message. In order for the art-code to
+     * be useful it must be the same for each distinct error situation without
+     * taking into account variable parts of the message.
+     *
+     * This method strips all strings inside quotes. This is not perfect
+     * because it relies on sprintf arguments to always be quoted inside the
+     * message.
+     *
+     * @param $message
+     * @return string
+     */
+    private static function stripVariableArgumentsFromMessage($message)
+    {
+        return preg_replace('#".*"|\'.*\'#', '', $message);
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Pdp/Dto/Response.php
+++ b/src/OpenConext/EngineBlockBundle/Pdp/Dto/Response.php
@@ -66,11 +66,11 @@ final class Response
     public static function fromData(array $jsonData)
     {
         if (!isset($jsonData['Response'])) {
-            throw new InvalidPdpResponseException('Key "Response" was not found in the PDP response');
+            throw new InvalidPdpResponseException('Key: Response was not found in the PDP response');
         }
 
         if (!is_array($jsonData['Response'])) {
-            throw new InvalidPdpResponseException('Key "Response" is not an array');
+            throw new InvalidPdpResponseException('Key: Response is not an array');
         }
 
 
@@ -81,15 +81,15 @@ final class Response
         $responseData = $jsonData['Response'][0];
 
         if (!isset($responseData['Status'])) {
-            throw new InvalidPdpResponseException('Key "Status" was not found in the PDP response');
+            throw new InvalidPdpResponseException('Key: Status was not found in the PDP response');
         }
 
         if (!isset($responseData['PolicyIdentifier'])) {
-            throw new InvalidPdpResponseException('Key "PolicyIdentifier" was not found in the PDP response');
+            throw new InvalidPdpResponseException('Key: PolicyIdentifier was not found in the PDP response');
         }
 
         if (!isset($responseData['Decision'])) {
-            throw new InvalidPdpResponseException('Key "Decision" was not found in the PDP response');
+            throw new InvalidPdpResponseException('Key: Decision was not found in the PDP response');
         }
 
         $response = new self;

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
@@ -71,6 +71,10 @@ class Feedback extends Twig_Extension
                 }
             }
         }
+
+        // Sort the feedback info on key
+        ksort($feedbackInfo);
+
         return $feedbackInfo;
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/IdentityProviderController.php
@@ -69,7 +69,7 @@ class IdentityProviderController extends Controller
         }
 
         if (!$message instanceof AuthnRequest) {
-            throw new \RuntimeException('Unknown message type: ' . get_class($message));
+            throw new \RuntimeException(sprintf('Unknown message type: "%s"', get_class($message)));
         }
         $authnRequest = $message;
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ServiceProviderController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ServiceProviderController.php
@@ -48,7 +48,7 @@ class ServiceProviderController extends Controller
     public function triggerLoginRedirectAction($spName)
     {
         if (!$this->mockSpRegistry->has($spName)) {
-            throw new BadRequestHttpException('No SP found for ' . $spName);
+            throw new BadRequestHttpException(sprintf('No SP found for "%s"', $spName));
         }
 
         /** @var MockServiceProvider $sp */
@@ -78,7 +78,7 @@ class ServiceProviderController extends Controller
     public function triggerLoginPostAction($spName)
     {
         if (!$this->mockSpRegistry->has($spName)) {
-            throw new BadRequestHttpException('No SP found for ' . $spName);
+            throw new BadRequestHttpException(sprintf('No SP found for "%s"', $spName));
         }
 
         $factory = new AuthnRequestFactory();
@@ -119,16 +119,12 @@ class ServiceProviderController extends Controller
                 $httpRedirectBinding = new HTTPRedirect();
                 $message = $httpRedirectBinding->receive();
             } catch (\Exception $e2) {
-                throw new \RuntimeException(
-                    'Unable to retrieve SAML message?',
-                    1,
-                    $e1
-                );
+                throw new \RuntimeException('Unable to retrieve SAML message?', 1, $e1);
             }
         }
 
         if (!$message instanceof SAMLResponse) {
-            throw new \RuntimeException('Unrecognized message type received: ' . get_class($message));
+            throw new \RuntimeException(sprintf('Unrecognized message type received: "%s"', get_class($message)));
         }
 
         $xml = base64_decode($request->get('SAMLResponse'));

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -26,7 +26,7 @@ Feature:
       And I should see "Unique Request Id:"
       And I should see "User Agent:"
       And I should see "IP Address:"
-      And I should see "ART Code:"
+      And I should see "Error Code:"
       And I should see "Service Provider:"
       And I should see "Service Provider Name:"
       And I should see "Identity Provider:"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -26,6 +26,7 @@ Feature:
       And I should see "Unique Request Id:"
       And I should see "User Agent:"
       And I should see "IP Address:"
+      And I should see "ART Code:"
       And I should see "Service Provider:"
       And I should see "Service Provider Name:"
       And I should see "Identity Provider:"
@@ -217,6 +218,7 @@ Feature:
     And I should see "Service Provider:"
     And I should see "Service Provider Name:"
     And I should see "Identity Provider:"
+    And I should see ART code "39211"
 
   Scenario: I log in at my Identity Provider, that has the 'block_user_on_violation' feature activated, and has a valid schacHomeOrganization attribute.
     Given feature "eb.block_user_on_violation" is enabled
@@ -247,6 +249,7 @@ Feature:
       And I should see "Service Provider:"
       And I should see "Service Provider Name:"
       And I should see "Identity Provider:"
+      And I should see ART code "25138"
 
   Scenario: I log in at my Identity Provider, that has the 'block_user_on_violation' feature activated, and has a valid eduPersonPrincipalName attribute.
     Given feature "eb.block_user_on_violation" is enabled
@@ -278,6 +281,7 @@ Feature:
    Given the SP "Dummy SP" sends a malformed AuthNRequest
     When I log in at "Dummy SP"
     Then I should see "No SAMLRequest parameter was found in the HTTP \"GET\" request parameters"
+     And I should see ART code "18993"
 
   Scenario: The SP uses the wrong request parameter while using HTTP Post binding
    Given the SP "Dummy SP" sends a malformed AuthNRequest
@@ -285,7 +289,7 @@ Feature:
     When I log in at "Dummy SP"
      And I pass through the SP
     Then I should see "No SAMLRequest parameter was found in the HTTP \"POST\" request parameters"
-
+     And I should see ART code "18993"
 #
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a location
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a binding

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -261,7 +261,7 @@ HTML;
 
         if (!$mockIdp) {
             throw new RuntimeException(
-                "Unable to find idp with name '$idpName'"
+                sprintf('Unable to find idp with name "%s"', $idpName)
             );
         }
 
@@ -287,7 +287,7 @@ HTML;
         $formField = $mink->find('css', $selector);
 
         if (!$formField) {
-            throw new RuntimeException(sprintf('The %s form field should have been on the form.', $formFieldName));
+            throw new RuntimeException(sprintf('The "%s" form field should have been on the form.', $formFieldName));
         }
     }
 
@@ -301,7 +301,7 @@ HTML;
         $formField = $mink->find('css', $selector);
 
         if (!is_null($formField)) {
-            throw new RuntimeException(sprintf('The %s form field should not have been on the form.', $formFieldName));
+            throw new RuntimeException(sprintf('The "%s" form field should not have been on the form.', $formFieldName));
         }
     }
 
@@ -316,7 +316,7 @@ HTML;
         $button = $mink->find('css', $selector);
 
         if (!$button) {
-            throw new RuntimeException(sprintf('Unable to find Request access button %s', $selector));
+            throw new RuntimeException(sprintf('Unable to find Request access button "%s"', $selector));
         }
     }
 
@@ -517,14 +517,14 @@ HTML;
 
         if ($cookie === null) {
             throw new ExpectationException(
-                'The "lang" cookie has not been set',
+                'The lang cookie has not been set',
                 $this->getMinkContext()->getSession()->getDriver()
             );
         }
 
         if ($cookie !== $locale) {
             throw new ExpectationException(
-                sprintf('The "lang" cookie should contain "%s", but contains "%s"', $locale, $cookie),
+                sprintf('The lang cookie should contain "%s", but contains "%s"', $locale, $cookie),
                 $this->getMinkContext()->getSession()->getDriver()
             );
         }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -580,16 +580,16 @@ HTML;
         $session = $this->getMinkContext()->getSession();
         $mink = $session->getPage();
         // Grab the ART code from the page with an xpath expression.
-        $result = $mink->find('xpath', '//td[text()="ART Code:"]/../td[2]');
+        $result = $mink->find('xpath', '//td[text()="Error Code:"]/../td[2]');
         if ($result) {
             $artOnPage = $result->getText();
             if ($artOnPage == $artCode) {
                 return;
             }
             throw new RuntimeException(
-                sprintf('Expected ART Code "%s" did not match the ART Code on the page "%s"', $artCode, $artOnPage)
+                sprintf('Expected Error Code "%s" did not match the Error Code on the page "%s"', $artCode, $artOnPage)
             );
         }
-        throw new RuntimeException('Unable to find the ART Code on the page');
+        throw new RuntimeException('Unable to find the Error Code on the page');
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -571,4 +571,25 @@ HTML;
             );
         }
     }
+
+    /**
+     * @Given /^I should see ART code "([^"]*)"$/
+     */
+    public function iShouldSeeARTCode($artCode)
+    {
+        $session = $this->getMinkContext()->getSession();
+        $mink = $session->getPage();
+        // Grab the ART code from the page with an xpath expression.
+        $result = $mink->find('xpath', '//td[text()="ART Code:"]/../td[2]');
+        if ($result) {
+            $artOnPage = $result->getText();
+            if ($artOnPage == $artCode) {
+                return;
+            }
+            throw new RuntimeException(
+                sprintf('Expected ART Code "%s" did not match the ART Code on the page "%s"', $artCode, $artOnPage)
+            );
+        }
+        throw new RuntimeException('Unable to find the ART Code on the page');
+    }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/DataStore/AbstractDataStore.php
@@ -32,7 +32,7 @@ abstract class AbstractDataStore
         $fileContents = $this->fileSystem->read($this->filePath);
 
         if ($fileContents === false) {
-            throw new RuntimeException('Unable to load data from: ' . $this->filePath);
+            throw new RuntimeException(sprintf('Unable to load data from: "%s"', $this->filePath));
         }
 
         if (empty($fileContents)) {
@@ -41,7 +41,7 @@ abstract class AbstractDataStore
 
         $data = $this->decode($fileContents);
         if ($data === false) {
-            throw new RuntimeException('Unable to decode data from: ' . $this->filePath);
+            throw new RuntimeException(sprintf('Unable to decode data from: "%s"', $this->filePath));
         }
         return $data;
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingAttributeAggregationClient.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingAttributeAggregationClient.php
@@ -48,13 +48,13 @@ final class FunctionalTestingAttributeAggregationClient implements AttributeAggr
         foreach ($attributes as $attribute) {
             if (empty($request->rules)) {
                 throw new InvalidArgumentException(
-                    "Expecting an ARP rule for {$attribute['name']}, but no rules found."
+                    sprintf('Expecting an ARP rule for "%s", but no rules found.', $attribute['name'])
                 );
             }
 
             if (!$this->hasRuleForAttribute($request->rules, $attribute['name'], $attribute['source'])) {
                 throw new InvalidArgumentException(
-                    "Expectation failed in AA client mock: expecting ARP rule for '{$attribute['name']}"
+                    sprintf('Expectation failed in AA client mock: expecting ARP rule for "%s"', $attribute['name'])
                 );
             }
         }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingPdpClient.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingPdpClient.php
@@ -113,7 +113,7 @@ XML;
 
                 throw new RuntimeException(
                     sprintf(
-                        'Invalid Policy Decision fixture given: expected one of %s, got: %s',
+                        'Invalid Policy Decision fixture given: expected one of "%s", got: "%s"',
                         implode(
                             ', ',
                             [

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -61,7 +61,7 @@ class ServiceRegistryFixture
 
         if ($entity === null) {
             throw new \Exception(
-                "Entity '{$entityId} was not registered with registerSp()"
+                sprintf('Entity "%s" was not registered with registerSp()', $entityId)
             );
         }
 
@@ -81,7 +81,7 @@ class ServiceRegistryFixture
 
         if ($entity === null) {
             throw new \Exception(
-                "Entity '{$entityId} was not registered with registerIdp()"
+                sprintf('Entity "%s" was not registered with registerIdp()', $entityId)
             );
         }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/FileOrStdInHelper.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/FileOrStdInHelper.php
@@ -71,7 +71,7 @@ class FileOrStdInHelper
         }
 
         if (!is_file($filename)) {
-            throw new InvalidArgumentException("File '$filename' doesn't exist.");
+            throw new InvalidArgumentException(sprintf('File "%s" doesn\'t exist.', $filename));
         }
 
         return fopen($filename, 'r');

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/AbstractMockEntityRole.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/AbstractMockEntityRole.php
@@ -167,6 +167,6 @@ abstract class AbstractMockEntityRole
             return $pathFromRoot;
         }
 
-        throw new RuntimeException('Unable to find file: ' . $filePath . " ($fullFilePath)");
+        throw new RuntimeException(sprintf('Unable to find file: "%s" ("%s")', $filePath, $fullFilePath));
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
@@ -79,7 +79,7 @@ class MockIdentityProvider extends AbstractMockEntityRole
             return $constValue;
         }
 
-        throw new \RuntimeException("'$shortStatusCode' is not a valid status code");
+        throw new \RuntimeException(sprintf('"%s" is not a valid status code', $shortStatusCode));
     }
 
     /**

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Parser/Corto/XmlToArray.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Parser/Corto/XmlToArray.php
@@ -191,7 +191,10 @@ class XmlToArray
         $foldingOptionSet = xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
         if (!$foldingOptionSet) {
             throw new \RuntimeException(
-                "Unable to set XML_OPTION_CASE_FOLDING on parser object? Error message: " . xml_error_string(xml_get_error_code($parser))
+                sprintf(
+                    'Unable to set XML_OPTION_CASE_FOLDING on parser object? Error message: "%s"',
+                    xml_error_string(xml_get_error_code($parser))
+                )
             );
         }
 
@@ -199,9 +202,13 @@ class XmlToArray
         $parserResultStatus = xml_parse_into_struct($parser, $xml, $values);
         if ($parserResultStatus !== 1) {
             throw new \RuntimeException(
-                'Error parsing incoming XML. ' . PHP_EOL .
-                'Error code: ' . xml_error_string(xml_get_error_code($parser)) . PHP_EOL .
-                'XML: ' . $xml
+                sprintf(
+                    'Error parsing incoming XML. '.PHP_EOL.
+                    'Error code: "%s"'.PHP_EOL.
+                    'XML: "%s"',
+                    xml_error_string(xml_get_error_code($parser)),
+                    $xml
+                )
             );
         }
 
@@ -343,7 +350,11 @@ class XmlToArray
 
         if ($level > self::MAX_RECURSION_LEVEL) {
             throw new \RuntimeException(
-                'Recursion threshold exceed on element: ' . $elementName . ' for hashvalue: ' . var_export($hash, true)
+                sprintf(
+                    'Recursion threshold exceed on element: "%s" for hashvalue: "%s"',
+                    $elementName,
+                    var_export($hash, true)
+                )
             );
         }
         if ($hash == self::PLACEHOLDER_VALUE) {
@@ -373,7 +384,11 @@ class XmlToArray
             }
             else {
                 throw new \RuntimeException(
-                    "Value for key '$key' unrecognized (key naming error?)! Value" . print_r($value, true)
+                    sprintf(
+                        'Value for key "%s" unrecognized (key naming error?)! Value: "%s"',
+                        $key,
+                        print_r($value, true)
+                    )
                 );
             }
         }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Saml2/Compat/Container.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Saml2/Compat/Container.php
@@ -83,7 +83,7 @@ class Container extends AbstractContainer
      */
     public function redirect($url, $data = [])
     {
-        throw new NotImplementedException('SSP/SAML2 Redirect not implemented! URL: ' . $url);
+        throw new NotImplementedException(sprintf('SSP/SAML2 Redirect not implemented! URL: "%s', $url));
     }
 
     /**

--- a/tests/integration/OpenConext/EngineBlockBundle/ExecutionTimeTrackerTest.php
+++ b/tests/integration/OpenConext/EngineBlockBundle/ExecutionTimeTrackerTest.php
@@ -86,8 +86,8 @@ class ExecutionTimeTrackerTest extends TestCase
 
         $this->assertTrue($executionTimeTracker->currentExecutionTimeExceeds($aGivenExecutionTime),
             sprintf(
-                'Current execution time should exceed the given execution time of (%d ms) which is smaller: '
-                . '%d ms remaining',
+                'Current execution time should exceed the given execution time of ("%d" ms) which is smaller: '
+                . '"%d" ms remaining',
                 $aGivenExecutionTime->getExecutionTime(),
                 $executionTimeTracker->timeRemainingUntil($aGivenExecutionTime)->getExecutionTime()
             )

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/Metadata/ServiceReplacerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/Metadata/ServiceReplacerTest.php
@@ -55,7 +55,7 @@ class EngineBlock_Test_ServiceReplacerTest extends PHPUnit_Framework_TestCase
     public function testMissingServiceMetadataThrowsException()
     {
         $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
-        $this->expectExceptionMessage('No service \'singleSignOnServices\' is configured in EngineBlock metadata');
+        $this->expectExceptionMessage('No service "singleSignOnServices" is configured in EngineBlock metadata');
 
         unset($this->proxyEntity->singleSignOnServices);
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
@@ -71,7 +71,7 @@ class EngineBlock_Test_ServiceReplacerTest extends PHPUnit_Framework_TestCase
     public function testInvalidServiceMetadataThrowsException()
     {
         $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
-        $this->expectExceptionMessage('Service \'SingleSignOnService\' in EngineBlock metadata is not an array');
+        $this->expectExceptionMessage('Service "SingleSignOnService" in EngineBlock metadata is not an array');
 
         $this->proxyEntity->singleSignOnServices = false;
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
@@ -80,7 +80,7 @@ class EngineBlock_Test_ServiceReplacerTest extends PHPUnit_Framework_TestCase
     public function testMissingServiceBindingMetadataThrowsException()
     {
         $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
-        $this->expectExceptionMessage('Service \'SingleSignOnService\' configured without a Binding in EngineBlock metadata');
+        $this->expectExceptionMessage('Service "SingleSignOnService" configured without a Binding in EngineBlock metadata');
 
         unset($this->proxyEntity->singleSignOnServices[0]->binding);
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
@@ -89,7 +89,7 @@ class EngineBlock_Test_ServiceReplacerTest extends PHPUnit_Framework_TestCase
     public function testInvalidServiceBindingMetadataThrowsException()
     {
         $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
-        $this->expectExceptionMessage('Service \'SingleSignOnService\' has an invalid binding \'foo\' configured in EngineBlock metadata');
+        $this->expectExceptionMessage('Service "SingleSignOnService" has an invalid binding "foo" configured in EngineBlock metadata');
 
         $this->proxyEntity->singleSignOnServices[0]->binding = 'foo';
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);
@@ -98,7 +98,7 @@ class EngineBlock_Test_ServiceReplacerTest extends PHPUnit_Framework_TestCase
     public function testNoValidServiceBindingsFoundInMetadataThrowsException()
     {
         $this->expectException(EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer_Exception::class);
-        $this->expectExceptionMessage('No \'singleSignOnServices\' service bindings configured in EngineBlock metadata');
+        $this->expectExceptionMessage('No "singleSignOnServices" service bindings configured in EngineBlock metadata');
 
         $this->proxyEntity->singleSignOnServices = array();
         new ServiceReplacer($this->proxyEntity, 'SingleSignOnService', ServiceReplacer::REQUIRED);

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/ProcessConsentTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/ProcessConsentTest.php
@@ -49,7 +49,7 @@ class EngineBlock_Test_Corto_Module_Service_ProcessConsentTest extends PHPUnit_F
     public function testSessionLostExceptionIfPostIdNotInSession()
     {
         $this->expectException(EngineBlock_Corto_Module_Services_SessionLostException::class);
-        $this->expectExceptionMessage('Stored response for ResponseID \'test\' not found');
+        $this->expectExceptionMessage('Stored response for ResponseID "test" not found');
 
         unset($_SESSION['consent']['test']);
 

--- a/tests/unit/OpenConext/EngineBlockBundle/Exception/ArtTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Exception/ArtTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Tests;
+
+use Exception;
+use PHPUnit_Framework_TestCase as TestCase;
+use RuntimeException;
+use OpenConext\EngineBlockBundle\Exception\Art;
+
+class ArtTest extends TestCase
+{
+    /**
+     * @test
+     * @group art
+     */
+    public function art_code_is_numeric()
+    {
+        $this->assertTrue(is_numeric(Art::forException(new Exception)), 'Expected numeric Art code');
+    }
+
+    /**
+     * @test
+     * @group art
+     */
+    public function art_code_is_distinct_per_exception_type()
+    {
+        $art1 = new Exception();
+        $art2 = new RuntimeException();
+
+        $this->assertNotEquals($art1, $art2, 'Expected different art code for different exception type');
+    }
+
+    /**
+     * @test
+     * @group art
+     */
+    public function art_code_is_distinct_per_message()
+    {
+        $art1 = new Exception('one');
+        $art2 = new Exception('two');
+
+        $this->assertNotEquals($art1, $art2, 'Expected different art code for different exception message');
+    }
+
+    /**
+     * @test
+     * @group art
+     * @dataProvider artCodeWithStrippedVariables
+     *
+     * @param Exception $exception
+     * @param int $expectedArtCode
+     */
+    public function exception_translates_to_art_code_with_variables_stripped(Exception $exception, $expectedArtCode)
+    {
+        $this->assertEquals(
+            $expectedArtCode,
+            Art::forException($exception)
+        );
+    }
+
+    public function artCodeWithStrippedVariables()
+    {
+        $artCode = Art::forException(
+            new Exception('This is a \'good\' message')
+        );
+
+        return [
+            [new Exception('This is a \'nice\' message'), $artCode],
+            [new Exception('This is a "real" message'), $artCode],
+            [new Exception('This is a "re"X"al" message'), $artCode],
+            [new Exception('This is a "re\'X\'al" message'), $artCode],
+            [new Exception('This is a "" message'), $artCode],
+        ];
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Pdp/Dto/ResponseTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Pdp/Dto/ResponseTest.php
@@ -40,7 +40,7 @@ class ResponseTest extends TestCase
     public function a_pdp_response_without_a_response_key_is_invalid()
     {
         $this->expectException('\OpenConext\EngineBlockBundle\Exception\InvalidPdpResponseException');
-        $this->expectExceptionMessage('Key "Response" was not found in the PDP response');
+        $this->expectExceptionMessage('Key: Response was not found in the PDP response');
 
         $responseJson = file_get_contents(__DIR__ . '/../fixture/invalid/response_without_response_key.json');
 
@@ -54,7 +54,7 @@ class ResponseTest extends TestCase
     public function a_pdp_response_without_a_response_key_as_an_array_is_invalid()
     {
         $this->expectException('\OpenConext\EngineBlockBundle\Exception\InvalidPdpResponseException');
-        $this->expectExceptionMessage('"Response" is not an array');
+        $this->expectExceptionMessage('Response is not an array');
 
         $responseJson = file_get_contents(__DIR__ . '/../fixture/invalid/response_without_response_array.json');
 
@@ -82,7 +82,7 @@ class ResponseTest extends TestCase
     public function a_pdp_response_without_a_status_is_invalid()
     {
         $this->expectException('\OpenConext\EngineBlockBundle\Exception\InvalidPdpResponseException');
-        $this->expectExceptionMessage('Key "Status" was not found in the PDP response');
+        $this->expectExceptionMessage('Key: Status was not found in the PDP response');
 
         $responseJson = file_get_contents(__DIR__ . '/../fixture/invalid/response_without_status_key.json');
 
@@ -96,7 +96,7 @@ class ResponseTest extends TestCase
     public function a_pdp_response_without_a_policy_identifier_is_invalid()
     {
         $this->expectException('\OpenConext\EngineBlockBundle\Exception\InvalidPdpResponseException');
-        $this->expectExceptionMessage('Key "PolicyIdentifier" was not found in the PDP response');
+        $this->expectExceptionMessage('Key: PolicyIdentifier was not found in the PDP response');
 
         $responseJson = file_get_contents(__DIR__ . '/../fixture/invalid/response_without_policy_identifier_key.json');
 
@@ -110,7 +110,7 @@ class ResponseTest extends TestCase
     public function a_pdp_response_without_a_decision_is_invalid()
     {
         $this->expectException('\OpenConext\EngineBlockBundle\Exception\InvalidPdpResponseException');
-        $this->expectExceptionMessage('Key "Decision" was not found in the PDP response');
+        $this->expectExceptionMessage('Key: Decision was not found in the PDP response');
 
         $responseJson = file_get_contents(__DIR__ . '/../fixture/invalid/response_without_decision_key.json');
 


### PR DESCRIPTION
This PR levers the ART implementation of StepUp and implements it into Engineblock.

The ART code is generated in the `collectFeedbackInfo`, and is based on the exception message of the exception that was raised. In order to generate consistent ART codes, #644 was opened to ensure variable texts in exception messages are put between quotes. These quoted variable strings are then ignored during ART generation.

Note that the commits of #644 are also in this commit.