### PR TITLE
Vertical align the error continer

### DIFF
--- a/theme/material/stylesheets/error-page/base/_page.css.sass
+++ b/theme/material/stylesheets/error-page/base/_page.css.sass
@@ -7,6 +7,9 @@ body
     background: $light-grey
 
 .l-container
+  position: relative
+  height: 100%
+
   +max-width($small)
     padding: 1em
 

--- a/theme/material/stylesheets/error-page/modules/_error-container.sass
+++ b/theme/material/stylesheets/error-page/modules/_error-container.sass
@@ -1,12 +1,18 @@
 .error-container
-  margin: 0 auto
-  position: relative
-  top: 8em
+  left: 50%
+  margin: 0
+  position: absolute
+  top: 50%
+  transform: translate(-50%, -50%)
   width: 720px
   +max-width($small)
     top: 2.75em
     width: 100%
     margin-bottom: 3em
+    transform: none
+    position: relative
+    margin: 0 auto
+    left: unset
 
   &__content
     padding: 2em


### PR DESCRIPTION
The container is now positioned in the exact middle of the page for viewports greater than small.

There are multiple ways to vertical align a container. This one seems to fit the current HTML structure very well.

This fixes point 10 of https://www.pivotaltracker.com/story/show/166437858