### PR TITLE
Update endpoints needing sessions

### DIFF
--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -48,7 +48,9 @@ class EngineBlock_Corto_ProxyServer
     protected $_servicesNotNeedingSession = array(
         'singleSignOnService',
         'unsolicitedSingleSignOnService',
-        'logout'
+        'singleLogoutService',
+        'idpMetadataService',
+        'spMetadataService',
     );
 
     protected $_headers = array();

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -272,7 +272,7 @@ Feature:
     Then I should see "your session was lost"
 
   Scenario: A session is not started while expected
-    When I go to Engineblock URL "/authentication/sp/metadata"
+    When I go to Engineblock URL "/authentication/sp/process-consent"
     Then I should see "your session was not found"
 
   Scenario: The SP uses the wrong request parameter while using HTTP Redirect binding


### PR DESCRIPTION
The endpoints needing a session cookie were incomplete and needed to be
fixed.