### PR TITLE
Add the possibility to sign a SAML response

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -237,6 +237,7 @@
             <arg line="-c ./tests/behat.yml"/>
             <arg line="--suite ${suite} -vv"/>
             <arg line="--format progress"/>
+            <arg line="--strict"/>
         </exec>
     </target>
 

--- a/database/DoctrineMigrations/Version20190425205743.php
+++ b/database/DoctrineMigrations/Version20190425205743.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190425205743 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD sign_response TINYINT(1) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP sign_response');
+    }
+}

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -583,8 +583,16 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
                     $assertion->setCertificates($sspMessage->getCertificates());
                     $assertion->setSignatureKey($sspMessage->getSignatureKey());
                 }
-                // BWC dictates that we don't sign responses.
-                $messageElement = $sspMessage->toUnsignedXML();
+
+                // According to saml2int 0.2, the assertion element must be directly signed, which we do.
+                // This suffices for most SP's. However, some SP's require the outer Response element to be signed directly.
+                // If configured to do so for that SP, Engineblock will sign the outer response element in addition to the signed Assertion element.
+                // It might make sense in the future to always sign both, if it has been shown that this causes no problems.
+                if ($remoteEntity instanceof ServiceProvider && $remoteEntity->signResponse) {
+                    $messageElement = $sspMessage->toSignedXML();
+                } else {
+                    $messageElement = $sspMessage->toUnsignedXML();
+                }
             }
             else {
                 $messageElement = $sspMessage->toSignedXML();

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -207,6 +207,14 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
             'requesteridRequired'
         );
 
+        $properties += $this->setPathFromObject(
+            array(
+                $connection,
+                'metadata:coin:sign_response'
+            ),
+            'signResponse'
+        );
+
         return Utils::instantiate(
             'OpenConext\EngineBlock\Metadata\Entity\ServiceProvider',
             $properties

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -108,6 +108,13 @@ class ServiceProvider extends AbstractRole
     public $requesteridRequired;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="sign_response", type="boolean")
+     */
+    public $signResponse;
+
+    /**
      * @var null|RequestedAttribute[]
      *
      * @ORM\Column(name="requested_attributes", type="array")
@@ -166,6 +173,7 @@ class ServiceProvider extends AbstractRole
      * @param bool $skipDenormalization
      * @param bool $policyEnforcementDecisionRequired
      * @param bool $requesteridRequired
+     * #param bool $signResponse
      * @param string $manipulation
      * @param AttributeReleasePolicy $attributeReleasePolicy
      * @param string|null $supportUrlEn
@@ -212,6 +220,7 @@ class ServiceProvider extends AbstractRole
         $skipDenormalization = false,
         $policyEnforcementDecisionRequired = false,
         $requesteridRequired = false,
+        $signResponse = false,
         $manipulation = '',
         AttributeReleasePolicy $attributeReleasePolicy = null,
         $supportUrlEn = null,
@@ -259,6 +268,7 @@ class ServiceProvider extends AbstractRole
         $this->skipDenormalization = $skipDenormalization;
         $this->policyEnforcementDecisionRequired = $policyEnforcementDecisionRequired;
         $this->requesteridRequired = $requesteridRequired;
+        $this->signResponse = $signResponse;
         $this->supportUrlEn = $supportUrlEn;
         $this->supportUrlNl = $supportUrlNl;
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
@@ -6,6 +6,7 @@ use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\MinkContext as BaseMinkContext;
 use DOMDocument;
 use DOMXPath;
+use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RuntimeException;
 
 /**
@@ -36,6 +37,7 @@ class MinkContext extends BaseMinkContext
         $document->loadXML($this->getSession()->getPage()->getContent());
 
         $xpathObj = new DOMXPath($document);
+        $xpathObj->registerNamespace('ds', XMLSecurityDSig::XMLDSIGNS);
         $nodeList = $xpathObj->query($xpath);
 
         if (!$nodeList || $nodeList->length === 0) {
@@ -53,6 +55,7 @@ class MinkContext extends BaseMinkContext
         $document->loadXML($this->getSession()->getPage()->getContent());
 
         $xpathObj = new DOMXPath($document);
+        $xpathObj->registerNamespace('ds', XMLSecurityDSig::XMLDSIGNS);
         $nodeList = $xpathObj->query($xpath);
 
         if ($nodeList && $nodeList->length > 0) {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -546,6 +546,32 @@ class MockSpContext extends AbstractSubContext
     }
 
     /**
+     * @Given /^SP "([^"]*)" requires a signed response$/
+     */
+    public function spRequiresASignedResponse($spName)
+    {
+        /** @var MockServiceProvider $mockSp */
+        $mockSp = $this->mockSpRegistry->get($spName);
+
+        $this->serviceRegistryFixture
+            ->setSpSignRepsones($mockSp->entityId())
+            ->save();
+    }
+
+    /**
+     * @Given /^SP "([^"]*)" does not require a signed response$/
+     */
+    public function spDoesNotRequireASignedResponse($spName)
+    {
+        /** @var MockServiceProvider $mockSp */
+        $mockSp = $this->mockSpRegistry->get($spName);
+
+        $this->serviceRegistryFixture
+            ->setSpSignRepsones($mockSp->entityId(), false)
+            ->save();
+    }
+
+    /**
      * @Given /^SP "([^"]*)" is configured to display unconnected IdPs in the WAYF$/
      * @param string $spName
      */

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Encryption.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Encryption.feature
@@ -83,3 +83,25 @@ Feature:
       And I give my consent
       And I pass through EngineBlock
      Then the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+
+  Scenario: EngineBlock supports not signed responses
+    Given the SP uses the HTTP POST Binding
+    And SP "Dummy SP" does not require a signed response
+    When I log in at "Dummy SP"
+    And I pass through the SP
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+    Then the response should not match xpath '//samlp:Response/ds:Signature/ds:SignedInfo/ds:SignatureMethod'
+
+  Scenario: EngineBlock supports signed responses
+    Given the SP uses the HTTP POST Binding
+    And SP "Dummy SP" requires a signed response
+    When I log in at "Dummy SP"
+    And I pass through the SP
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+    Then the response should match xpath '//samlp:Response/ds:Signature/ds:SignedInfo/ds:SignatureMethod'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -234,6 +234,13 @@ QUERY;
         return $this;
     }
 
+    public function setSpSignRepsones($entityId, $state = true)
+    {
+        $this->getServiceProvider($entityId)->signResponse = (bool)$state;
+
+        return $this;
+    }
+
     public function setSpEntityTrustedProxy($entityId)
     {
         $this->getServiceProvider($entityId)->isTrustedProxy = true;
@@ -290,6 +297,11 @@ QUERY;
         $this->getServiceProvider($entityId)->attributeReleasePolicy = new AttributeReleasePolicy($rules);
 
         return $this;
+    }
+
+    public function requireASignedResponse($entityId)
+    {
+        $this->getServiceProvider($entityId)->signResponse = true;
     }
 
     public function displayUnconnectedIdpsForSp($entityId, $displayUnconnected = true)


### PR DESCRIPTION
An option is needed to sign the saml response if the option
`metadata:coin:sign_response` is set. This because some sp's require
the saml response to be signed and not only the assertions.