### PR TITLE
Make the memory limit for push configurable

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,7 +1,9 @@
 # UPGRADE NOTES
 
-## 5.8 -> 5.9
-The minified `web/javascripts/application.min.js` is removed from VCS therefore you need to build it yourself if you don't use the release tarballs. In the `README.md` you can find how to accomplish this. 
+## 5.9 -> 5.10
+
+### Metadata push memory configurable
+The memory used in php for the metadata push is now configurable with the `engineblock.metadata_push_memory_limit` configuration option.
 
 ## 5.7 -> 5.8
 

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -182,6 +182,8 @@ attributeAggregation.password = "secret"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; MISCELLANEOUS SETTINGS ;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; The memory limit used for the metadata push this setting is overridden in the ConnectionsController
+engineblock.metadata_push_memory_limit = "256M"
 
 ; Minimum execution time in milliseconds when a received response is deemed invalid (default: 5000 ms)
 minimumExecutionTimeOnInvalidReceivedResponse = 5000

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -154,6 +154,9 @@ $ymlContent = array(
         'attribute_aggregation.username'                          => $config->get('attributeAggregation.username'),
         'attribute_aggregation.password'                          => escapeYamlValue($config->get('attributeAggregation.password')),
 
+        // Metdata push memory limit
+        'engineblock.metadata_push_memory_limit'                  => $config->get('engineblock.metadata_push_memory_limit'),
+
         // Logger settings.
         'logger.channel'                                          => $config->get('logger.conf.name'),
         'logger.fingers_crossed.passthru_level'                   => $config->get('logger.conf.handler.fingers_crossed.conf.passthru_level'),

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
@@ -41,21 +41,29 @@ class ConnectionsController
     private $repository;
 
     /**
+     * @var string
+     */
+    private $memoryLimit;
+
+    /**
      * @param MetadataAssemblerInterface $assembler
      * @param AuthorizationCheckerInterface $authorizationChecker
      * @param FeatureConfiguration $featureConfiguration
      * @param DoctrineMetadataPushRepository $repository
+     * @param string|null $memoryLimit
      */
     public function __construct(
         MetadataAssemblerInterface $assembler,
         AuthorizationCheckerInterface $authorizationChecker,
         FeatureConfiguration $featureConfiguration,
-        DoctrineMetadataPushRepository $repository
+        DoctrineMetadataPushRepository $repository,
+        $memoryLimit
     ) {
         $this->pushMetadataAssembler           = $assembler;
         $this->authorizationChecker            = $authorizationChecker;
         $this->featureConfiguration            = $featureConfiguration;
         $this->repository                      = $repository;
+        $this->memoryLimit                     = $memoryLimit;
     }
 
     public function pushConnectionsAction(Request $request)
@@ -74,7 +82,9 @@ class ConnectionsController
             );
         }
 
-        ini_set('memory_limit', '256M');
+        if ($this->memoryLimit) {
+            ini_set('memory_limit', $this->memoryLimit);
+        }
 
         $body = JsonRequestHelper::decodeContentOf($request);
 

--- a/src/OpenConext/EngineBlockBundle/Resources/config/controllers/api.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/controllers/api.yml
@@ -6,6 +6,7 @@ services:
             - "@security.authorization_checker"
             - "@engineblock.features"
             - "@engineblock.metadata_push.repository.doctrine"
+            - "%engineblock.metadata_push_memory_limit%"
 
     engineblock.controller.api.consent:
         class: OpenConext\EngineBlockBundle\Controller\Api\ConsentController


### PR DESCRIPTION
The metadata memory limit needs to be configurable. This is done so
engineblock could be quickly configured to allow more data being
pushed.

https://www.pivotaltracker.com/n/projects/1425900/stories/164329554
https://github.com/OpenConext/OpenConext-deploy/pull/199