### PR TITLE
Make uncaught error page reloadable

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -58,6 +58,14 @@ class FeedbackController
         );
     }
 
+    public function unknownErrorAction()
+    {
+        return new Response(
+            $this->twig->render('@theme/Default/View/Error/display.html.twig'),
+            500
+        );
+    }
+
     /**
      * @return Response
      * @throws \EngineBlock_Exception

--- a/src/OpenConext/EngineBlockBundle/Resources/config/event_listeners.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/event_listeners.yml
@@ -56,10 +56,9 @@ services:
     engineblock.listener.fallback_exception:
         class: OpenConext\EngineBlockBundle\EventListener\FallbackExceptionListener
         arguments:
-            - "@engineblock.compat.application"
-            - "@twig"
             - "@engineblock.compat.logger"
             - "@engineblock.bridge.error_reporter"
+            - "@router"
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: -200 }
 

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing.yml
@@ -28,7 +28,12 @@ certificate:
 
 feedback:
     resource: routing/feedback.yml
-    prefix:   '/authentication/feedback'
+    prefix: '/authentication/feedback'
+
+feedback_unknown_error:
+    path: /feedback/unknown-error
+    methods: [GET]
+    defaults: { _controller: engineblock.controller.authentication.feedback:unknownErrorAction }
 
 wayf:
     resource: routing/wayf.yml

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -299,6 +299,16 @@ Feature:
      And I give my consent
     Then I should see "Error - The Assertion is not yet valid or has expired"
      And I should see ART code "44601"
+
+  Scenario: I encounter an unexpected error, and can reload the error feedback page
+   Given EngineBlock raises an unexpected error
+    When I log in at "Dummy SP"
+    Then I should see "Error - An error occurred"
+     And I should see "Your log-in has failed and we don't know exactly why."
+     And I write down the request id as seen on the error page
+     And I reload the page
+    Then I should see the same request id on the error page
+
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a location
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a binding
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying an invalid index

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -309,6 +309,18 @@ Feature:
      And I reload the page
     Then I should see the same request id on the error page
 
+  Scenario: I encounter an unexpected error, and see the same message after losing my session
+   Given EngineBlock raises an unexpected error
+    When I log in at "Dummy SP"
+    Then I should see "Error - An error occurred"
+     And I should see "Your log-in has failed and we don't know exactly why."
+     And I write down the request id as seen on the error page
+     And I lose my session and reload
+     And I should see "Error - An error occurred"
+      # The session is lost, so the feedback information (containing the request id) can no longer be rendered on page
+    Then I should not see the same request id on the error page
+
+
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a location
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a binding
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying an invalid index

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -385,6 +385,18 @@ HTML;
         // set unknown session id to prevent session not found exception
         $session->setCookie(session_name(), '000000');
     }
+    /**
+     * @Given /^I lose my session and reload$/
+     */
+    public function iLoseMySessionAndReload()
+    {
+        $session = $this->getMinkContext()->getSession();
+        $currentUrl = $session->getCurrentUrl();
+        $session->restart();
+        // set unknown session id to prevent session not found exception
+        $session->setCookie(session_name(), '000000');
+        $session->visit($currentUrl);
+    }
 
     /**
      * @Given /^pdp gives a deny response$/
@@ -645,6 +657,20 @@ HTML;
             );
         }
         return;
+    }
+    /**
+     * @Then /^I should not see the same request id on the error page$/
+     */
+    public function iShouldNotSeeTheSameRequestId()
+    {
+        try {
+            // Not being able to find the request id yields a runtime exception
+            $this->getRequestIdFromFeedbackInformation();
+        } catch (RuntimeException $e) {
+            return;
+        }
+
+        throw new RuntimeException('The request was found on the page, and we expected it not to be.');
     }
 
     /**

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
@@ -68,3 +68,7 @@ services:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore
         arguments: ['%engineblock.functional_testing.attribute_aggregation_data_store.file%']
     #endregion Data Stores
+
+    # test stand ins
+    engineblock.validator.sso_request_validator:
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Validator\SsoRequestValidator

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Validator/SsoRequestValidator.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Validator/SsoRequestValidator.php
@@ -27,10 +27,10 @@ class SsoRequestValidator extends BaseSsoRequestValidator
     public function isValid(Request $request)
     {
         // This service is overloaded in order to allow us to throw a custom exception from behat
-        if (isset($_COOKIE['throwException'])) {
+        if ($request->cookies->has('throwException')) {
             // Remove the cookie to prevent side effects in the next requests
             setcookie("throwException", "", time()-3600);
-            throw new RuntimeException($_COOKIE['throwException']);
+            throw new RuntimeException($request->cookies->get('throwException'));
         }
         parent::isValid($request);
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Validator/SsoRequestValidator.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Validator/SsoRequestValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Validator;
+
+use OpenConext\EngineBlock\Validator\SsoRequestValidator as BaseSsoRequestValidator;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
+
+class SsoRequestValidator extends BaseSsoRequestValidator
+{
+    public function isValid(Request $request)
+    {
+        // This service is overloaded in order to allow us to throw a custom exception from behat
+        if (isset($_COOKIE['throwException'])) {
+            // Remove the cookie to prevent side effects in the next requests
+            setcookie("throwException", "", time()-3600);
+            throw new RuntimeException($_COOKIE['throwException']);
+        }
+        parent::isValid($request);
+    }
+}

--- a/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
+++ b/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
@@ -93,6 +93,10 @@ const errorPages = [
         name: 'authorization-policy-violation',
         url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=authorization-policy-violation&feedback-info={"requestId":"5cb4bd3879b49","artCode":"31914", "ipAddress":"192.168.66.98","serviceProvider":"https://current-sp.entity-id.org/metadata","serviceProviderName":"OpenConext Drop Supplies SP","identityProvider":"https://current-idp.entity-id.org/metadata"}&parameters={"logo":{"height":"96","width":"96","url":"https://static.vm.openconext.org/media/conext_logo.png"},"policyDecisionMessage":"No localized deny messages present"}'
     },
+    {
+        name: 'uncaught-error',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=feedback_unknown_error&feedback-info={"requestId":"5cb4bd3879b49","artCode":"31914", "ipAddress":"192.168.66.98","serviceProvider":"https://current-sp.entity-id.org/metadata","serviceProviderName":"OpenConext Drop Supplies SP","identityProvider":"https://current-idp.entity-id.org/metadata"}'
+    }
 ];
 
 const viewports = [


### PR DESCRIPTION
That was previously also possible (but might have leaded to a new error condition), and resulted in a new unique request id, timestamp combination upon reload. Making it very hard for service desk to match the request id with the actual error message in logs.

This is resolved by redirecting to the feedback controller. On this controller a new action handles the 'unknown error'.

This action is intentionally not accessible on the authentication/feedback base route. This because the unknown error might not be authentication related.

See: https://www.pivotaltracker.com/story/show/164076480