### PR TITLE
Remove ul from session exception messages

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -176,9 +176,9 @@ If you want to use this application you have to:<br />
 The service you\'re trying to reach (&lsquo;Service Provider&rsquo;) is not accessible through %suiteName%.<br /><br />
     </p>',
     'error_session_lost'            => 'Error - your session was lost',
-    'error_session_lost_desc'       => '<p>This action requires an active session, however, we could not find the session.<br /><ul><li>Did you wait too long?</li><li>Close your browser and retry, or try a different browser.</li></ul></p>',
+    'error_session_lost_desc'       => '<p>This action requires an active session, however, we could not find the session. Did you wait too long? Close your browser and retry, or try a different browser.</p>',
     'error_session_not_started'            => 'Error - your session was not found',
-    'error_session_not_started_desc'       => '<p>This action requires an active session, however, we could not find one.<br /><ul><li>Were you inactive for a while?</li><li>Please close your browser and try again, or use a different browser.</li></ul></p>',
+    'error_session_not_started_desc'       => '<p>This action requires an active session, however, we could not find one. Were you inactive for a while? Please close your browser and try again, or use a different browser.</p>',
     'error_authorization_policy_violation'            => 'Error - No access',
     'error_authorization_policy_violation_desc'       => '<p>
         You have successfully logged in at your %organisationNoun%, but unfortunately you cannot use this service (the &lsquo;Service Provider&rsquo;) because you have no access. Your %organisationNoun% limits access to this service with an <i>authorization policy</i>. Please contact the helpdesk of your %organisationNoun% if you think you should be allowed access to this service.

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -174,9 +174,9 @@ Als je deze applicatie wilt gebruiken moet je:<br />
         De dienst die je probeert te benaderen (de &lsquo;Service Provider&rsquo;) is niet toegankelijk via de %suiteName%-infrastructuur.
     </p>',
     'error_session_lost'                => 'Error - Sessie is verloren gegaan',
-    'error_session_lost_desc'           => '<p>Voor deze actie heb je een actieve sessie nodig, maar deze kan niet gevonden worden.<br /><ul><li>Heb je te lang gewacht?</li><li>Sluit je browser en probeer opnieuw, of probeer een andere browser.</li></ul></p>',
+    'error_session_lost_desc'           => '<p>Voor deze actie heb je een actieve sessie nodig, maar deze kan niet gevonden worden. Heb je te lang gewacht? Sluit je browser en probeer opnieuw, of probeer een andere browser.</p>',
     'error_session_not_started'                => 'Error - Sessie is niet gevonden',
-    'error_session_not_started_desc'           => '<p>Voor deze actie heb je een actieve sessie nodig, alleen hebben we géén sessie-cookie ontvangen.<br /><ul><li>De browser moet cookies ondersteune.n</li><li>Gebruik geen bladwijzer of link<./li><li>Sluit je browser en probeer opnieuw, of probeer een andere browser.</li></ul></p>',
+    'error_session_not_started_desc'           => '<p>Voor deze actie heb je een actieve sessie nodig, alleen hebben we géén sessie-cookie ontvangen. De browser moet cookies ondersteunen. Gebruik geen bladwijzer of link. Sluit je browser en probeer opnieuw, of probeer een andere browser.</p>',
     'error_authorization_policy_violation'            => 'Error - Geen toegang',
     'error_authorization_policy_violation_desc'       => '<p>
         Je bent succesvol ingelogd bij jouw %organisationNoun%, maar je kunt geen gebruik maken van deze dienst omdat je geen toegang hebt. Voor deze dienst (de &lsquo;Service Provider&rsquo;) heeft jouw %organisationNoun% met <i>autorisatieregels</i> ingesteld dat alleen bepaalde gebruikers toegang krijgen. Neem contact op met de (IT-)servicedesk van je %organisationNoun% als je vindt dat je wel toegang moet hebben.

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -157,9 +157,9 @@ Se pretende utilizar esta aplicação devem:<br />
 O serviço (&lsquo;Service Provider&rsquo;) a que pretende ligar-se não está acessível através da %suiteName%.<br /><br />
     </p>',
     'error_session_lost'            => 'Erro - a sua sessão foi perdida',
-    'error_session_lost_desc'       => '<p>Esta ação requer uma sessão ativa, no entanto, não conseguimos encontrar a sessão.<br /><ul><li>Está a aguardar há muito tempo?</li><li>Feche o browser e tente novamente, ou tente um browser diferente.</li></ul></p>',
+    'error_session_lost_desc'       => '<p>Esta ação requer uma sessão ativa, no entanto, não conseguimos encontrar a sessão. Está a aguardar há muito tempo? Feche o browser e tente novamente, ou tente um browser diferente.</p>',
     'error_session_not_started'            => 'Erro - a sua sessão não foi encontrada',
-    'error_session_not_started_desc'       => '<p>Esta ação requer uma sessão ativa, no entanto, não recebemos nenhum cookie de sessão.<br /><ul><li>O browser deve aceitar cookies</li><li>Não utilize endereços do marcador ou link.</li><li>Feche o browser e tente novamente, ou tente um browser diferente.</li></ul></p>',
+    'error_session_not_started_desc'       => '<p>Esta ação requer uma sessão ativa, no entanto, não recebemos nenhum cookie de sessão. O browser deve aceitar cookies. Não utilize endereços do marcador ou link. Feche o browser e tente novamente, ou tente um browser diferente.</p>',
     'error_authorization_policy_violation'            => 'Erro - Sem acesso',
     'error_authorization_policy_violation_desc'       => '<p>
         Você autenticu-se com sucesso na sua %organisationNoun%, mas infelizmente você não pode utilizar este serviço (o &lsquo;Fornecedor de Serviço&rsquo;) porque não tem acesso. A sua %organisationNoun% limita o acesso a este serviço com uma <i>política de autorização</i>. Entre em contacto com o suporte da sua %organisationNoun% se acha que deve ser-lhe concedido acesso ao serviço.


### PR DESCRIPTION
The ul needed to be removed from the session exception message.