### PR TITLE
Add margin to the error feedback block

### DIFF
--- a/theme/material/stylesheets/error-page/modules/_error-details.sass
+++ b/theme/material/stylesheets/error-page/modules/_error-details.sass
@@ -9,6 +9,7 @@
         display: block
   &__feedback-list
     width: 100%
+    margin: 1.5em 0 1.5em 0
     +min-width($small + 1)
       display: grid
       grid-auto-flow: row dense


### PR DESCRIPTION
The top and bottom margin is set to 1.5em. This visually improves the error feedback block.

Solves point 3 of https://www.pivotaltracker.com/story/show/166437858