### PR TITLE
Prevent blurring the search bar

### DIFF
--- a/theme/material/javascripts/application.js
+++ b/theme/material/javascripts/application.js
@@ -69,7 +69,7 @@ function initialize() {
         configuration.requestAccessUrl
     );
     const keyboardListener         = new KeyboardListener(idpPicker, $searchBar, requestAccessModalHelper);
-    const mouseListener         = new MouseListener(idpPicker, $searchBar, requestAccessModalHelper);
+    const mouseListener         = new MouseListener(idpPicker, requestAccessModalHelper);
 
     // Keyup, click and input are registered events for cross-browser compatibility with HTML5 'search' input
     $searchBar.addEventListener('keyup', throttle(event => idpPicker.searchBy(event.target.value), throttleAmountInMs));

--- a/theme/material/javascripts/modules/MouseListener.js
+++ b/theme/material/javascripts/modules/MouseListener.js
@@ -1,7 +1,6 @@
 export class MouseListener {
-    constructor(idpPicker, searchBarElement, requestAccessModalHelper) {
+    constructor(idpPicker, requestAccessModalHelper) {
         this.idpPicker        = idpPicker;
-        this.searchBarElement = searchBarElement;
         this.requestAccessModalHelper = requestAccessModalHelper;
     }
 
@@ -10,11 +9,6 @@ export class MouseListener {
 
             // Don't interfere with the IDP selection list when
             // the request-access modal dialog is open.
-            return;
-        }
-
-        if (document.activeElement === this.searchBarElement) {
-            this.searchBarElement.blur();
             return;
         }
 


### PR DESCRIPTION
When the mouse moves away from the search bar, previously the focus was blurred from the input field.

This behavior made using the search bar very un-user-friendly. Removing this behavior seems to fix the issue at hand.

Fixes https://www.pivotaltracker.com/story/show/165020904