### PR TITLE
Fix npm installation consistency between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
 cache:
   directories:
     - ~/.composer/cache/files
+    - "$HOME/.npm"
 
 before_install:
   - mysql -e "create database IF NOT EXISTS eb_test;" -uroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_script:
   - composer config secure-http false
   - composer install --prefer-dist -n -o
   - app/console cache:clear --env=test
-  - npm install --prefix=theme
+  - npm ci --prefix=theme
   - cd theme && npm run build && cd ..
 
 script:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the [UPGRADING.md][upgrading] file
 Please see the [wiki][eb-wiki-theme-development] for information on how to get started with developing themes for OpenConext EngineBlock
 In short, themes require compilation which can be done by running the following commands:
 ```
-    (cd theme && npm install && npm run:build)
+    (cd theme && npm ci && npm run:build)
 ```
 
 To setup the required tooling on the VM, the following steps might be useful:
@@ -29,7 +29,7 @@ To setup the required tooling on the VM, the following steps might be useful:
     cd /opt/openconext/OpenConext-engineblock/theme
     sudo curl --silent --location https://rpm.nodesource.com/setup_11.x | sudo bash -
     sudo yum install nodejs
-    (npm install && npm run build)
+    (npm ci && npm run build)
 
 ## System Requirements
 

--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -53,7 +53,7 @@ php ./bin/composer.phar install -n --no-dev --prefer-dist -o &&
 
 echo "Build assets" &&
 cd ${PROJECT_DIR}/theme &&
-npm install &&
+npm ci &&
 npm run release &&
 
 echo "Tagging the release in RELEASE file" &&


### PR DESCRIPTION
Npm was not consistent between builds and changed the package-lock.json.
Therefore we are now using the 'ci' commmand.

https://docs.npmjs.com/cli/ci.html