### PR TITLE
Move the SURFboard to the left on smaller than large viewports

### DIFF
--- a/theme/material/stylesheets/theme/openconext/error-page/_background.sass
+++ b/theme/material/stylesheets/theme/openconext/error-page/_background.sass
@@ -17,6 +17,9 @@
     position: absolute
     height: 100%
     width: 100%
+    z-index: 1
+    +max-width($large)
+      left: -8%
 
   &__back
     background: url(/images/background-back.svg) left bottom repeat-x
@@ -25,3 +28,4 @@
     position: absolute
     height: 200px
     width: 100%
+    z-index: 0


### PR DESCRIPTION
When the viewport is smaller than large (1024px), then the surfboard is moved to a position of '-8% left' of the viewport boundary. This makes sure the image is well readable when the viewport size is smaller.

The SVG itself (not tracked in this repo) is updated, the sign is moved to the left of the surfboard.

See point 1 of https://www.pivotaltracker.com/story/show/166437858