### PR TITLE
Remove unused SSO routes

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/identity_provider.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/identity_provider.yml
@@ -59,7 +59,7 @@ authentication_idp_sso_idphash:
 
 authentication_idp_unsolicited_sso:
     path:     '/authentication/idp/unsolicited-single-sign-on'
-    methods:  [GET,POST]
+    methods:  [GET]
     defaults:
         _controller: engineblock.controller.authentication.identity_provider:unsolicitedSingleSignOnAction
         idpHash: ~
@@ -67,7 +67,7 @@ authentication_idp_unsolicited_sso:
 
 authentication_idp_unsolicited_sso_keyid:
     path:     '/authentication/idp/unsolicited-single-sign-on/key:{keyId}'
-    methods:  [GET,POST]
+    methods:  [GET]
     defaults:
         _controller: engineblock.controller.authentication.identity_provider:unsolicitedSingleSignOnAction
         idpHash: ~
@@ -76,7 +76,7 @@ authentication_idp_unsolicited_sso_keyid:
 
 authentication_idp_unsolicited_sso_keyid_idphash:
     path:     '/authentication/idp/unsolicited-single-sign-on/key:{keyId}/{idpHash}'
-    methods:  [GET,POST]
+    methods:  [GET]
     defaults:
         _controller: engineblock.controller.authentication.identity_provider:unsolicitedSingleSignOnAction
     requirements:
@@ -85,7 +85,7 @@ authentication_idp_unsolicited_sso_keyid_idphash:
 
 authentication_idp_unsolicited_sso_idphash:
     path:     '/authentication/idp/unsolicited-single-sign-on/{idpHash}'
-    methods:  [GET,POST]
+    methods:  [GET]
     defaults:
         _controller: engineblock.controller.authentication.identity_provider:unsolicitedSingleSignOnAction
         keyId: ~


### PR DESCRIPTION
The {idpHash}/key:{keyId}' solicited and unsolicited routes have been removed. These routes are not supported by EngineBlock.

See: https://www.pivotaltracker.com/story/show/164924925

:warning: Also cherry-pick the commit(s) from this branch on `master`