### PR TITLE
Update PT tranlation of error_clock_issue_title

### DIFF
--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -240,7 +240,7 @@ A sua %organisationNoun% negou-lhe acesso a este serviço. Terá de entrar em co
     'error_attribute_validator_availability'        => '\'%arg3%\' é um schacHomeOrganization reservado para outro Fornecedor de Identidade',
     'error_unknown_service'         => 'Erro - Serviço desconhecido',
     'error_unknown_service_desc'    => '<p>O serviço solicitado não foi encontrado.</p>',
-    'error_clock_issue_title' => 'Erro - A asserção ainda não é válida ou expirou',
+    'error_clock_issue_title' => 'Erro - A asserção ainda não é válida ou pode ter expirado',
     'error_clock_issue_desc' => '<p>Por favor, verifique se a hora no IdP está correta.</p>',
     'attributes_validation_succeeded' => 'Autenticação com sucesso',
     'attributes_validation_failed'    => 'Alguns atributos falharam na validação',


### PR DESCRIPTION
As suggested in: https://github.com/OpenConext/OpenConext-engineblock/pull/655#discussion_r271282767 by a native speaker, the translation for the clock issue title was updated.

Thanks @domgon!