### PR TITLE
Improve error reporting for clock related SAMLResponse issues

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -264,6 +264,8 @@ Your %organisationNoun% has denied you access to this service. You will have to 
 
     'error_unknown_service'         => 'Error - Unknown service',
     'error_unknown_service_desc'    => '<p>Your requested service couldn\'t be found.</p>',
+    'error_clock_issue_title' => 'Error - The Assertion is not yet valid or has expired',
+    'error_clock_issue_desc' => '<p>Please verify that the time on the IdP is correct.</p>',
 
     'attributes_validation_succeeded' => 'Authentication success',
     'attributes_validation_failed'    => 'Some attributes failed validation',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -261,6 +261,8 @@ Je %organisationNoun% heeft je de toegang geweigerd tot deze dienst. Je zult dus
 
     'error_unknown_service'         => 'Error - Deze dienst is niet geregistreerd bij %suiteName%.',
     'error_unknown_service_desc'    => '<p>Deze dienst is niet bekend.</p>',
+    'error_clock_issue_title' => 'Error - De Assertion is nog niet geldig of is verlopen',
+    'error_clock_issue_desc' => '<p>Controleer de tijd op de IdP.</p>',
 
     'attributes_validation_succeeded' => 'Authenticatie geslaagd',
     'attributes_validation_failed'    => 'Sommige attributen kunnen niet gevalideerd worden',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -240,6 +240,8 @@ A sua %organisationNoun% negou-lhe acesso a este serviço. Terá de entrar em co
     'error_attribute_validator_availability'        => '\'%arg3%\' é um schacHomeOrganization reservado para outro Fornecedor de Identidade',
     'error_unknown_service'         => 'Erro - Serviço desconhecido',
     'error_unknown_service_desc'    => '<p>O serviço solicitado não foi encontrado.</p>',
+    'error_clock_issue_title' => 'Erro - A asserção ainda não é válida ou expirou',
+    'error_clock_issue_desc' => '<p>Por favor, verifique se a hora no IdP está correta.</p>',
     'attributes_validation_succeeded' => 'Autenticação com sucesso',
     'attributes_validation_failed'    => 'Alguns atributos falharam na validação',
     'attributes_data_mailed'          => 'Os dados dos atributos foram enviados',

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -414,6 +414,19 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             ]);
         }
         catch (ResponseProcessingFailedException $e) {
+            // The clock on the IdP side must be checked
+            // @see \SAML2\Assertion\Validation\ConstraintValidator\NotBefore::validate
+            // @see \SAML2\Assertion\Validation\ConstraintValidator\NotOnOrAfter::validate
+            if (strpos($e->getMessage(), 'Received an assertion that is valid in the future') !== false ||
+                strpos($e->getMessage(), 'Received an assertion that has expired') !== false
+            ) {
+                throw new EngineBlock_Corto_Module_Bindings_ClockIssueException(
+                    $e->getMessage(),
+                    EngineBlock_Exception::CODE_ERROR,
+                    $e
+                );
+            }
+
             // Passthrough, should be handled at a different level protecting against oracle attacks
             throw $e;
         }

--- a/library/EngineBlock/Corto/Module/Bindings/ClockIssueException.php
+++ b/library/EngineBlock/Corto/Module/Bindings/ClockIssueException.php
@@ -1,0 +1,5 @@
+<?php
+
+class EngineBlock_Corto_Module_Bindings_ClockIssueException extends EngineBlock_Corto_Module_Bindings_Exception
+{
+}

--- a/library/EngineBlock/Corto/Module/Bindings/TimingException.php
+++ b/library/EngineBlock/Corto/Module/Bindings/TimingException.php
@@ -1,5 +1,0 @@
-<?php
-
-class EngineBlock_Corto_Module_Bindings_TimingException extends EngineBlock_Corto_Module_Bindings_VerificationException
-{
-}

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -393,6 +393,17 @@ class FeedbackController
     }
 
     /**
+     * @return Response
+     */
+    public function clockIssueAction()
+    {
+        return new Response(
+            $this->twig->render('@theme/Authentication/View/Feedback/clock-issue.html.twig'),
+            400
+        );
+    }
+
+    /**
      * @param SessionInterface $session
      * @param array $customFeedbackInfo
      */

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -86,6 +86,11 @@ class RedirectToFeedbackPageExceptionListener
         $this->errorReporter = $errorReporter;
     }
 
+    /**
+     * @param GetResponseForExceptionEvent $event
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength) - See comment in class doc block
+     */
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
         $exception = $event->getException();
@@ -165,6 +170,9 @@ class RedirectToFeedbackPageExceptionListener
             $message = $exception->getMessage();
             $event->getRequest()->getSession()->set('feedback_custom', $exception->getMessage());
             $redirectToRoute = 'authentication_feedback_no_authentication_request_received';
+        } elseif ($exception instanceof \EngineBlock_Corto_Module_Bindings_ClockIssueException) {
+            $message = $exception->getMessage();
+            $redirectToRoute = 'authentication_feedback_response_clock_issue';
         } else {
             return;
         }

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
@@ -102,3 +102,8 @@ authentication_feedback_no_authentication_request_received:
     path:       '/invalid-request-method-on-sso'
     methods:    [GET]
     defaults:    { _controller: engineblock.controller.authentication.feedback:noAuthenticationRequestReceivedAction }
+
+authentication_feedback_response_clock_issue:
+    path:       '/clock-issue'
+    methods:    [GET]
+    defaults:    { _controller: engineblock.controller.authentication.feedback:clockIssueAction }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -284,22 +284,30 @@ Feature:
      And I pass through the SP
     Then I should see "No SAMLRequest parameter was found in the HTTP \"POST\" request parameters"
      And I should see ART code "18993"
-#
+
+  Scenario: The IdP sends a SAMLResponse that triggers a NotOnOrAfter violation when behind on time
+   Given The clock on the IdP "Dummy Idp" is behind
+    When I log in at "Dummy SP"
+     And I pass through EngineBlock
+     And I pass through the IdP
+     And I give my consent
+    Then I should see "Error - The Assertion is not yet valid or has expired"
+    And I should see ART code "44601"
+
+  Scenario: The IdP sends a SAMLResponse that triggers a NotOnOrAfter violation when ahead of time
+   Given The clock on the IdP "Dummy Idp" is ahead
+    When I log in at "Dummy SP"
+     And I pass through EngineBlock
+     And I pass through the IdP
+     And I give my consent
+    Then I should see "Error - The Assertion is not yet valid or has expired"
+     And I should see ART code "44601"
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a location
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a binding
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying an invalid index
 #
-#
 #  Scenario: I don't give consent to release my attributes to a Service Provider
-#
-#  Scenario: I visit the EngineBlock SSO location without a SAMLRequest
-#  Scenario: I visit the EngineBlock ACS location without a SAMLResponse
-#  Scenario: I visit the EngineBlock SSO location with a bad SAMLRequest
-#  Scenario: I visit the EngineBlock ACS location with a bad SAMLResponse
-#
-#  Scenario: I lose my 'main' session cookie.
 #
 #  Scenario: An attribute manipulation determines that a user may not continue
 #
-#  Scenario: An Identity Provider dates its assertions in the future.
 #  Scenario: I want to log in to a service but am not a member of the appropriate VO

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -346,4 +346,26 @@ class MockIdpContext extends AbstractSubContext
         $this->serviceRegistryFixture->setConsentSettings($idp->entityId(), $sp->entityId(), ConsentSettings::CONSENT_DISABLED);
         $this->serviceRegistryFixture->save();
     }
+
+    /**
+     * @Given /^The clock on the IdP "([^"]*)" is behind$/
+     */
+    public function theClockOnTheIdPIsBehind($idpName)
+    {
+        $idp = $this->mockIdpRegistry->get($idpName);
+        $idp->turnBackTheTime();
+
+        $this->mockIdpRegistry->save();
+    }
+
+    /**
+     * @Given /^The clock on the IdP "([^"]*)" is ahead/
+     */
+    public function theClockOnTheIdPIsAhead($idpName)
+    {
+        $idp = $this->mockIdpRegistry->get($idpName);
+        $idp->fromTheFuture();
+
+        $this->mockIdpRegistry->save();
+    }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
@@ -14,6 +14,10 @@ class MockIdentityProvider extends AbstractMockEntityRole
 {
     private $sendAssertions = true;
 
+    private $turnBackTime = false;
+
+    private $fromTheFuture = false;
+
     private $logo = null;
 
     public function singleSignOnLocation()
@@ -267,6 +271,30 @@ class MockIdentityProvider extends AbstractMockEntityRole
     public function doNotSendAssertions()
     {
         $this->sendAssertions = false;
+
+        return $this;
+    }
+
+    public function shouldTurnBackTheTime()
+    {
+        return $this->turnBackTime;
+    }
+
+    public function turnBackTheTime()
+    {
+        $this->turnBackTime = true;
+
+        return $this;
+    }
+
+    public function isFromTheFuture()
+    {
+        return $this->fromTheFuture;
+    }
+
+    public function fromTheFuture()
+    {
+        $this->fromTheFuture = true;
 
         return $this;
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Saml2/ResponseFactory.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Saml2/ResponseFactory.php
@@ -31,6 +31,16 @@ class ResponseFactory
             $response->setAssertions([]);
         }
 
+        if ($mockIdp->shouldTurnBackTheTime()) {
+            // Set the timestamp to Unix Epoch
+            $response->getAssertions()[0]->setNotOnOrAfter(0);
+        }
+
+        if ($mockIdp->isFromTheFuture()) {
+            // Set the timestamp to current time + i year
+            $response->getAssertions()[0]->setNotBefore(strtotime(date('Y-m-d H:i:s', strtotime('+1 year'))));
+        }
+
         return $response;
     }
 

--- a/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
@@ -1,6 +1,11 @@
 <?php
 
+use Mockery as m;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use SAML2\Assertion;
+use SAML2\Assertion\Validation\Result;
+use SAML2\Assertion\Validation\ConstraintValidator\NotBefore;
+use SAML2\Assertion\Validation\ConstraintValidator\NotOnOrAfter;
 use SAML2\Constants;
 use SAML2\Response;
 
@@ -17,10 +22,12 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends PHPUnit_Framework_TestC
     public function setup()
     {
         $proxyServer = Phake::mock('EngineBlock_Corto_ProxyServer');
-        Phake::when($proxyServer)->getSigningCertificates()->thenReturn(new EngineBlock_X509_KeyPair(
-            new EngineBlock_X509_Certificate(openssl_x509_read(file_get_contents(__DIR__ . '/test.pem.crt'))),
-            new EngineBlock_X509_PrivateKey(__DIR__ . '/test.pem.key')
-        ));
+        Phake::when($proxyServer)->getSigningCertificates()->thenReturn(
+            new EngineBlock_X509_KeyPair(
+                new EngineBlock_X509_Certificate(openssl_x509_read(file_get_contents(__DIR__.'/test.pem.crt'))),
+                new EngineBlock_X509_PrivateKey(__DIR__.'/test.pem.key')
+            )
+        );
         $this->bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
     }
 
@@ -36,6 +43,48 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends PHPUnit_Framework_TestC
     }
 
     /**
+     * We specifically test for some error / validation messages to have a certain value,
+     * and throw a custom exception if that is the case. For example we did this to show a
+     * custom user facing error page when the received SAML Response contains an assertion
+     * from the past or future.
+     *
+     * This test simply verifies if the error message that is yielded from the SAML2 library
+     * did not change, effectively changing behaviour of EB.
+     *
+     * Disclaimer, this is not a pure unit test in the sense it tests a specific feature of
+     * Bindings. This however seemed the most logical place to put it.
+     */
+    public function test_saml2_library_error_messages_we_specifically_test_have_not_changed()
+    {
+        $assertion = m::mock(Assertion::class);
+        $assertion
+            ->shouldReceive('getNotBefore')
+            // Unix timestamp: 9000000000 translates to: 11/20/2286 @ 5:46pm (UTC)
+            ->andReturn(9999999999);
+
+        $assertion
+            ->shouldReceive('getNotOnOrAfter')
+            // Unix timestamp: 1 translates to: 01/01/1970 @ 12:00am (UTC)
+            ->andReturn(1);
+
+        $result = new Result();
+        $notBefore = new NotBefore();
+        $notOnOrAfter = new NotOnOrAfter();
+
+        $notBefore->validate($assertion, $result);
+        $this->assertEquals(
+            'Received an assertion that is valid in the future. Check clock synchronization on IdP and SP.',
+            $result->getErrors()[0]
+        );
+
+        $notOnOrAfter->validate($assertion, $result);
+        $this->assertEquals(
+            'Received an assertion that has expired. Check clock synchronization on IdP and SP.',
+            $result->getErrors()[1]
+        );
+    }
+
+    /**
      * Provides a list of paths to response xml files and certificate files
      *
      * @return array
@@ -44,11 +93,11 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends PHPUnit_Framework_TestC
     {
         $responseFiles = array();
         $certificateFiles = array();
-        $responsesDir = TEST_RESOURCES_DIR . '/saml/responses';
-        $defaultCertFile = $responsesDir . '/defaultCert';
+        $responsesDir = TEST_RESOURCES_DIR.'/saml/responses';
+        $defaultCertFile = $responsesDir.'/defaultCert';
         $responsesDirIterator = new DirectoryIterator($responsesDir);
         /** @var $responseFile DirectoryIterator */
-        foreach($responsesDirIterator as $responseFile) {
+        foreach ($responsesDirIterator as $responseFile) {
             if ($responseFile->isFile() && !$responseFile->isDot()) {
                 $extension = substr($responseFile->getFilename(), -3);
                 $fileNameWithoutExtension = substr($responseFile->getFilename(), 0, -4);

--- a/theme/material/templates/modules/Authentication/View/Feedback/clock-issue.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/clock-issue.html.twig
@@ -1,9 +1,9 @@
 {% extends '@theme/Default/View/Error/error.html.twig' %}
 
 {% set wide = true %}
-{% set pageTitle = 'error_no_consent'|trans %}
+{% set pageTitle = 'error_clock_issue_title'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_no_consent_desc'|trans|raw }}{% endblock %}
+{% block errorMessage %}{{ 'error_clock_issue_desc'|trans|raw }}{% endblock %}

--- a/theme/material/templates/modules/Authentication/View/Feedback/clock-issue.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/clock-issue.html.twig
@@ -1,0 +1,9 @@
+{% extends '@theme/Default/View/Error/error.html.twig' %}
+
+{% set wide = true %}
+{% set pageTitle = 'error_no_consent'|trans %}
+{% block pageTitle %}{{ pageTitle }}{% endblock %}
+{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block pageHeading %}{{ pageTitle }}{% endblock %}
+
+{% block errorMessage %}{{ 'error_no_consent_desc'|trans|raw }}{% endblock %}


### PR DESCRIPTION
This PR adds a custom error page for when the issuer instant of the assertion is before/after the allowed time determined by the SAML2 response validator.

The individual commits should give additional information.

Test-tip:
Either manipulate your IdP to send out of time saml responses, or update the response before validating it in the bindins module.

1. Go to: `\EngineBlock_Corto_Module_Bindings::receiveResponse` at line 264
2. Override the NotOnOrAfter of the first assertion by adding line: `$sspResponse->getAssertions()[0]->setNotOnOrAfter(0);` to mimick an idp from the past
3. Override the `$sspResponse->getAssertions()[0]->setNotBefore(strtotime(date('Y-m-d H:i:s', strtotime('+1 year'))));` to mimick an idp from the future

This fixes tasks 1 and 2 of: https://www.pivotaltracker.com/story/show/164076668
~~The remaining task is to set a meaningful error title and text.~~