### PR TITLE
Enrich unsolicited SSO test coverage

### DIFF
--- a/src/OpenConext/EngineBlock/Validator/UnsolicitedSsoRequestValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/UnsolicitedSsoRequestValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Validator;
+
+use OpenConext\EngineBlock\Exception\RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Valid requests method / query parameter combinations for IdP initiated SSO (unsolicited SSO) are:
+ *
+ *  | Request method | Parameter name  |
+ *  | -------------- | --------------- |
+ *  | GET            | sp-entity-id    |
+ */
+class UnsolicitedSsoRequestValidator implements RequestValidator
+{
+    private $supportedRequestMethods = [Request::METHOD_GET];
+
+    public function isValid(Request $request)
+    {
+        $requestMethod = $request->getMethod();
+        // Defense in depth; anything other than GET is probably already rejected at routing time.
+        if (!in_array($requestMethod, $this->supportedRequestMethods)) {
+            throw new RuntimeException(
+                sprintf(
+                    'The HTTP request method "%s" is not supported on the IdP initiated SSO endpoint',
+                    $requestMethod
+                )
+            );
+        }
+
+        if (!$request->query->has('sp-entity-id')) {
+            throw new RuntimeException(
+                sprintf('The query parameter "sp-entity-id" is missing on the IdP initiated SSO request')
+            );
+        }
+
+        return true;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -67,6 +67,11 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
     /**
      * @var RequestValidator
      */
+    private $unsolicitedRequestValidator;
+
+    /**
+     * @var RequestValidator
+     */
     private $bindingValidator;
 
     public function __construct(
@@ -76,6 +81,7 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
         RequestAccessMailer $requestAccessMailer,
         RequestValidator $requestValidator,
         RequestValidator $bindingValidator,
+        RequestValidator $unsolicitedRequestValidator,
         AuthenticationStateHelperInterface $authenticationStateHelper
     ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
@@ -84,6 +90,7 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
         $this->requestAccessMailer = $requestAccessMailer;
         $this->requestValidator = $requestValidator;
         $this->bindingValidator = $bindingValidator;
+        $this->unsolicitedRequestValidator = $unsolicitedRequestValidator;
         $this->authenticationStateHelper = $authenticationStateHelper;
     }
 
@@ -126,6 +133,8 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
      */
     public function unsolicitedSingleSignOnAction(Request $request, $keyId = null, $idpHash = null)
     {
+        $this->unsolicitedRequestValidator->isValid($request);
+
         $cortoAdapter = new EngineBlock_Corto_Adapter();
 
         if ($keyId !== null) {

--- a/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
@@ -16,6 +16,7 @@ services:
             - "@engineblock.service.request_access_mailer"
             - "@engineblock.validator.sso_request_validator"
             - "@engineblock.validator.saml_binding_validator"
+            - "@engineblock.validator.unsolicited_sso_request_validator"
             - "@engineblock.service.authentication_state_helper"
 
     engineblock.controller.authentication.index:

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -161,6 +161,9 @@ services:
     engineblock.validator.sso_request_validator:
         class: OpenConext\EngineBlock\Validator\SsoRequestValidator
 
+    engineblock.validator.unsolicited_sso_request_validator:
+        class: OpenConext\EngineBlock\Validator\UnsolicitedSsoRequestValidator
+
     engineblock.twig.extension.debug:
         class: OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Debug
         tags:

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -238,6 +238,34 @@ HTML;
     }
 
     /**
+     * @Given /^An IdP initiated Single Sign on for SP "([^"]*)" is triggered by IdP "([^"]*)" and specifies a valid signing key$/
+     */
+    public function anIdpInitiatedSingleSignOnForSpIsTriggeredByIdPWithSigningKey($spName, $idpName)
+    {
+        $mockSp = $this->mockSpRegistry->get($spName);
+        $mockIdP = $this->mockIdpRegistry->get($idpName);
+
+        $mink = $this->getMinkContext();
+        $mink->visit(
+            $this->engineBlock->unsolicitedLocation($mockIdP->entityId(), $mockSp->entityId(), 'default')
+        );
+    }
+
+    /**
+     * @Given /^An IdP initiated Single Sign on for SP "([^"]*)" is triggered by IdP "([^"]*)" and specifies an invalid signing key$/
+     */
+    public function anIdpInitiatedSingleSignOnForSpIsTriggeredByIdPWithInvalidSigningKey($spName, $idpName)
+    {
+        $mockSp = $this->mockSpRegistry->get($spName);
+        $mockIdP = $this->mockIdpRegistry->get($idpName);
+
+        $mink = $this->getMinkContext();
+        $mink->visit(
+            $this->engineBlock->unsolicitedLocation($mockIdP->entityId(), $mockSp->entityId(), 'does-not-exist')
+        );
+    }
+
+    /**
      * @Given /^An IdP initiated Single Sign on for SP "([^"]*)" is incorrectly triggered by IdP "([^"]*)"$/
      */
     public function anIdpInitiatedSingleSignOnForSpIsIncorrectlyTriggeredByIdP($spName, $idpName)
@@ -248,6 +276,20 @@ HTML;
         $mink = $this->getMinkContext();
         $mink->visit(
             $this->engineBlock->unsolicitedLocation($mockIdP->entityId() . 'I made a booboo', $mockSp->entityId())
+        );
+    }
+
+    /**
+     * @Given /^An IdP initiated Single Sign on for SP "([^"]*)" with invalid parameter, by IdP "([^"]*)"$/
+     */
+    public function anIdpInitiatedSingleSignOnForSpIsInvalidParameterByIdP($spName, $idpName)
+    {
+        $mockSp = $this->mockSpRegistry->get($spName);
+        $mockIdP = $this->mockIdpRegistry->get($idpName);
+
+        $mink = $this->getMinkContext();
+        $mink->visit(
+            $this->engineBlock->unsolicitedLocationInvalidParam($mockIdP->entityId(), $mockSp->entityId())
         );
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/UnsolicitedSingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/UnsolicitedSingleSignOn.feature
@@ -18,6 +18,24 @@ Feature:
       And I pass through EngineBlock
      Then the url should match "functional-testing/Dummy%20SP/acs"
 
+  Scenario: An IdP initiates a login with a valid signing key
+    When An IdP initiated Single Sign on for SP "Dummy SP" is triggered by IdP "Dummy IdP" and specifies a valid signing key
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/Dummy%20SP/acs"
+
+  # Should result in a generic 500 error, the logs specify the problem in greater detail.
+  Scenario: An IdP initiates a login with an SP identity id query parameter
+    When An IdP initiated Single Sign on for SP "Dummy SP" with invalid parameter, by IdP "Dummy IdP"
+    Then I should see "OpenConext - Error - An error occurred"
+
   Scenario: An IdP initiates a login with an invalid hash
      When An IdP initiated Single Sign on for SP "Dummy SP" is incorrectly triggered by IdP "Dummy IdP"
      Then the url should match "authentication/feedback/unknown-preselected-idp"
+
+  # Trying to use a non existent key results in a generic 500 error, this is known, correct behavior
+  Scenario: An IdP initiates a login with an invalid signing key
+    When An IdP initiated Single Sign on for SP "Dummy SP" is triggered by IdP "Dummy IdP" and specifies an invalid signing key
+    Then I should see "OpenConext - Error - An error occurred"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Service/EngineBlock.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Service/EngineBlock.php
@@ -45,12 +45,22 @@ class EngineBlock
         return $this->baseUrl . self::SINGLE_SIGN_ON_PATH;
     }
 
-    public function unsolicitedLocation($identityProviderEntityId, $serviceProviderEntityId)
+    public function unsolicitedLocation($identityProviderEntityId, $serviceProviderEntityId, $keyId = false)
+    {
+        $keyParameter = '';
+        if ($keyId) {
+            $keyParameter = sprintf('key:%s/', $keyId);
+        }
+        return $this->baseUrl
+               . sprintf(self::UNSOLICITED_SSO_START_PATH, $keyParameter . md5($identityProviderEntityId))
+               . '?sp-entity-id=' . urlencode($serviceProviderEntityId);
+    }
+
+    public function unsolicitedLocationInvalidParam($identityProviderEntityId, $serviceProviderEntityId)
     {
         return $this->baseUrl
                . sprintf(self::UNSOLICITED_SSO_START_PATH, md5($identityProviderEntityId))
-               . '?sp-entity-id=' . urlencode($serviceProviderEntityId)
-               . '&SAMLRequest=test';
+               . '?wrong-parameter=' . urlencode($serviceProviderEntityId);
     }
 
     public function spEntityId()

--- a/tests/unit/OpenConext/EngineBlock/Validator/UnsolicitedSsoRequestValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/UnsolicitedSsoRequestValidatorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace OpenConext\EngineBlock\Validator;
+
+use OpenConext\EngineBlock\Exception\MissingParameterException;
+use OpenConext\EngineBlock\Exception\RuntimeException;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class UnsolicitedSsoRequestValidatorTest extends TestCase
+{
+    /**
+     * @var UnsolicitedSsoRequestValidator
+     */
+    private $validator;
+
+    public function setUp()
+    {
+        $this->validator = new UnsolicitedSsoRequestValidator();
+
+        // PHPunit does not reset the superglobals on each run.
+        $_GET = [];
+        $_POST = [];
+        $_SERVER = [];
+    }
+
+    public function test_happy_flow_get()
+    {
+        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET['sp-entity-id'] = 'http://mock-sp';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->assertTrue($this->validator->isValid($request));
+    }
+
+    public function test_post_is_not_allowed()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The HTTP request method "POST" is not supported on the IdP initiated SSO endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+
+    public function test_put_binding_is_not_supported()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The HTTP request method "PUT" is not supported on the IdP initiated SSO endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+
+    public function test_malformed_argument()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The query parameter "sp-entity-id" is missing on the IdP initiated SSO request');
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET['sp-identity-id'] = 'http://mock-sp';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+
+    public function test_missing_argument()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The query parameter "sp-entity-id" is missing on the IdP initiated SSO request');
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
+    }
+}


### PR DESCRIPTION
Three tests where added:
1. Verify that specifying a signing key id works correctly
2. Ensure passing a non existent signing key results in the expected
   error
3. Triggering an unsolicited SSO authentication with incorrect/missing
   query parameters trigger the expected error.

Resolves task 2 of https://www.pivotaltracker.com/story/show/165821300

:warning: include this in release 5.11, so also merge to `master`