### PR TITLE
Implement visual regression tests for error pages

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -168,6 +168,20 @@
         </exec>
     </target>
 
+    <target name="js-visual-regression-tests">
+        <exec dir="${basedir}/theme" executable="node_modules/.bin/jest" failonerror="true">
+            <arg line="--runInBand" />
+            <arg line="material/javascripts/tests/visual-regression" />
+        </exec>
+    </target>
+
+    <target name="js-visual-regression-tests-update-snapshots">
+        <exec dir="${basedir}/theme" executable="node_modules/.bin/jest" failonerror="true">
+            <arg line="-u --runInBand" />
+            <arg line="material/javascripts/tests/visual-regression" />
+        </exec>
+    </target>
+
     <target name="api-functional-tests"
             description="Run functional tests with PHPUnit"
             depends="create-test-db">

--- a/docs/js_testing.md
+++ b/docs/js_testing.md
@@ -22,7 +22,7 @@ Running  `npm run jest` can also be used from the `theme` folder, this will run 
 
 Note that the `expect-puppeteer` package is used to perform more efficient interactions and assertions on the DOM. Expect-puppeteer states:
 
-> Writing integration test is very hard, especially when you are testing a Single Page Applications. Data are loaded asynchronously and it is difficult to know exactly when an element will be displayed in the page.
+> Writing integration test is very hard, especially when you are testing Single Page Applications. Data are loaded asynchronously and it is difficult to know exactly when an element will be displayed in the page.
   Puppeteer API is great, but it is low level and not designed for integration testing.
   
 More info about this package can be found at their [GitHub](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer)
@@ -51,3 +51,21 @@ parameters can be used to manipulate the behaviour of the wayf that is rendered.
 ## Acceptance tests
 The WAYF acceptance tests utilize the `/functional-testing/wayf` endpoint in order to test the correct inner working of
 the WAYF.
+
+## Visual regression tests
+While building the new error page styling, visual regression testing was utilized to take control over visual regressions. The `jest-image-snapshot` <sup>1</sup> package is used to perform these tests.
+
+Running them is as simple as:
+
+`$ ant js-visual-regression-tests`
+
+And to update the snapshots (should be performed after every controlled change):
+
+`$ ant js-visual-regression-tests-update-snapshots`
+
+Snapshots are stored in `__image_snapshots__` directories in a subfolder of the `theme/material/javascripts/tests/visual-regression/` directory, here you will also find diffs if ever your snapshot diverges from the previous snapshot.
+Additional, more user friendly, screenshots are saved respective `screenshots` directories.
+
+:warning: These tests are considered risky tests and are not run on every Travis build. 
+
+[1] https://github.com/americanexpress/jest-image-snapshot

--- a/theme/.gitignore
+++ b/theme/.gitignore
@@ -38,3 +38,5 @@ bower_components
 
 ### Test output
 material/javascripts/tests/smoke/screenshots
+material/javascripts/tests/visual-regression/error-page/screenshots
+material/javascripts/tests/visual-regression/error-page/__image_snapshots__

--- a/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
+++ b/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
@@ -1,4 +1,4 @@
-const timeout = 10000;
+const timeout = 15000;
 const {toMatchImageSnapshot} = require('jest-image-snapshot');
 
 // Extend Jest expect
@@ -101,28 +101,30 @@ const viewports = [
 ];
 
 describe(
-    'Error screens match the previous snapshots',
+    'Verify',
     () => {
         let page;
 
         beforeAll(async () => {
             page = await global.__BROWSER__.newPage();
-            jest.setTimeout(15000);
+            jest.setTimeout(20000);
         }, timeout);
 
         for (const errorPage of errorPages) {
-            it(`Verify ${errorPage.name} no visual regression occurred between test runs`, async () => {
-                await page.goto(errorPage.url);
-                for (const viewport of viewports) {
+            for (const viewport of viewports) {
+                it(`${errorPage.name}-${viewport.width}x${viewport.height}`, async () => {
+
+                    await page.goto(errorPage.url);
                     await page.setViewport(viewport);
                     await page.waitFor(".error-container");
-                    const screenshot = await page.screenshot({path: `./material/javascripts/tests/visual-regression/error-page/screenshots/error-page/${errorPage.name}-${viewport.width}x${viewport.height}.png`});
-                    expect(screenshot).toMatchImageSnapshot()
-                }
-            });
+                    const screenshot = await page.screenshot({
+                        fullPage: true,
+                        path: `./material/javascripts/tests/visual-regression/error-page/screenshots/error-page/${errorPage.name}-${viewport.width}x${viewport.height}.png`
+                    });
+                    expect(screenshot).toMatchImageSnapshot();
+                });
+            }
         }
-
-
     },
     timeout,
 );

--- a/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
+++ b/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
@@ -1,0 +1,128 @@
+const timeout = 10000;
+const {toMatchImageSnapshot} = require('jest-image-snapshot');
+
+// Extend Jest expect
+expect.extend({toMatchImageSnapshot});
+
+const errorPages = [
+    {
+        name: 'unable-to-receive-message',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unable-to-receive-message'
+    },
+    {
+        name: 'session-lost',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=session-lost'
+    },
+    {
+        name: 'session-not-started',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=session-not-started'
+    },
+    {
+        name: 'no-idps',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=no-idps'
+    },
+    {
+        name: 'invalid-acs-location',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=invalid-acs-location'
+    },
+    {
+        name: 'unsupported-acs-location-scheme',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unsupported-acs-location-scheme'
+    },
+    {
+        name: 'missing-required-fields',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=missing-required-fields'
+    },
+    {
+        name: 'invalid-acs-binding',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=invalid-acs-binding'
+    },
+    {
+        name: 'received-error-status-code',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=received-error-status-code'
+    },
+    {
+        name: 'received-invalid-signed-response',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=received-invalid-signed-response'
+    },
+    {
+        name: 'received-invalid-response',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=received-invalid-response'
+    },
+    {
+        name: 'no-consent',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=no-consent'
+    },
+    {
+        name: 'unknown-service',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unknown-service'
+    },
+    {
+        name: 'unknown-preselected-idp',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unknown-preselected-idp'
+    },
+    {
+        name: 'stuck-in-authentication-loop',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=stuck-in-authentication-loop'
+    },
+    {
+        name: 'clock-issue',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=clock-issue'
+    },
+    {
+        name: 'unknown-issuer',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unknown-issuer&feedback-info={"timestamp":"2019-04-18T19:21:06+02:00","requestId":"5cb4bd3879b49","userAgent":"Mozilla\/5.0 (X11; Ubuntu; Linux x86_64; rv:66.0) Gecko\/20100101 Firefox\/66.0","ipAddress":"192.168.66.98","artCode":"31914","EntityId":"https://serviceregistry.vm.openconext.org/simplesaml/module.php/saml/sp/metadata.php/default-sp","Destination":"https://serviceregistry.vm.openconext.org/simplesaml/module.php/saml/sp/metadata.php/destination"}'
+    },
+    {
+        name: 'unsupported-signature-method',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unsupported-signature-method&parameters={"signatureMethod":"http://www.w3.org/2000/09/xmldsig%23%0Arsa-sha1"}'
+    },
+    {
+        name: 'unknown-service-provider',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unknown-service-provider&parameters={"entityId":"https://serviceregistry.vm.openconext.org/simplesaml/module.php/saml/sp/metadata.php/default-sp"}'
+    },
+    {
+        name: 'invalid-attribute-value',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=invalid-attribute-value&parameters={"attributeName":"schacHomeOrganization","attributeValue":"openconext"}'
+    },
+    {
+        name: 'no-authentication-request-received',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=no-authentication-request-received&parameters={"message":"No SAMLRequest parameter was found in the HTTP POST request parameters"}'
+    },
+    {
+        name: 'authorization-policy-violation',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=authorization-policy-violation&parameters={"logo":{"height":"96","width":"96","url":"https://static.vm.openconext.org/media/conext_logo.png"},"policyDecisionMessage":"No localized deny messages present"}'
+    },
+];
+
+const viewports = [
+    {width: 375, height: 667},
+    {width: 1920, height: 1080},
+];
+
+describe(
+    'Error screens match the previous snapshots',
+    () => {
+        let page;
+
+        beforeAll(async () => {
+            page = await global.__BROWSER__.newPage();
+            jest.setTimeout(15000);
+        }, timeout);
+
+        for (const errorPage of errorPages) {
+            it(`Verify ${errorPage.name} no visual regression occurred between test runs`, async () => {
+                await page.goto(errorPage.url);
+                for (const viewport of viewports) {
+                    await page.setViewport(viewport);
+                    await page.waitFor(".error-container");
+                    const screenshot = await page.screenshot({path: `./material/javascripts/tests/visual-regression/error-page/screenshots/error-page/${errorPage.name}-${viewport.width}x${viewport.height}.png`});
+                    expect(screenshot).toMatchImageSnapshot()
+                }
+            });
+        }
+
+
+    },
+    timeout,
+);

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -6127,6 +6127,54 @@
         "walker": "^1.0.7"
       }
     },
+    "jest-image-snapshot": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/jest-image-snapshot/-/jest-image-snapshot-2.8.1.tgz",
+      "integrity": "sha512-/el/cknCo0pu7nopKg1Hu9PEaFNNIHIDpxxUGxYr/cYO7qSrIFAfUgRPDXGOJN2tqMu1tuwqaO+xlTWV86mjLw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "get-stdin": "^5.0.1",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "pixelmatch": "^4.0.2",
+        "pngjs": "^3.3.3",
+        "rimraf": "^2.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "jest-jasmine2": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.7.1.tgz",
@@ -8093,6 +8141,15 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "pixelmatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
+      "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
+      "dev": true,
+      "requires": {
+        "pngjs": "^3.0.0"
+      }
+    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -8157,6 +8214,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
+    },
+    "pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
       "dev": true
     },
     "popper.js": {

--- a/theme/package.json
+++ b/theme/package.json
@@ -35,6 +35,7 @@
     "core-js": "^2.6.5",
     "cssnano": "^4.1.10",
     "jest": "^24.7.1",
+    "jest-image-snapshot": "^2.8.1",
     "jshint": "^2.10.2",
     "node-sass": "^4.11.0",
     "postcss-cli": "^6.1.2",


### PR DESCRIPTION
Different error pages are visited and compared to previous snapshots
when a screenshot differs from a previous one, the test will fail. This
test should be run manually for now.

See task 3 of https://www.pivotaltracker.com/story/show/165593518