### PR TITLE
Whitelist debugSingleSignOnService for session

### DIFF
--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -46,11 +46,12 @@ class EngineBlock_Corto_ProxyServer
     );
 
     protected $_servicesNotNeedingSession = array(
-        'singleSignOnService',
-        'unsolicitedSingleSignOnService',
-        'singleLogoutService',
+        'debugSingleSignOnService',
         'idpMetadataService',
+        'singleLogoutService',
+        'singleSignOnService',
         'spMetadataService',
+        'unsolicitedSingleSignOnService',
     );
 
     protected $_headers = array();

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -46,8 +46,12 @@ class EngineBlock_Corto_ProxyServer
     );
 
     protected $_servicesNotNeedingSession = array(
+        'edugainMetadataService',
         'debugSingleSignOnService',
+        'idpCertificateService',
+        'idpCertificateService',
         'idpMetadataService',
+        'idpsMetadataService',
         'singleLogoutService',
         'singleSignOnService',
         'spMetadataService',


### PR DESCRIPTION
The debugSingleSignOnService was only added to the configuration
array in the corto proxyserver on master but not in the 5.10 release
branch while this was needed. This was done in order to prevent it from
checking if the session did already start.