### PR TITLE
Render 405 error pages more elegantly

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -160,6 +160,8 @@ TXT
     // Error screens
     'error_404'                         => '404 - Page not found',
     'error_404_desc'                    => 'This page has not been found.',
+    'error_405'                         => 'HTTP Method not allowed',
+    'error_405_desc'                    => 'The HTTP method "%requestMethod%" is not allowed for location "%uri%". Supported methods are: %allowedMethods%.',
     'error_help_desc'               => '<p></p>',
     'error_no_consent'              => 'Unable to continue to service',
     'error_no_consent_desc'         => 'This application can only be used when you share the mentioned information.<br /><br />

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -158,6 +158,8 @@ TXT
     // Error screens
     'error_404'                         => '404 - Pagina niet gevonden',
     'error_404_desc'                    => 'De pagina is niet gevonden.',
+    'error_405'                         => 'HTTP methode is niet toegestaan',
+    'error_405_desc'                    => 'De HTTP-methode "%requestMethod%" is niet toegestaan ​​voor locatie "%uri%". Ondersteunde methodes zijn: %allowedMethods%.',
     'error_help_desc'                   => '<p></p>',
     'error_no_consent'                  => 'Niet mogelijk om verder te gaan naar dienst',
     'error_no_consent_desc'             => 'Deze applicatie kan enkel worden gebruikt wanneer de vermelde informatie wordt gedeeld.<br /><br />

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -142,6 +142,8 @@ TXT
     // Error screens
     'error_404'                         => '404 - Página não encontrada',
     'error_404_desc'                    => 'Esta página não foi encontrada.',
+    'error_405'                         => 'Método HTTP não permitido',
+    'error_405_desc'                    => 'O método HTTP "%requestMethod%" não é permitido para o endereço "%uri%". Os métodos suportados são: %allowedMethods%.',
     'error_help_desc'               => '<p></p>',
     'error_no_consent'              => 'Não é possivel continua para o serviço',
     'error_no_consent_desc'         => 'Esta aplicação só pode ser utilizada quando a informação mencionada for partilhada.<br /><br />

--- a/src/OpenConext/EngineBlockBundle/EventListener/MethodNotAllowedHttpExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/MethodNotAllowedHttpExceptionListener.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\EventListener;
+
+use EngineBlock_ApplicationSingleton;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Twig_Environment;
+
+final class MethodNotAllowedHttpExceptionListener
+{
+    /**
+     * @var Twig_Environment
+     */
+    private $twig;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton
+     * @param Twig_Environment $twig
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        Twig_Environment $twig,
+        LoggerInterface $logger
+    ) {
+        $this->twig = $twig;
+        $this->logger = $logger;
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $exception = $event->getException();
+        if (!$exception instanceof MethodNotAllowedHttpException) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $uri = strtok($request->getUri(), '?');
+        $requestMethod = $request->getRealMethod();
+        $allowedMethods = isset($exception->getHeaders()['Allow']) ? $exception->getHeaders()['Allow'] : 'Unknown';
+
+        // inverted quotes for BC, existing log parsers may rely on this
+        $this->logger->notice(sprintf(
+            "[405]Disallowed request method: '%s'",
+            $requestMethod
+        ));
+
+        $response = new Response(
+            $this->twig->render(
+                '@theme/Default/View/Error/method-not-allowed.html.twig',
+                [
+                    'requestMethod' => $requestMethod,
+                    'allowedMethods' => $allowedMethods,
+                    'uri' => $uri
+                ]
+            ),
+            405
+        );
+
+        $event->setResponse($response);
+        // once we've handled it, we don't want anything else to interfere.
+        $event->stopPropagation();
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Resources/config/event_listeners.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/event_listeners.yml
@@ -45,6 +45,14 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 25 }
 
+    engineblock.listener.method_not_allowed_http_exception:
+        class: OpenConext\EngineBlockBundle\EventListener\MethodNotAllowedHttpExceptionListener
+        arguments:
+            - "@twig"
+            - "@engineblock.compat.logger"
+        tags:
+            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 25 }
+
     engineblock.listener.fallback_exception:
         class: OpenConext\EngineBlockBundle\EventListener\FallbackExceptionListener
         arguments:

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
@@ -6,11 +6,13 @@ api_heartbeat:
     path:     /
     defaults:
         _controller: engineblock.controller.api.heartbeat:itWorksAction
+        _format: json
 
 api_connections:
     path:     /api/connections
     defaults:
         _controller: engineblock.controller.api.connections:pushConnectionsAction
+        _format: json
 
 api_consent_user:
     path:    /consent/{userId}
@@ -18,6 +20,7 @@ api_consent_user:
         userId: .+
     defaults:
         _controller: engineblock.controller.api.consent:userAction
+        _format: json
 
 api_deprovision_delete_user_data_dry_run:
     path:    /deprovision/{collabPersonId}/dry-run
@@ -25,6 +28,7 @@ api_deprovision_delete_user_data_dry_run:
         collabPersonId: .+
     defaults:
         _controller: engineblock.controller.api.deprovision:dryRunAction
+        _format: json
 
 api_deprovision_get_user_data:
     path:    /deprovision/{collabPersonId}
@@ -32,18 +36,22 @@ api_deprovision_get_user_data:
         collabPersonId: .+
     defaults:
         _controller: engineblock.controller.api.deprovision:userDataAction
+        _format: json
 
 api_metadata_idp:
     path:    /metadata/idp
     defaults:
         _controller: engineblock.controller.api.metadata:idpAction
+        _format: json
 
 api_apply_attribute_release_policy:
     path:   /arp
     defaults:
         _controller: engineblock.controller.api.attribute_release_policy:applyArpAction
+        _format: json
 
 api_read_attribute_release_policy:
     path:   /read-arp
     defaults:
         _controller: engineblock.controller.api.attribute_release_policy:readArpAction
+        _format: json

--- a/theme/material/templates/modules/Default/View/Error/method-not-allowed.html.twig
+++ b/theme/material/templates/modules/Default/View/Error/method-not-allowed.html.twig
@@ -1,0 +1,17 @@
+{% extends '@themeLayouts/scripts/default.html.twig' %}
+
+{# Prepare the page title #}
+{% set pageTitle = 'error_405'|trans %}
+
+{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block pageHeading %}{{ parent() }} - {{ pageTitle }}{% endblock %}
+
+{% block content %}
+<div class="box">
+  <div class="mod-content">
+    <h1>{{ pageTitle }}</h1>
+    {{ 'error_405_desc'|trans({'%requestMethod%': requestMethod, '%uri%': uri,'%allowedMethods%': allowedMethods}) }}
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
The http 405 (request method not allowed) error handling has been made
more verbose for the users of engine block. A custom error screen was
added where the user is informed of the error situation.

On this screen we do not show the error table as we do during the
authentication process.

Task 1 of: https://www.pivotaltracker.com/story/show/164121663