### PR TITLE
Improve feedback information word wrapping

### DIFF
--- a/theme/material/stylesheets/error-page/modules/_feedback-info.sass
+++ b/theme/material/stylesheets/error-page/modules/_feedback-info.sass
@@ -1,10 +1,8 @@
 .feedback-info
   background: $light-grey
   border-radius: 2px
-  overflow: hidden
+  overflow-wrap: anywhere
   padding: 0.5em
-  text-overflow: ellipsis
-  white-space: nowrap
 
   +max-width($small)
     float: none


### PR DESCRIPTION
By using overflow-wrap with the anywhere option, we should be able to display longer strings in the feedback blocks without losing any text to an overflow hidden option.

Overflow wrap instructs the render engine to find a way to break the string wherever it sees fitting. This might result in grammatically incorrect word-breaks. But this would be virtually impossible to do correctly in the context of an entity id. The ability to read the entire string (which was not possible with the previous text-overflow: ellipsis solution) is a requirement for the support team to be able to find possible problems with the entity ids. 

See task 7 from: https://www.pivotaltracker.com/story/show/166437858