### PR TITLE
Honor explicit keyid in unsolicited single sign on request

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -261,6 +261,10 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         }
 
         $request = new EngineBlock_Saml2_AuthnRequestAnnotationDecorator($sspRequest);
+        if ($keyid = $this->_server->getKeyId()) {
+            $request->setKeyId($keyid);
+        }
+
         $request->setUnsolicited();
 
         return $request;


### PR DESCRIPTION
When creating a new authnrequest based on a call to the
unsolicited-single-sign-on endpoint, do not forget to set
the keyid in this new request if it was specified in the
u-s-s-o URL.

This fixes the bug that assertions to SPs in response to unsolicited sso
calls would always be signed with the default key, regardless of any
explicit keyslugs in the unsolicited sso endpoint call.