### PR TITLE
Add visual tests for the feedback page footer

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/FeedbackController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/FeedbackController.php
@@ -57,8 +57,6 @@ class FeedbackController extends Controller
         $feedbackInfo = $this->getFeedbackInfo($request);
         $parameters = $this->getTemplateParameters($request);
 
-        $this->validateFooterTemplateParameters($parameters);
-
         $session = $request->getSession();
 
         $template = sprintf(
@@ -106,7 +104,6 @@ class FeedbackController extends Controller
         return $feedbackInfo;
     }
 
-
     /**
      * @param Request $request
      * @return mixed|string
@@ -122,21 +119,4 @@ class FeedbackController extends Controller
         return $parameters;
     }
 
-
-    /**
-     * @param array $parameters
-     * @return null|string
-     */
-    private function validateFooterTemplateParameters(array &$parameters)
-    {
-        $key = 'supportEmail';
-        if (!array_key_exists($key, $parameters)) {
-            $parameters[$key] = null;
-        }
-
-        $key = 'showWikiButton';
-        if (!array_key_exists($key, $parameters)) {
-            $parameters[$key] = false;
-        }
-    }
 }

--- a/theme/material/javascripts/tests/visual-regression/error-page/Footer.test.js
+++ b/theme/material/javascripts/tests/visual-regression/error-page/Footer.test.js
@@ -1,0 +1,58 @@
+const timeout = 15000;
+const {toMatchImageSnapshot} = require('jest-image-snapshot');
+
+// Extend Jest expect
+expect.extend({toMatchImageSnapshot});
+
+const footerDifferences = [
+    {
+        name: 'all-buttons-visible',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unable-to-receive-message&parameters={"supportEmail":"support@openconext.nl","showWikiButton":true}'
+    },
+    {
+        name: 'only-support-email-hidden',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unable-to-receive-message&parameters={"showWikiButton":true}'
+    },
+    {
+        name: 'only-wiki-hidden',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unable-to-receive-message&parameters={"supportEmail":"support@openconext.nl"}'
+    },
+    {
+        name: 'support-email-and-wiki-button-hidden',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=unable-to-receive-message&parameters={}'
+    },
+];
+
+const viewports = [
+    {width: 375, height: 667},
+    {width: 1920, height: 1080},
+];
+
+describe(
+    'Verify',
+    () => {
+        let page;
+
+        beforeAll(async () => {
+            page = await global.__BROWSER__.newPage();
+            jest.setTimeout(20000);
+        }, timeout);
+
+        for (const footer of footerDifferences) {
+            for (const viewport of viewports) {
+                it(`${footer.name}-${viewport.width}x${viewport.height}`, async () => {
+
+                    await page.goto(footer.url);
+                    await page.setViewport(viewport);
+                    await page.waitFor(".error-container");
+                    const screenshot = await page.screenshot({
+                        fullPage: true,
+                        path: `./material/javascripts/tests/visual-regression/error-page/screenshots/footer/${footer.name}-${viewport.width}x${viewport.height}.png`
+                    });
+                    expect(screenshot).toMatchImageSnapshot();
+                });
+            }
+        }
+    },
+    timeout,
+);


### PR DESCRIPTION
In order to detect regressions in the footer of the feedback page
some tests are added.