### PR TITLE
Allow only POST requests on /sp/consume-assertion

### DIFF
--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -289,14 +289,6 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         // Remember idp for debugging
         $_SESSION['currentIdentityProvider'] = $idpEntityId;
 
-        // We only support HTTP-POST binding for Responses
-        if (!$sspBinding instanceof HTTPPost) {
-            throw new EngineBlock_Corto_Module_Bindings_UnsupportedBindingException(
-                sprintf('Unsupported Binding used: "%s"', get_class($sspBinding)),
-                EngineBlock_Exception::CODE_NOTICE
-            );
-        }
-
         // Verify that we know this IdP and have metadata for it.
         $cortoIdpMetadata = $this->_verifyKnownIdP(
             $idpEntityId,

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/service_provider.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/service_provider.yml
@@ -1,6 +1,6 @@
 authentication_sp_consume_assertion:
     path:     /authentication/sp/consume-assertion
-    methods:  [GET,POST] # GET is allowed on purpose to present a meaningful error message.
+    methods:  [POST]
     defaults:
         _controller: engineblock.controller.authentication.service_provider:consumeAssertionAction
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -151,14 +151,8 @@ Feature:
     Given the IdP uses the HTTP Redirect Binding
      When I log in at "Dummy SP"
       And I pass through EngineBlock
-     Then I should see "Invalid ACS Binding Type"
-      And I should see "Timestamp:"
-      And I should see "Unique Request Id:"
-      And I should see "User Agent:"
-      And I should see "IP Address:"
-      And I should see "Service Provider:"
-      And I should see "Service Provider Name:"
-      And I should see "Identity Provider:"
+     Then I should see "HTTP Method not allowed"
+      And I should see "The HTTP method \"GET\" is not allowed for location \"https://engine.vm.openconext.org/authentication/sp/consume-assertion\". Supported methods are: POST."
 
   Scenario: An Identity Provider sends a response without a SHO
     Given the IdP does not send the attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization"


### PR DESCRIPTION
We stated that GET was also allowed in order to render more user
friendly error reports. That was not at all the case. In a recent effort
error reporting regarding disallowed request methods was improved.

So we can now start enforcing POST requests on the ACS endpoint. Any
other request method will result in routing exception that in turn will
be handled by the improved error reporting.

Task 2 & 4 of: https://www.pivotaltracker.com/story/show/164121663
Also see: #646