### PR TITLE
Run node with the unsafe-perm option

### DIFF
--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -51,9 +51,11 @@ git checkout ${TAG} &&
 echo "Running Composer Install" &&
 php ./bin/composer.phar install -n --no-dev --prefer-dist -o &&
 
+# --unsafe-perm because we do branch install as root.
+# can be removed when we stop doing that
 echo "Build assets" &&
 cd ${PROJECT_DIR}/theme &&
-npm ci &&
+npm ci --unsafe-perm &&
 npm run release &&
 
 echo "Tagging the release in RELEASE file" &&


### PR DESCRIPTION
When deploying a development branch of EB to our test environment, we do this as root (hysterical raisins). We run `bin/makeRelease.sh` as root after checking out the branch to build the assets.

This fails because NPM thinks this is unsafe and runs installation as user `nobody` in that case. Which has permission problems because that user cannot write to the checked out tree.

The flag `--unsafe-perm` option tells npm not to do this.

This is acceptable I think because it only has effect if you are running `bin/makeRelease.sh` as root. So it does not make normal developer use, or anyone that runs it as non-root, more unsafe. And if you do run bin/makeRelease.sh as root you're already exposed to plenty of risks from other tools (hence we only do this on test).

The longer term solution is to stop installing stuff as root. We can then drop this again (and should add a guard at the start of makeRelease that you must not run it as root).