### PR TITLE
Remove validation on unsolicitedSingleSignOnAction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ branches:
   only:
     - 5.x-dev
     - master
-    - release/5.8
+    - release/5.10
     - feature/allow-repost-on-consent
 
 after_failure:

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -126,9 +126,6 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
      */
     public function unsolicitedSingleSignOnAction(Request $request, $keyId = null, $idpHash = null)
     {
-        $this->requestValidator->isValid($request);
-        $this->bindingValidator->isValid($request);
-
         $cortoAdapter = new EngineBlock_Corto_Adapter();
 
         if ($keyId !== null) {


### PR DESCRIPTION
The validations are solicited SSO specific. Adding them on the unsolicited SSO endpoint blocks the unsolicited sso attempts.

Removing them for now is the best option right now, adding an additional request validator for unsolicited single sign on is requested in this ticket: https://www.pivotaltracker.com/story/show/165821300

Also see: https://www.pivotaltracker.com/story/show/164121560/comments/202263683

:warning: Cherry pick this on master!