### PR TITLE
Change mariadb version to fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,5 +89,5 @@ after_failure:
 addons:
   hosts:
     - engine.vm.openconext.org
-  mariadb: '10.1'
+  mariadb: '10.2'
   chrome: stable


### PR DESCRIPTION
The build with 10.1 breaks because apparmor kicks in and prevents
mariadb from starting. This is a temporarily workaround and should
maybe be reverted over time.