### PR TITLE
Fix unexpected SSO behaviour for trusted proxy

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -25,6 +25,13 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         $log->info(sprintf("Fetching service provider matching request issuer '%s'", $request->getIssuer()));
         $sp = $this->_server->getRepository()->fetchServiceProviderByEntityId($request->getIssuer());
 
+        // When dealing with an SP that acts as a trusted proxy, we should perform SSO on the proxying SP and not the
+        // proxy itself.
+        if ($sp->isTrustedProxy) {
+            // Overwrite the trusted proxy SP instance with that of the SP that uses the trusted proxy.
+            $sp = $this->findOriginalServiceProvider($request, $log);
+        }
+
         // Exposing entityId to be used when tracking the start of an authentication procedure
         $application->authenticationStateSpEntityId = $sp->entityId;
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -295,6 +295,26 @@ class MockSpContext extends AbstractSubContext
 
         $this->mockSpRegistry->save();
     }
+
+    /**
+     * @Given /^SP "([^"]*)" is authenticating for SP "([^"]*)" resetting the RequesterID chain$/
+     */
+    public function spIsAuthenticatingForSpReset($spName, $spDestinationName)
+    {
+        /** @var MockServiceProvider $sp */
+        $sp = $this->mockSpRegistry->get($spName);
+        /** @var MockServiceProvider $spDestination */
+        $spDestination = $this->mockSpRegistry->get($spDestinationName);
+
+        $authNRequest = $sp->getAuthnRequest();
+        $requesterIds = [];
+        $requesterIds[] = $spDestination->entityId();
+        $authNRequest->setRequesterID($requesterIds);
+
+        $this->mockSpRegistry->save();
+    }
+
+
     /**
      * @Given /^SP "([^"]*)" is authenticating for misconfigured SP "([^"]*)"$/
      */

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
@@ -15,6 +15,7 @@ Feature:
       And a Service Provider named "Loa SP"
       And a Service Provider named "Far SP"
       And a Service Provider named "Test SP"
+      And a Service Provider named "Second SP"
       And SP "Far SP" is not connected to IdP "CombinedAuth"
       And SP "Far SP" is not connected to IdP "LoaOnlyAuth"
       And SP "Far SP" is not connected to IdP "StepUpOnlyAuth"
@@ -229,3 +230,22 @@ Feature:
     And SP "Step Up" signs its requests
     When I log in at "Step Up"
     Then I should see "Error - Unknown service"
+
+  Scenario: User logs in to two SPs via trusted proxy
+   Given SP "Step Up" is authenticating for SP "Loa SP"
+     And SP "Step Up" is a trusted proxy
+     And SP "Step Up" does not require consent
+    When I log in at "Step Up"
+     And I select "AlwaysAuth" on the WAYF
+     And I pass through EngineBlock
+     And I pass through the IdP
+     And I pass through EngineBlock
+         # Next, Step Up SP would redirect to the Loa SP, but verifying this is out of our test boundaries
+    Then the url should match "functional-testing/Step%20Up/acs"
+   Given SP "Step Up" is authenticating for SP "Second SP" resetting the RequesterID chain
+     And SP "Second SP" is not connected to IdP "AlwaysAuth"
+    When I log in at "Second SP"
+         # Bug report: https://www.pivotaltracker.com/story/show/164069793
+    Then I should not see "Error - No Identity Providers found"
+         # The WAYF should be visible
+     And I should see "Select an organisation to login to the service"


### PR DESCRIPTION
This bugfix adds a Behat scenario the reproduces the behavior described in the bug report. It then proceeds to fix the issue by preventing IdP scope limiting based on previously selected IdPs.

More details about this bug can be found in:
https://www.pivotaltracker.com/story/show/164069793