### PR TITLE
Add Saml binding validator to acs endpoint

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -1,6 +1,7 @@
 <?php
 
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
+use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
 use OpenConext\Value\Saml\Entity;
 use OpenConext\Value\Saml\EntityId;
 use OpenConext\Value\Saml\EntityType;
@@ -70,7 +71,7 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
             // Authentication state needs to be registered here as the debug flow differs from the regular flow,
             // yet the procedures for both are completed when consuming the assertion in the ServiceProviderController
             $identityProvider = new Entity(new EntityId($idp->entityId), EntityType::IdP());
-            $authenticationState = $this->_session->get('authentication_state');
+            $authenticationState = $this->getAuthenticationState();
             $authenticationState->authenticatedAt($requestId, $identityProvider);
 
             $this->_server->redirect(
@@ -111,7 +112,7 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
             $newResponse->setReturn($this->_server->getUrl('processedAssertionConsumerService'));
 
             $identityProvider = new Entity(new EntityId($idp->entityId), EntityType::IdP());
-            $authenticationState = $this->_session->get('authentication_state');
+            $authenticationState = $this->getAuthenticationState();
             $authenticationState->authenticatedAt($inResponseTo, $identityProvider);
 
             $this->_server->getBindingsModule()->send($newResponse, $firstProcessingEntity);
@@ -164,5 +165,13 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         if (in_array($signatureMethod, $this->_server->getConfig('forbiddenSignatureMethods'))) {
             throw new EngineBlock_Corto_Module_Bindings_UnsupportedSignatureMethodException($signatureMethod);
         }
+    }
+
+    /**
+     * @return AuthenticationState
+     */
+    private function getAuthenticationState()
+    {
+        return $this->_session->get('authentication_state');
     }
 }

--- a/src/OpenConext/EngineBlock/Exception/MissingParameterException.php
+++ b/src/OpenConext/EngineBlock/Exception/MissingParameterException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Exception;
+
+class MissingParameterException extends RuntimeException
+{
+}

--- a/src/OpenConext/EngineBlock/Validator/AcsRequestValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/AcsRequestValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Validator;
+
+use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
+use OpenConext\EngineBlock\Exception\MissingParameterException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The AcsRequestValidator verifies valid saml binding
+ *
+ * Valid requests method / binding combinations for SSO are:
+ *
+ *  | Request method | Parameter name  |
+ *  | -------------- | --------------- |
+ *  | GET            | SAMLResponse    |
+ *  | POST           | SAMLResponse    |
+ */
+class AcsRequestValidator implements RequestValidator
+{
+    private $supportedRequestMethods = [Request::METHOD_GET, Request::METHOD_POST];
+
+    public function isValid(Request $request)
+    {
+        $requestMethod = $request->getMethod();
+        // Defense in depth; anything other than POST and GET are probably already rejected at routing time.
+        if (!in_array($requestMethod, $this->supportedRequestMethods)) {
+            // Only Redirect binding is supported for Single Sign On
+            throw new InvalidRequestMethodException(
+                sprintf('The HTTP request method "%s" is not supported on this SAML ACS endpoint', $requestMethod)
+            );
+        }
+
+        if (($requestMethod ===  Request::METHOD_POST && !$request->request->has('SAMLResponse')) ||
+            ($requestMethod ===  Request::METHOD_GET && !$request->query->has('SAMLResponse'))) {
+            throw new MissingParameterException(
+                sprintf('The parameter "SAMLResponse" is missing on this SAML ACS endpoint')
+            );
+        }
+
+        return true;
+    }
+}

--- a/src/OpenConext/EngineBlock/Validator/AcsRequestValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/AcsRequestValidator.php
@@ -50,7 +50,7 @@ class AcsRequestValidator implements RequestValidator
         if (($requestMethod ===  Request::METHOD_POST && !$request->request->has('SAMLResponse')) ||
             ($requestMethod ===  Request::METHOD_GET && !$request->query->has('SAMLResponse'))) {
             throw new MissingParameterException(
-                sprintf('The parameter "SAMLResponse" is missing on this SAML ACS endpoint')
+                sprintf('The parameter "SAMLResponse" is missing on the SAML ACS request')
             );
         }
 

--- a/src/OpenConext/EngineBlock/Validator/SamlBindingValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/SamlBindingValidator.php
@@ -20,14 +20,13 @@ namespace OpenConext\EngineBlock\Validator;
 
 use Exception;
 use OpenConext\EngineBlock\Exception\InvalidBindingException;
-use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
 use SAML2\Binding;
 use SAML2\HTTPPost;
 use SAML2\HTTPRedirect;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * The SsoRequestValidator verifies valid requests on the SSO endpoint
+ * The SamlBindingValidator verifies valid saml binding
  *
  * Valid requests method / binding combinations for SSO are:
  *
@@ -38,23 +37,13 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class SamlBindingValidator implements RequestValidator
 {
-    private $supportedRequestMethods = [Request::METHOD_GET, Request::METHOD_POST];
-
     public function isValid(Request $request)
     {
-        $requestMethod = $request->getMethod();
-        // Defense in depth; anything other than POST and GET are probably already rejected at routing time.
-        if (!in_array($requestMethod, $this->supportedRequestMethods)) {
-            // Only Redirect binding is supported for Single Sign On
-            throw new InvalidRequestMethodException(
-                sprintf('The HTTP request method "%s" is not supported on this SAML SSO endpoint', $requestMethod)
-            );
-        }
         try {
             $binding = Binding::getCurrentBinding();
         } catch (Exception $e) {
             throw new InvalidBindingException(
-                sprintf('No SAMLRequest or SAMLResponse parameter was found in the HTTP "%s" request parameters', $requestMethod),
+                sprintf('No SAMLRequest or SAMLResponse parameter was found in the HTTP "%s" request parameters', $request->getMethod()),
                 0,
                 $e
             );

--- a/src/OpenConext/EngineBlock/Validator/SamlBindingValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/SamlBindingValidator.php
@@ -31,12 +31,12 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * Valid requests method / binding combinations for SSO are:
  *
- *  | SAML Binding     | Request method | Parameter name |
- *  | ---------------- | -------------- | -------------- |
- *  | HttpRedirect     | GET            | SAMLRequest    |
- *  | HTTPPost         | POST           | SAMLRequest    |
+ *  | SAML Binding     | Request method | Parameter name              |
+ *  | ---------------- | -------------- | --------------------------- |
+ *  | HttpRedirect     | GET            | SAMLRequest,SAMLResponse    |
+ *  | HTTPPost         | POST           | SAMLRequest,SAMLResponse    |
  */
-class SsoRequestValidator implements RequestValidator
+class SamlBindingValidator implements RequestValidator
 {
     private $supportedRequestMethods = [Request::METHOD_GET, Request::METHOD_POST];
 
@@ -54,7 +54,7 @@ class SsoRequestValidator implements RequestValidator
             $binding = Binding::getCurrentBinding();
         } catch (Exception $e) {
             throw new InvalidBindingException(
-                sprintf('No SAMLRequest parameter was found in the HTTP "%s" request parameters', $requestMethod),
+                sprintf('No SAMLRequest or SAMLResponse parameter was found in the HTTP "%s" request parameters', $requestMethod),
                 0,
                 $e
             );
@@ -62,7 +62,7 @@ class SsoRequestValidator implements RequestValidator
         if (!($binding instanceof HTTPRedirect || $binding instanceof HTTPPost)) {
             // We only support HTTP Redirect binding
             throw new InvalidBindingException(
-                sprintf('The binding type "%s" is not supported on this SAML SSO endpoint', get_class($binding))
+                sprintf('The binding type "%s" is not supported on this endpoint', get_class($binding))
             );
         }
         return true;

--- a/src/OpenConext/EngineBlock/Validator/SsoRequestValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/SsoRequestValidator.php
@@ -50,7 +50,7 @@ class SsoRequestValidator implements RequestValidator
         if (($requestMethod ===  Request::METHOD_POST && !$request->request->has('SAMLRequest')) ||
             ($requestMethod ===  Request::METHOD_GET && !$request->query->has('SAMLRequest'))) {
             throw new MissingParameterException(
-                sprintf('The parameter "SAMLRequest" is missing on this SAML SSO endpoint')
+                sprintf('The parameter "SAMLRequest" is missing on the SAML SSO request')
             );
         }
 

--- a/src/OpenConext/EngineBlock/Validator/SsoRequestValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/SsoRequestValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Validator;
+
+use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
+use OpenConext\EngineBlock\Exception\MissingParameterException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The SsoRequestValidator verifies valid saml binding
+ *
+ * Valid requests method / binding combinations for SSO are:
+ *
+ *  | Request method | Parameter name  |
+ *  | -------------- | --------------- |
+ *  | GET            | SAMLRequest     |
+ *  | POST           | SAMLRequest    |
+ */
+class SsoRequestValidator implements RequestValidator
+{
+    private $supportedRequestMethods = [Request::METHOD_GET, Request::METHOD_POST];
+
+    public function isValid(Request $request)
+    {
+        $requestMethod = $request->getMethod();
+        // Defense in depth; anything other than POST and GET are probably already rejected at routing time.
+        if (!in_array($requestMethod, $this->supportedRequestMethods)) {
+            // Only Redirect binding is supported for Single Sign On
+            throw new InvalidRequestMethodException(
+                sprintf('The HTTP request method "%s" is not supported on this SAML SSO endpoint', $requestMethod)
+            );
+        }
+
+        if (($requestMethod ===  Request::METHOD_POST && !$request->request->has('SAMLRequest')) ||
+            ($requestMethod ===  Request::METHOD_GET && !$request->query->has('SAMLRequest'))) {
+            throw new MissingParameterException(
+                sprintf('The parameter "SAMLRequest" is missing on this SAML SSO endpoint')
+            );
+        }
+
+        return true;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationState.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationState.php
@@ -91,8 +91,10 @@ final class AuthenticationState implements AuthenticationStateInterface
 
         if ($currentRequest === null) {
             throw new LogicException(
-                'Current authentication procedure cannot be authenticated:'
-                 . ' authentication procedure has not been started'
+                sprintf(
+                    'The requested authentication procedure with requestId (%s) couldn\'t be found in the session storage.',
+                    $requestId
+                )
             );
         }
 
@@ -110,15 +112,19 @@ final class AuthenticationState implements AuthenticationStateInterface
         $currentRequest = $this->authenticationProcedures->find($requestId);
         if ($currentRequest === null) {
             throw new LogicException(
-                'Current authentication procedure cannot be completed:'
-                . ' authentication procedure has not been started'
+                sprintf(
+                    'The requested authentication procedure with requestId (%s) couldn\'t be found in the session storage.',
+                    $requestId
+                )
             );
         }
 
         if ($currentRequest->hasBeenAuthenticated()) {
             throw new LogicException(
-                'Current authentication procedure cannot be completed:'
-                . ' authentication procedure has not been authenticated'
+                sprintf(
+                    'The requested authentication procedure with requestId (%s) couldn\'t be completed in the session storage.',
+                    $requestId
+                )
             );
         }
 

--- a/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationState.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationState.php
@@ -113,7 +113,7 @@ final class AuthenticationState implements AuthenticationStateInterface
         if ($currentRequest === null) {
             throw new LogicException(
                 sprintf(
-                    'The requested authentication procedure with requestId (%s) couldn\'t be found in the session storage.',
+                    'The requested authentication procedure with requestId (%s) couldn\'t be found in the session storage in order to complete.',
                     $requestId
                 )
             );
@@ -122,7 +122,7 @@ final class AuthenticationState implements AuthenticationStateInterface
         if ($currentRequest->hasBeenAuthenticated()) {
             throw new LogicException(
                 sprintf(
-                    'The requested authentication procedure with requestId (%s) couldn\'t be completed in the session storage.',
+                    'The requested authentication procedure with requestId (%s) has already been authenticated.',
                     $requestId
                 )
             );

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -20,14 +20,10 @@ namespace OpenConext\EngineBlockBundle\Controller;
 
 use EngineBlock_ApplicationSingleton;
 use EngineBlock_Corto_Adapter;
-use Exception;
 use OpenConext\EngineBlock\Service\AuthenticationStateHelperInterface;
 use OpenConext\EngineBlock\Service\RequestAccessMailer;
 use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
-use OpenConext\Value\Saml\Entity;
-use OpenConext\Value\Saml\EntityId;
-use OpenConext\Value\Saml\EntityType;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -115,13 +111,15 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
     }
 
     /**
+     * @param Request $request
      * @param null|string $keyId
      * @param null|string $idpHash
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
-     * @throws Exception
      */
-    public function unsolicitedSingleSignOnAction($keyId = null, $idpHash = null)
+    public function unsolicitedSingleSignOnAction(Request $request, $keyId = null, $idpHash = null)
     {
+        $this->requestValidator->isValid($request);
+
         $cortoAdapter = new EngineBlock_Corto_Adapter();
 
         if ($keyId !== null) {

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -64,19 +64,26 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
      */
     private $requestValidator;
 
+    /**
+     * @var RequestValidator
+     */
+    private $bindingValidator;
+
     public function __construct(
         EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton,
         Twig_Environment $twig,
         LoggerInterface $loggerInterface,
         RequestAccessMailer $requestAccessMailer,
-        RequestValidator $validator,
+        RequestValidator $requestValidator,
+        RequestValidator $bindingValidator,
         AuthenticationStateHelperInterface $authenticationStateHelper
     ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
         $this->twig = $twig;
         $this->logger = $loggerInterface;
         $this->requestAccessMailer = $requestAccessMailer;
-        $this->requestValidator = $validator;
+        $this->requestValidator = $requestValidator;
+        $this->bindingValidator = $bindingValidator;
         $this->authenticationStateHelper = $authenticationStateHelper;
     }
 
@@ -98,6 +105,7 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
     public function singleSignOnAction(Request $request, $keyId = null, $idpHash = null)
     {
         $this->requestValidator->isValid($request);
+        $this->bindingValidator->isValid($request);
 
         $cortoAdapter = new EngineBlock_Corto_Adapter();
 
@@ -119,6 +127,7 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
     public function unsolicitedSingleSignOnAction(Request $request, $keyId = null, $idpHash = null)
     {
         $this->requestValidator->isValid($request);
+        $this->bindingValidator->isValid($request);
 
         $cortoAdapter = new EngineBlock_Corto_Adapter();
 

--- a/src/OpenConext/EngineBlockBundle/Controller/ServiceProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/ServiceProviderController.php
@@ -20,7 +20,9 @@ namespace OpenConext\EngineBlockBundle\Controller;
 
 use EngineBlock_ApplicationSingleton;
 use EngineBlock_Corto_Adapter;
+use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class ServiceProviderController implements AuthenticationLoopThrottlingController
@@ -34,20 +36,29 @@ class ServiceProviderController implements AuthenticationLoopThrottlingControlle
      * @var Session
      */
     private $session;
+    /**
+     * @var RequestValidator
+     */
+    private $requestValidator;
 
     public function __construct(
         EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton,
-        Session $session
+        Session $session,
+        RequestValidator $requestValidator
     ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
         $this->session                         = $session;
+        $this->requestValidator = $requestValidator;
     }
 
     /**
+     * @param Request $request
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function consumeAssertionAction()
+    public function consumeAssertionAction(Request $request)
     {
+        $this->requestValidator->isValid($request);
+
         $proxyServer = new EngineBlock_Corto_Adapter();
         $proxyServer->consumeAssertion();
 

--- a/src/OpenConext/EngineBlockBundle/Controller/ServiceProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/ServiceProviderController.php
@@ -41,14 +41,21 @@ class ServiceProviderController implements AuthenticationLoopThrottlingControlle
      */
     private $requestValidator;
 
+    /**
+     * @var RequestValidator
+     */
+    private $bindingValidator;
+
     public function __construct(
         EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton,
         Session $session,
-        RequestValidator $requestValidator
+        RequestValidator $requestValidator,
+        RequestValidator $bindingValidator
     ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
         $this->session                         = $session;
         $this->requestValidator = $requestValidator;
+        $this->bindingValidator = $bindingValidator;
     }
 
     /**
@@ -58,6 +65,7 @@ class ServiceProviderController implements AuthenticationLoopThrottlingControlle
     public function consumeAssertionAction(Request $request)
     {
         $this->requestValidator->isValid($request);
+        $this->bindingValidator->isValid($request);
 
         $proxyServer = new EngineBlock_Corto_Adapter();
         $proxyServer->consumeAssertion();

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -40,6 +40,7 @@ use EngineBlock_Corto_Module_Services_SessionNotStartedException;
 use EngineBlock_Exception_UnknownServiceProvider;
 use OpenConext\EngineBlock\Exception\InvalidBindingException;
 use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
+use OpenConext\EngineBlock\Exception\MissingParameterException;
 use OpenConext\EngineBlockBridge\ErrorReporter;
 use OpenConext\EngineBlockBundle\Exception\StuckInAuthenticationLoopException;
 use Psr\Log\LoggerInterface;
@@ -169,7 +170,10 @@ class RedirectToFeedbackPageExceptionListener
         } elseif ($exception instanceof StuckInAuthenticationLoopException) {
             $message         = 'Stuck in authentication loop';
             $redirectToRoute = 'authentication_feedback_stuck_in_authentication_loop';
-        } elseif ($exception instanceof InvalidRequestMethodException || $exception instanceof InvalidBindingException) {
+        } elseif ($exception instanceof InvalidRequestMethodException ||
+            $exception instanceof InvalidBindingException ||
+            $exception instanceof  MissingParameterException
+        ) {
             $message = $exception->getMessage();
             $event->getRequest()->getSession()->set('feedback_custom', $exception->getMessage());
             $redirectToRoute = 'authentication_feedback_no_authentication_request_received';

--- a/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
@@ -4,6 +4,7 @@ services:
         arguments:
             - "@engineblock.compat.application"
             - "@session"
+            - "@engineblock.validator.acs_request_validator"
             - "@engineblock.validator.saml_binding_validator"
 
     engineblock.controller.authentication.identity_provider:
@@ -13,6 +14,7 @@ services:
             - "@twig"
             - "@engineblock.compat.logger"
             - "@engineblock.service.request_access_mailer"
+            - "@engineblock.validator.sso_request_validator"
             - "@engineblock.validator.saml_binding_validator"
             - "@engineblock.service.authentication_state_helper"
 

--- a/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
@@ -4,6 +4,7 @@ services:
         arguments:
             - "@engineblock.compat.application"
             - "@session"
+            - "@engineblock.validator.saml_binding_validator"
 
     engineblock.controller.authentication.identity_provider:
         class: OpenConext\EngineBlockBundle\Controller\IdentityProviderController
@@ -12,7 +13,7 @@ services:
             - "@twig"
             - "@engineblock.compat.logger"
             - "@engineblock.service.request_access_mailer"
-            - "@engineblock.validator.sso_request_validator"
+            - "@engineblock.validator.saml_binding_validator"
             - "@engineblock.service.authentication_state_helper"
 
     engineblock.controller.authentication.index:

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -147,7 +147,13 @@ services:
             - "%allowed_acs_location_schemes%"
 
     engineblock.validator.saml_binding_validator:
-            class: OpenConext\EngineBlock\Validator\SamlBindingValidator
+        class: OpenConext\EngineBlock\Validator\SamlBindingValidator
+
+    engineblock.validator.acs_request_validator:
+        class: OpenConext\EngineBlock\Validator\AcsRequestValidator
+
+    engineblock.validator.sso_request_validator:
+        class: OpenConext\EngineBlock\Validator\SsoRequestValidator
 
     engineblock.twig.extension.debug:
         class: OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Debug

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -146,8 +146,8 @@ services:
         arguments:
             - "%allowed_acs_location_schemes%"
 
-    engineblock.validator.sso_request_validator:
-            class: OpenConext\EngineBlock\Validator\SsoRequestValidator
+    engineblock.validator.saml_binding_validator:
+            class: OpenConext\EngineBlock\Validator\SamlBindingValidator
 
     engineblock.twig.extension.debug:
         class: OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Debug

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -278,26 +278,26 @@ Feature:
   Scenario: The SP uses the wrong request parameter while using HTTP Redirect binding
    Given the SP "Dummy SP" sends a malformed AuthNRequest
     When I log in at "Dummy SP"
-    Then I should see "The parameter \"SAMLRequest\" is missing on this SAML SSO endpoint"
-     And I should see ART code "35954"
+    Then I should see "The parameter \"SAMLRequest\" is missing on the SAML SSO request"
+     And I should see ART code "41946"
 
   Scenario: The SP uses the wrong request parameter while using HTTP Post binding
    Given the SP "Dummy SP" sends a malformed AuthNRequest
      And the SP "Dummy SP" uses the HTTP POST Binding
     When I log in at "Dummy SP"
      And I pass through the SP
-    Then I should see "The parameter \"SAMLRequest\" is missing on this SAML SSO endpoint"
-     And I should see ART code "35954"
+    Then I should see "The parameter \"SAMLRequest\" is missing on the SAML SSO request"
+     And I should see ART code "41946"
 
   Scenario: The acs location is missing the SamlResponse parameter
     When I post data "{}" to Engineblock URL "/authentication/sp/consume-assertion"
-    Then I should see "he parameter \"SAMLResponse\" is missing on this SAML ACS endpoint."
-    And I should see ART code "39524"
+    Then I should see "he parameter \"SAMLResponse\" is missing on the SAML ACS request"
+    And I should see ART code "16088"
 
   Scenario: The sso location is missing the SamlRequest parameter
     When I post data "{}" to Engineblock URL "/authentication/idp/single-sign-on"
-    Then I should see "The parameter \"SAMLRequest\" is missing on this SAML SSO endpoint"
-    And I should see ART code "35954"
+    Then I should see "The parameter \"SAMLRequest\" is missing on the SAML SSO request"
+    And I should see ART code "41946"
 
   Scenario: The IdP sends a SAMLResponse that triggers a NotOnOrAfter violation when behind on time
    Given The clock on the IdP "Dummy Idp" is behind

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -278,16 +278,16 @@ Feature:
   Scenario: The SP uses the wrong request parameter while using HTTP Redirect binding
    Given the SP "Dummy SP" sends a malformed AuthNRequest
     When I log in at "Dummy SP"
-    Then I should see "No SAMLRequest parameter was found in the HTTP \"GET\" request parameters"
-     And I should see ART code "18993"
+    Then I should see "The parameter \"SAMLRequest\" is missing on this SAML SSO endpoint"
+     And I should see ART code "35954"
 
   Scenario: The SP uses the wrong request parameter while using HTTP Post binding
    Given the SP "Dummy SP" sends a malformed AuthNRequest
      And the SP "Dummy SP" uses the HTTP POST Binding
     When I log in at "Dummy SP"
      And I pass through the SP
-    Then I should see "No SAMLRequest parameter was found in the HTTP \"POST\" request parameters"
-     And I should see ART code "18993"
+    Then I should see "The parameter \"SAMLRequest\" is missing on this SAML SSO endpoint"
+     And I should see ART code "35954"
 
   Scenario: The IdP sends a SAMLResponse that triggers a NotOnOrAfter violation when behind on time
    Given The clock on the IdP "Dummy Idp" is behind

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -289,6 +289,16 @@ Feature:
     Then I should see "The parameter \"SAMLRequest\" is missing on this SAML SSO endpoint"
      And I should see ART code "35954"
 
+  Scenario: The acs location is missing the SamlResponse parameter
+    When I post data "{}" to Engineblock URL "/authentication/sp/consume-assertion"
+    Then I should see "he parameter \"SAMLResponse\" is missing on this SAML ACS endpoint."
+    And I should see ART code "39524"
+
+  Scenario: The sso location is missing the SamlRequest parameter
+    When I post data "{}" to Engineblock URL "/authentication/idp/single-sign-on"
+    Then I should see "The parameter \"SAMLRequest\" is missing on this SAML SSO endpoint"
+    And I should see ART code "35954"
+
   Scenario: The IdP sends a SAMLResponse that triggers a NotOnOrAfter violation when behind on time
    Given The clock on the IdP "Dummy Idp" is behind
     When I log in at "Dummy SP"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -549,6 +549,17 @@ HTML;
     }
 
     /**
+     * @When /^I post data "([^"]*)" to Engineblock URL "([^"]*)"$/
+     */
+    public function iPostDataToEngineBlockUrl($data, $path)
+    {
+        $postdata = json_decode($data, true);
+        $url = $this->engineBlockDomain . $path;
+
+        $this->getMinkContext()->getSession()->getDriver()->getClient()->request('POST', $url, $postdata);
+    }
+
+    /**
      * @Given /^the attribute aggregator returns no attributes$/
      */
     public function aaReturnsNoAttributes()

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Service/EngineBlock.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Service/EngineBlock.php
@@ -49,7 +49,8 @@ class EngineBlock
     {
         return $this->baseUrl
                . sprintf(self::UNSOLICITED_SSO_START_PATH, md5($identityProviderEntityId))
-               . '?sp-entity-id=' . urlencode($serviceProviderEntityId);
+               . '?sp-entity-id=' . urlencode($serviceProviderEntityId)
+               . '&SAMLRequest=test';
     }
 
     public function spEntityId()

--- a/tests/unit/OpenConext/EngineBlock/Validator/AcsRequestValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/AcsRequestValidatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace OpenConext\EngineBlock\Validator;
+
+use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class AcsRequestValidatorTest extends TestCase
+{
+    /**
+     * @var AcsRequestValidator
+     */
+    private $validator;
+
+    public function setUp()
+    {
+        $this->validator = new AcsRequestValidator();
+
+        // PHPunit does not reset the superglobals on each run.
+        $_GET = [];
+        $_POST = [];
+        $_SERVER = [];
+    }
+
+    public function test_happy_flow_get()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET['SAMLResponse'] = 'loremipsum';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->assertTrue($this->validator->isValid($request));
+    }
+
+    public function test_happy_flow_post()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['SAMLResponse'] = 'loremipsum';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->assertTrue($this->validator->isValid($request));
+    }
+
+    public function test_patch_method_is_not_supported()
+    {
+        $this->expectException(InvalidRequestMethodException::class);
+        $this->expectExceptionMessage('The HTTP request method "PATCH" is not supported on this SAML ACS endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'PATCH';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Validator/AcsRequestValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/AcsRequestValidatorTest.php
@@ -3,6 +3,7 @@
 namespace OpenConext\EngineBlock\Validator;
 
 use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
+use OpenConext\EngineBlock\Exception\MissingParameterException;
 use PHPUnit_Framework_TestCase as TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -51,6 +52,30 @@ class AcsRequestValidatorTest extends TestCase
         $this->expectExceptionMessage('The HTTP request method "PATCH" is not supported on this SAML ACS endpoint');
 
         $_SERVER['REQUEST_METHOD'] = 'PATCH';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+
+    public function test_missing_saml_argument_on_post()
+    {
+        $this->expectException(MissingParameterException::class);
+        $this->expectExceptionMessage('The parameter "SAMLResponse" is missing on this SAML ACS endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+
+    public function test_missing_saml_argument_on_get()
+    {
+        $this->expectException(MissingParameterException::class);
+        $this->expectExceptionMessage('The parameter "SAMLResponse" is missing on this SAML ACS endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
 
         $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
 

--- a/tests/unit/OpenConext/EngineBlock/Validator/SamlBindingValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/SamlBindingValidatorTest.php
@@ -8,16 +8,16 @@ use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
 use PHPUnit_Framework_TestCase as TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
-class SsoRequestValidatorTest extends TestCase
+class SamlBindingValidatorTest extends TestCase
 {
     /**
-     * @var SsoRequestValidator
+     * @var SamlBindingValidator
      */
     private $validator;
 
     public function setUp()
     {
-        $this->validator = new SsoRequestValidator();
+        $this->validator = new SamlBindingValidator();
 
         // PHPunit does not reset the superglobals on each run.
         unset($_GET['SAMLRequest']);

--- a/tests/unit/OpenConext/EngineBlock/Validator/SsoRequestValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/SsoRequestValidatorTest.php
@@ -3,6 +3,7 @@
 namespace OpenConext\EngineBlock\Validator;
 
 use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
+use OpenConext\EngineBlock\Exception\MissingParameterException;
 use PHPUnit_Framework_TestCase as TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -51,6 +52,30 @@ class SsoRequestValidatorTest extends TestCase
         $this->expectExceptionMessage('The HTTP request method "PATCH" is not supported on this SAML SSO endpoint');
 
         $_SERVER['REQUEST_METHOD'] = 'PATCH';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+
+    public function test_missing_saml_argument_on_post()
+    {
+        $this->expectException(MissingParameterException::class);
+        $this->expectExceptionMessage('The parameter "SAMLRequest" is missing on this SAML SSO endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+
+    public function test_missing_saml_argument_on_get()
+    {
+        $this->expectException(MissingParameterException::class);
+        $this->expectExceptionMessage('The parameter "SAMLRequest" is missing on this SAML SSO endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
 
         $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
 

--- a/tests/unit/OpenConext/EngineBlock/Validator/SsoRequestValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/SsoRequestValidatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace OpenConext\EngineBlock\Validator;
+
+use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class SsoRequestValidatorTest extends TestCase
+{
+    /**
+     * @var SsoRequestValidator
+     */
+    private $validator;
+
+    public function setUp()
+    {
+        $this->validator = new SsoRequestValidator();
+
+        // PHPunit does not reset the superglobals on each run.
+        $_GET = [];
+        $_POST = [];
+        $_SERVER = [];
+    }
+
+    public function test_happy_flow_get()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET['SAMLRequest'] = 'loremipsum';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->assertTrue($this->validator->isValid($request));
+    }
+
+    public function test_happy_flow_post()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['SAMLRequest'] = 'loremipsum';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->assertTrue($this->validator->isValid($request));
+    }
+
+    public function test_post_binding_is_not_supported()
+    {
+        $this->expectException(InvalidRequestMethodException::class);
+        $this->expectExceptionMessage('The HTTP request method "PATCH" is not supported on this SAML SSO endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'PATCH';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Authentication/AuthenticationStateTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Authentication/AuthenticationStateTest.php
@@ -41,7 +41,7 @@ class AuthenticationStateTest extends TestCase
         $authenticationState = new AuthenticationState($authenticationLoopGuard);
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('authentication procedure has not been started');
+        $this->expectExceptionMessage('authentication procedure could not be found for given requestId');
 
         $authenticationState->authenticatedAt('_00000000-0000-0000-0000-000000000000', $identityProvider);
     }
@@ -57,7 +57,7 @@ class AuthenticationStateTest extends TestCase
         $authenticationState = new AuthenticationState($authenticationLoopGuard);
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('authentication procedure has not been started');
+        $this->expectExceptionMessage('authentication procedure could not be found for given requestId');
 
         $authenticationState->completeCurrentProcedure('_00000000-0000-0000-0000-000000000000');
     }
@@ -78,7 +78,7 @@ class AuthenticationStateTest extends TestCase
         $authenticationState->startAuthenticationOnBehalfOf($requestId, $serviceProvider);
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('authentication procedure has not been authenticated');
+        $this->expectExceptionMessage('authentication procedure could not be found for given requestId');
 
         $authenticationState->completeCurrentProcedure($requestId);
     }


### PR DESCRIPTION
This is done in order to make sure that the 'Current authentication
procedure exceptions' are split up. So the information returned
should be much more informative.