### PR TITLE
Persist coin data serialized for better rolling update support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,8 @@ branches:
   only:
     - master
     - feature/sfo
+    - /^feature\/serialize-coins.*$/
+    - feature/error-page-styling
 
 after_failure:
   - sudo tail -500 /var/log/apache2/error.log

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -87,6 +87,7 @@ doctrine:
         types:
             engineblock_collab_person_id: OpenConext\EngineBlockBundle\Doctrine\Type\CollabPersonIdType
             engineblock_collab_person_uuid: OpenConext\EngineBlockBundle\Doctrine\Type\CollabPersonUuidType
+            engineblock_metadata_coins: OpenConext\EngineBlockBundle\Doctrine\Type\MetadataCoinType
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
         proxy_dir: '%kernel.cache_dir%/doctrine/orm/Proxies'

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     },
     "require": {
         "php": ">=5.6,<7",
+        "ext-json": "*",
         "ext-mbstring": "*",
         "beberlei/assert": "^2.6",
         "doctrine/doctrine-bundle": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "350a860ca2e1e7fc3187a62a13b0baa0",
+    "content-hash": "c16949605a9251ebc612ab0b0b99b4d1",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -5174,6 +5174,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
         {
@@ -5840,6 +5841,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.6,<7",
+        "ext-json": "*",
         "ext-mbstring": "*"
     },
     "platform-dev": [],

--- a/database/DoctrineMigrations/Version20190703235333.php
+++ b/database/DoctrineMigrations/Version20190703235333.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190703235333 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD coins LONGTEXT NOT NULL COMMENT \'(DC2Type:engineblock_metadata_coins)\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP coins');
+    }
+}

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -140,7 +140,7 @@ class EngineBlock_Corto_Adapter
         $serviceProvider = $repository->fetchServiceProviderByEntityId($request->getIssuer());
 
         if (!$serviceProvider->allowAll) {
-            if ($serviceProvider->displayUnconnectedIdpsWayf) {
+            if ($serviceProvider->getCoins()->displayUnconnectedIdpsWayf()) {
                 $repository->appendVisitor(
                     new DisableDisallowedEntitiesInWayfVisitor($serviceProvider->allowedIdpEntityIds)
                 );

--- a/library/EngineBlock/Corto/Filter/Command/AddGuestStatus.php
+++ b/library/EngineBlock/Corto/Filter/Command/AddGuestStatus.php
@@ -33,18 +33,18 @@ class EngineBlock_Corto_Filter_Command_AddGuestStatus extends EngineBlock_Corto_
      */
     protected function _addIsMemberOfSurfNlAttribute()
     {
-        if ($this->_identityProvider->guestQualifier === IdentityProvider::GUEST_QUALIFIER_ALL) {
+        if ($this->_identityProvider->getCoins()->guestQualifier() === IdentityProvider::GUEST_QUALIFIER_ALL) {
             // All users from this IdP are guests, so no need to add the isMemberOf
             return;
         }
 
-        if ($this->_identityProvider->guestQualifier === IdentityProvider::GUEST_QUALIFIER_NONE) {
+        if ($this->_identityProvider->getCoins()->guestQualifier() === IdentityProvider::GUEST_QUALIFIER_NONE) {
             $this->_setIsMember();
             return;
         }
 
         $log = EngineBlock_ApplicationSingleton::getLog();
-        if ($this->_identityProvider->guestQualifier === IdentityProvider::GUEST_QUALIFIER_SOME) {
+        if ($this->_identityProvider->getCoins()->guestQualifier() === IdentityProvider::GUEST_QUALIFIER_SOME) {
             if (isset($this->_responseAttributes[static::URN_SURF_PERSON_AFFILIATION][0])) {
                 if ($this->_responseAttributes[static::URN_SURF_PERSON_AFFILIATION][0] === 'member') {
                     $this->_setIsMember();

--- a/library/EngineBlock/Corto/Filter/Command/DenormalizeAttributes.php
+++ b/library/EngineBlock/Corto/Filter/Command/DenormalizeAttributes.php
@@ -13,7 +13,7 @@ class EngineBlock_Corto_Filter_Command_DenormalizeAttributes extends EngineBlock
 
     public function execute()
     {
-        if ($this->_serviceProvider->skipDenormalization) {
+        if ($this->_serviceProvider->getCoins()->skipDenormalization()) {
             return;
         }
 

--- a/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
+++ b/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
@@ -18,7 +18,7 @@ class EngineBlock_Corto_Filter_Command_EnforcePolicy extends EngineBlock_Corto_F
             $serviceProvider = $this->_serviceProvider;
         }
 
-        if (!$serviceProvider->policyEnforcementDecisionRequired) {
+        if (!$serviceProvider->getCoins()->policyEnforcementDecisionRequired()) {
             return;
         }
 

--- a/library/EngineBlock/Corto/Filter/Command/ValidateRequiredAttributes.php
+++ b/library/EngineBlock/Corto/Filter/Command/ValidateRequiredAttributes.php
@@ -20,9 +20,9 @@ class EngineBlock_Corto_Filter_Command_ValidateRequiredAttributes extends Engine
     {
         // ServiceRegistry override of SchacHomeOrganization, set it and skip validation
         $excluded = array();
-        if ($this->_identityProvider->schacHomeOrganization) {
+        if ($this->_identityProvider->getCoins()->schacHomeOrganization()) {
             $this->_responseAttributes[self::URN_MACE_TERENA_SCHACHOMEORG] = array(
-                $this->_identityProvider->schacHomeOrganization
+                $this->_identityProvider->getCoins()->schacHomeOrganization()
             );
             $excluded[] = static::URN_MACE_TERENA_SCHACHOMEORG;
         }

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -568,7 +568,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             $sspMessage->setCertificates(array($keyPair->getCertificate()->toPem()));
             $sspMessage->setSignatureKey(
                 $keyPair->getPrivateKey()->toXmlSecurityKey(
-                    $remoteEntity->signatureMethod
+                    $remoteEntity->getCoins()->signatureMethod()
                 )
             );
         }

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -588,7 +588,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
                 // This suffices for most SP's. However, some SP's require the outer Response element to be signed directly.
                 // If configured to do so for that SP, Engineblock will sign the outer response element in addition to the signed Assertion element.
                 // It might make sense in the future to always sign both, if it has been shown that this causes no problems.
-                if ($remoteEntity instanceof ServiceProvider && $remoteEntity->signResponse) {
+                if ($remoteEntity instanceof ServiceProvider && $remoteEntity->getCoins()->signResponse()) {
                     $messageElement = $sspMessage->toSignedXML();
                 } else {
                     $messageElement = $sspMessage->toUnsignedXML();

--- a/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
+++ b/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
@@ -42,7 +42,7 @@ class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Mo
                 continue;
             }
 
-            if ($entity->hidden) {
+            if ($entity->coins()->hidden()) {
                 continue;
             }
 

--- a/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
+++ b/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
@@ -42,7 +42,7 @@ class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Mo
                 continue;
             }
 
-            if ($entity->coins()->hidden()) {
+            if ($entity->getCoins()->hidden()) {
                 continue;
             }
 

--- a/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
@@ -203,7 +203,7 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
     private function isConsentDisabled(array $serviceProviders, IdentityProvider $identityProvider)
     {
         foreach ($serviceProviders as $serviceProvider) {
-            if (!$serviceProvider->isConsentRequired) {
+            if (!$serviceProvider->getCoins()->isConsentRequired()) {
                 return true;
             }
 

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -420,7 +420,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
                 continue;
             }
 
-            if ($identityProvider->hidden) {
+            if ($identityProvider->getCoins()->hidden()) {
                 continue;
             }
 

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -27,7 +27,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
 
         // When dealing with an SP that acts as a trusted proxy, we should perform SSO on the proxying SP and not the
         // proxy itself.
-        if ($sp->isTrustedProxy) {
+        if ($sp->getCoins()->isTrustedProxy()) {
             // Overwrite the trusted proxy SP instance with that of the SP that uses the trusted proxy.
             $sp = $this->findOriginalServiceProvider($request, $log);
         }
@@ -367,7 +367,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
                 'backLink' => $container->isUiOptionReturnToSpActive(),
                 'cutoffPointForShowingUnfilteredIdps' => $container->getCutoffPointForShowingUnfilteredIdps(),
                 'rememberChoiceFeature' => $rememberChoiceFeature,
-                'showRequestAccess' => $serviceProvider->displayUnconnectedIdpsWayf,
+                'showRequestAccess' => $serviceProvider->getCoins()->displayUnconnectedIdpsWayf(),
                 'requestId' => $request->getId(),
                 'serviceProvider' => $serviceProvider,
                 'idpList' => $idpList,

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -476,7 +476,7 @@ class EngineBlock_Corto_ProxyServer
         // Unless of course we are in 'stealth' / transparent mode, in which case,
         // pretend to be the Identity Provider.
         $serviceProvider = $this->getRepository()->fetchServiceProviderByEntityId($request->getIssuer());
-        $mustProxyTransparently = ($request->isTransparent() || $serviceProvider->isTransparentIssuer);
+        $mustProxyTransparently = ($request->isTransparent() || $serviceProvider->getCoins()->isTransparentIssuer());
         if (!$this->isInProcessingMode() && $mustProxyTransparently) {
             $newResponse->setIssuer($newResponse->getOriginalIssuer());
             $newAssertion->setIssuer($newResponse->getOriginalIssuer());

--- a/library/EngineBlock/Saml2/AuthnRequestFactory.php
+++ b/library/EngineBlock/Saml2/AuthnRequestFactory.php
@@ -38,7 +38,7 @@ class EngineBlock_Saml2_AuthnRequestFactory
         $sspRequest->setIssuer($server->getUrl('spMetadataService'));
         $sspRequest->setNameIdPolicy($nameIdPolicy);
 
-        if (empty($idpMetadata->disableScoping)) {
+        if (empty($idpMetadata->getCoins()->disableScoping())) {
             // Copy over the Idps that are allowed to answer this request.
             $sspRequest->setIDPList($originalRequest->getIDPList());
 

--- a/library/EngineBlock/SamlHelper.php
+++ b/library/EngineBlock/SamlHelper.php
@@ -15,7 +15,7 @@ class EngineBlock_SamlHelper
     public static function doRemoteEntitiesRequireAdditionalLogging(array $entities)
     {
         return array_reduce($entities, function($carry, AbstractRole $entity) {
-            return $carry | $entity->additionalLogging;
+            return $carry | $entity->getCoins()->additionalLogging();
         }, false);
     }
 

--- a/library/EngineBlock/SamlHelper.php
+++ b/library/EngineBlock/SamlHelper.php
@@ -75,7 +75,7 @@ class EngineBlock_SamlHelper
         MetadataRepositoryInterface $repository,
         \Psr\Log\LoggerInterface $logger = null
     ) {
-        if (!$serviceProvider->isTrustedProxy) {
+        if (!$serviceProvider->getCoins()->isTrustedProxy()) {
             return null;
         }
 
@@ -89,7 +89,7 @@ class EngineBlock_SamlHelper
         $lastRequesterEntityId = end($requesterIds);
 
         if (!$lastRequesterEntityId) {
-            if ($serviceProvider->requesteridRequired) {
+            if ($serviceProvider->getCoins()->requesteridRequired()) {
                 throw new EngineBlock_Exception_UnknownServiceProvider(
                     $serviceProvider,
                     'No RequesterID specified'

--- a/src/OpenConext/EngineBlock/Authentication/Dto/Consent.php
+++ b/src/OpenConext/EngineBlock/Authentication/Dto/Consent.php
@@ -56,7 +56,7 @@ final class Consent
                 'en' => $this->serviceProvider->supportUrlEn,
                 'nl' => $this->serviceProvider->supportUrlNl,
             ],
-            'eula_url' => $this->serviceProvider->termsOfServiceUrl,
+            'eula_url' => $this->serviceProvider->getCoins()->termsOfServiceUrl(),
             'support_email' => $supportEmail,
             'name_id_format' => $this->serviceProvider->nameIdFormat,
         ];

--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace OpenConext\EngineBlock\Metadata;
+
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ */
+class Coins
+{
+    private $values = [];
+
+    public static function createForServiceProvider(
+        $isConsentRequired,
+        $isTransparentIssuer,
+        $isTrustedProxy,
+        $displayUnconnectedIdpsWayf,
+        $termsOfServiceUrl,
+        $skipDenormalization,
+        $policyEnforcementDecisionRequired,
+        $requesteridRequired,
+        $signResponse,
+        $publishInEdugain,
+        $disableScoping,
+        $additionalLogging,
+        $signatureMethod
+    ) {
+        return new self([
+            'isConsentRequired' => $isConsentRequired,
+            'isTransparentIssuer' => $isTransparentIssuer,
+            'isTrustedProxy' => $isTrustedProxy,
+            'displayUnconnectedIdpsWayf' => $displayUnconnectedIdpsWayf,
+            'termsOfServiceUrl' => $termsOfServiceUrl,
+            'skipDenormalization' => $skipDenormalization,
+            'policyEnforcementDecisionRequired' => $policyEnforcementDecisionRequired,
+            'requesteridRequired' => $requesteridRequired,
+            'signResponse' => $signResponse,
+            'publishInEdugain' => $publishInEdugain,
+            'disableScoping' => $disableScoping,
+            'additionalLogging' => $additionalLogging,
+            'signatureMethod' => $signatureMethod,
+        ]);
+    }
+
+    public static function createForIdentityProvider(
+        $guestQualifier,
+        $schacHomeOrganization,
+        $hidden,
+        $publishInEdugain,
+        $disableScoping,
+        $additionalLogging,
+        $signatureMethod
+    ) {
+        return new self([
+            'guestQualifier' => $guestQualifier,
+            'schacHomeOrganization' => $schacHomeOrganization,
+            'hidden' => $hidden,
+            'publishInEdugain' => $publishInEdugain,
+            'disableScoping' => $disableScoping,
+            'additionalLogging' => $additionalLogging,
+            'signatureMethod' => $signatureMethod,
+        ]);
+    }
+
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    /**
+     * @return false|string
+     */
+    public function toJson()
+    {
+        return json_encode($this->values);
+    }
+
+    /**
+     * @param string $data
+     * @return Coins
+     */
+    public static function fromJson($data)
+    {
+        $data = json_decode($data, true);
+
+        return new self($data);
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -7,6 +7,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 /**
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class Coins
 {

--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -2,6 +2,9 @@
 
 namespace OpenConext\EngineBlock\Metadata;
 
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+
 /**
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
  */
@@ -19,7 +22,6 @@ class Coins
         $policyEnforcementDecisionRequired,
         $requesteridRequired,
         $signResponse,
-        $publishInEdugain,
         $disableScoping,
         $additionalLogging,
         $signatureMethod
@@ -34,7 +36,6 @@ class Coins
             'policyEnforcementDecisionRequired' => $policyEnforcementDecisionRequired,
             'requesteridRequired' => $requesteridRequired,
             'signResponse' => $signResponse,
-            'publishInEdugain' => $publishInEdugain,
             'disableScoping' => $disableScoping,
             'additionalLogging' => $additionalLogging,
             'signatureMethod' => $signatureMethod,
@@ -45,7 +46,6 @@ class Coins
         $guestQualifier,
         $schacHomeOrganization,
         $hidden,
-        $publishInEdugain,
         $disableScoping,
         $additionalLogging,
         $signatureMethod
@@ -54,16 +54,20 @@ class Coins
             'guestQualifier' => $guestQualifier,
             'schacHomeOrganization' => $schacHomeOrganization,
             'hidden' => $hidden,
-            'publishInEdugain' => $publishInEdugain,
             'disableScoping' => $disableScoping,
             'additionalLogging' => $additionalLogging,
             'signatureMethod' => $signatureMethod,
         ]);
     }
 
-    public function __construct(array $values)
+    private function __construct(array $values)
     {
-        $this->values = $values;
+        $this->values = [];
+        foreach ($values as $key => $value) {
+            if (!is_null($value)) {
+                $this->values[$key] = $value;
+            }
+        }
     }
 
     /**
@@ -83,5 +87,91 @@ class Coins
         $data = json_decode($data, true);
 
         return new self($data);
+    }
+
+    // SP
+    public function isConsentRequired()
+    {
+        return $this->getValue('isConsentRequired', true);
+    }
+
+    public function isTransparentIssuer()
+    {
+        return $this->getValue('isTransparentIssuer', false);
+    }
+
+    public function isTrustedProxy()
+    {
+        return $this->getValue('isTrustedProxy', false);
+    }
+
+    public function displayUnconnectedIdpsWayf()
+    {
+        return $this->getValue('displayUnconnectedIdpsWayf', false);
+    }
+
+    public function termsOfServiceUrl()
+    {
+        return $this->getValue('termsOfServiceUrl');
+    }
+
+    public function skipDenormalization()
+    {
+        return $this->getValue('skipDenormalization', false);
+    }
+
+    public function policyEnforcementDecisionRequired()
+    {
+        return $this->getValue('policyEnforcementDecisionRequired', false);
+    }
+
+    public function requesteridRequired()
+    {
+        return $this->getValue('requesteridRequired', false);
+    }
+
+    public function signResponse()
+    {
+        return $this->getValue('signResponse', false);
+    }
+
+    // IDP
+    public function guestQualifier()
+    {
+        return $this->getValue('guestQualifier', IdentityProvider::GUEST_QUALIFIER_ALL);
+    }
+
+    public function schacHomeOrganization()
+    {
+        return $this->getValue('schacHomeOrganization');
+    }
+
+    public function hidden()
+    {
+        return $this->getValue('hidden', false);
+    }
+
+    // Abstract
+    public function disableScoping()
+    {
+        return $this->getValue('disableScoping', false);
+    }
+
+    public function additionalLogging()
+    {
+        return $this->getValue('additionalLogging', false);
+    }
+
+    public function signatureMethod()
+    {
+        return $this->getValue('signatureMethod', XMLSecurityKey::RSA_SHA1);
+    }
+
+    private function getValue($key, $default = null)
+    {
+        if (!array_key_exists($key, $this->values)) {
+            return $default;
+        }
+        return $this->values[$key];
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
@@ -4,6 +4,7 @@ namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
@@ -249,6 +250,13 @@ abstract class AbstractRole
      * @ORM\Column(name="manipulation", type="text")
      */
     public $manipulation;
+
+    /**
+     * @var Coins
+     *
+     * @ORM\Column(name="coins", type="engineblock_metadata_coins")
+     */
+    protected $coins = array();
 
     /**
      * @param $entityId

--- a/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
@@ -376,4 +376,12 @@ abstract class AbstractRole
 
         throw new \RuntimeException('Unknown workflow state');
     }
+
+    /**
+     * @return Coins
+     */
+    public function getCoins()
+    {
+        return $this->coins;
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -216,7 +216,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         );
 
         return Utils::instantiate(
-            'OpenConext\EngineBlock\Metadata\Entity\ServiceProvider',
+            ServiceProvider::class,
             $properties
         );
     }
@@ -237,7 +237,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         $properties += $this->assembleShibMdScopes($connection);
 
         return Utils::instantiate(
-            'OpenConext\EngineBlock\Metadata\Entity\IdentityProvider',
+            IdentityProvider::class,
             $properties
         );
     }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -153,21 +153,21 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
 
         $properties += $this->assembleAttributeReleasePolicy($connection);
         $properties += $this->assembleAssertionConsumerServices($connection);
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:transparant_issuer'
             ),
             'isTransparentIssuer'
         );
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:trusted_proxy'
             ),
             'isTrustedProxy'
         );
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:display_unconnected_idps_wayf'
@@ -177,21 +177,21 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
 
         $properties += $this->assembleIsConsentRequired($connection);
 
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectString(
             array(
                 $connection,
                 'metadata:coin:eula'
             ),
             'termsOfServiceUrl'
         );
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:do_not_add_attribute_aliases'
             ),
             'skipDenormalization'
         );
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:policy_enforcement_decision_required'
@@ -199,7 +199,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
             'policyEnforcementDecisionRequired'
         );
 
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:requesterid_required'
@@ -207,7 +207,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
             'requesteridRequired'
         );
 
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:sign_response'
@@ -230,10 +230,10 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         $properties = $this->assembleCommon($connection);
 
         $properties += $this->assembleSingleSignOnServices($connection);
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:guest_qualifier'), 'guestQualifier');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:schachomeorganization'), 'schacHomeOrganization');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:guest_qualifier'), 'guestQualifier');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:schachomeorganization'), 'schacHomeOrganization');
         $properties += $this->assembleConsentSettings($connection);
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:hidden'), 'hidden');
+        $properties += $this->setPathFromObjectBool(array($connection, 'metadata:coin:hidden'), 'hidden');
         $properties += $this->assembleShibMdScopes($connection);
 
         return Utils::instantiate(
@@ -246,33 +246,33 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
     {
         $properties = array();
 
-        $properties += $this->setPathFromObject(array($connection, 'name'), 'entityId');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:name:nl'), 'nameNl');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:name:en'), 'nameEn');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:displayName:nl'), 'displayNameNl');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:displayName:en'), 'displayNameEn');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:description:nl'), 'descriptionNl');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:description:en'), 'descriptionEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'name'), 'entityId');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:name:nl'), 'nameNl');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:name:en'), 'nameEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:displayName:nl'), 'displayNameNl');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:displayName:en'), 'displayNameEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:description:nl'), 'descriptionNl');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:description:en'), 'descriptionEn');
         $properties += $this->assembleLogo($connection);
         $properties += $this->assembleOrganization($connection, 'nl');
         $properties += $this->assembleOrganization($connection, 'en');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:keywords:en'), 'keywordsEn');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:keywords:nl'), 'keywordsNl');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:publish_in_edugain'), 'publishInEdugain');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:keywords:en'), 'keywordsEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:keywords:nl'), 'keywordsNl');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:publish_in_edugain'), 'publishInEdugain');
         $properties += $this->assembleCertificates($connection);
-        $properties += $this->setPathFromObject(array($connection, 'state'), 'workflowState');
+        $properties += $this->setPathFromObjectString(array($connection, 'state'), 'workflowState');
         $properties += $this->assembleContactPersons($connection);
-        $properties += $this->setPathFromObject(array($connection, 'metadata:NameIDFormat'), 'nameIdFormat');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:NameIDFormats'), 'supportedNameIdFormats');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:NameIDFormat'), 'nameIdFormat');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:NameIDFormats'), 'supportedNameIdFormats');
         $properties += $this->assembleSingleLogoutServices($connection);
         $properties += $this->assemblePublishInEdugainDate($connection);
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:disable_scoping'), 'disableScoping');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:additional_logging'), 'additionalLogging');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:signature_method'), 'signatureMethod');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:redirect:sign'), 'requestsMustBeSigned');
-        $properties += $this->setPathFromObject(array($connection, 'manipulation_code'), 'manipulation');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:url:en'), 'supportUrlEn');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:url:nl'), 'supportUrlNl');
+        $properties += $this->setPathFromObjectBool(array($connection, 'metadata:coin:disable_scoping'), 'disableScoping');
+        $properties += $this->setPathFromObjectBool(array($connection, 'metadata:coin:additional_logging'), 'additionalLogging');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:signature_method'), 'signatureMethod');
+        $properties += $this->setPathFromObjectBool(array($connection, 'metadata:redirect:sign'), 'requestsMustBeSigned');
+        $properties += $this->setPathFromObjectString(array($connection, 'manipulation_code'), 'manipulation');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:url:en'), 'supportUrlEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:url:nl'), 'supportUrlNl');
 
         return $properties;
     }
@@ -390,19 +390,38 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         ));
     }
 
-    private function setPathFromObject($from, $to)
+    private function setPathFromObjectString($from, $to)
+    {
+        $reference = $this->getValueFromPath($from);
+        if (is_null($reference)) {
+            return array($to => null);
+        }
+        return array($to => (string)$reference);
+    }
+
+    private function setPathFromObjectBool($from, $to)
+    {
+        $reference = $this->getValueFromPath($from);
+        if (is_null($reference)) {
+            return array($to => null);
+        }
+        return array($to => (bool)$reference);
+    }
+
+    private function getValueFromPath($from)
     {
         $pathParts = explode(':', $from[1]);
 
         $reference = $from[0];
         while ($pathPart = array_shift($pathParts)) {
             if (!isset($reference->$pathPart)) {
-                return array();
+                return null;
             }
 
             $reference = $reference->$pathPart;
         }
-        return array($to => $reference);
+
+        return $reference;
     }
 
     private function assembleSingleSignOnServices($connection)

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
@@ -31,10 +31,10 @@ class CortoDisassembler
 
         $cortoEntity = $this->translateCommon($entity, $cortoEntity);
 
-        if ($entity->isTransparentIssuer) {
+        if ($entity->getCoins()->isTransparentIssuer()) {
             $cortoEntity['TransparentIssuer'] = 'yes';
         }
-        if ($entity->displayUnconnectedIdpsWayf) {
+        if ($entity->getCoins()->displayUnconnectedIdpsWayf()) {
             $cortoEntity['DisplayUnconnectedIdpsWayf'] = 'yes';
         }
         foreach ($entity->assertionConsumerServices as $service) {
@@ -47,19 +47,19 @@ class CortoDisassembler
                 'Location' => $service->location,
             );
         }
-        if (!$entity->isConsentRequired) {
+        if (!$entity->getCoins()->isConsentRequired()) {
             $cortoEntity['NoConsentRequired'] = true;
         }
-        if ($entity->skipDenormalization) {
+        if ($entity->getCoins()->skipDenormalization()) {
             $cortoEntity['SkipDenormalization'] = true;
         }
-        if ($entity->policyEnforcementDecisionRequired) {
+        if ($entity->getCoins()->policyEnforcementDecisionRequired()) {
             $cortoEntity['PolicyEnforcementDecisionRequired'] = true;
         }
         if ($entity->isAttributeAggregationRequired()) {
             $cortoEntity['AttributeAggregationRequired'] = true;
         }
-        if ($entity->requesteridRequired) {
+        if ($entity->getCoins()->requesteridRequired()) {
             $cortoEntity['requesteridRequired'] = true;
         }
 

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
@@ -94,7 +94,7 @@ class CortoDisassembler
         }
 
         $cortoEntity['SpsWithoutConsent'] = $entity->getConsentSettings()->getSpEntityIdsWithoutConsent();
-        $cortoEntity['isHidden'] = $entity->hidden;
+        $cortoEntity['isHidden'] = $entity->coins()->hidden();
 
         $cortoEntity['shibmd:scopes'] = array();
         foreach ($entity->shibMdScopes as $scope) {
@@ -121,11 +121,11 @@ class CortoDisassembler
         if ($entity->publishInEduGainDate) {
             $cortoEntity['PublishInEdugainDate'] = $entity->publishInEduGainDate->format(DateTime::W3C);
         }
-        if ($entity->disableScoping) {
+        if ($entity->getCoins()->disableScoping()) {
             $cortoEntity['DisableScoping'] = true;
         }
-        if ($entity->additionalLogging) {
-            $cortoEntity['AdditionalLogging'] = $entity->additionalLogging;
+        if ($entity->getCoins()->additionalLogging()) {
+            $cortoEntity['AdditionalLogging'] = $entity->getCoins()->additionalLogging();
         }
         $cortoEntity = $this->translateCommonCertificates($entity, $cortoEntity);
         if ($entity->logo) {

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
@@ -87,14 +87,14 @@ class CortoDisassembler
             );
         }
 
-        $cortoEntity['GuestQualifier'] = $entity->guestQualifier;
+        $cortoEntity['GuestQualifier'] = $entity->getCoins()->guestQualifier();
 
-        if ($entity->schacHomeOrganization) {
-            $cortoEntity['SchacHomeOrganization'] = $entity->schacHomeOrganization;
+        if ($entity->getCoins()->schacHomeOrganization()) {
+            $cortoEntity['SchacHomeOrganization'] = $entity->getCoins()->schacHomeOrganization();
         }
 
         $cortoEntity['SpsWithoutConsent'] = $entity->getConsentSettings()->getSpEntityIdsWithoutConsent();
-        $cortoEntity['isHidden'] = $entity->coins()->hidden();
+        $cortoEntity['isHidden'] = $entity->getCoins()->hidden();
 
         $cortoEntity['shibmd:scopes'] = array();
         foreach ($entity->shibMdScopes as $scope) {

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -203,7 +203,6 @@ class IdentityProvider extends AbstractRole
             $guestQualifier,
             $schacHomeOrganization,
             $hidden,
-            $publishInEdugain,
             $disableScoping,
             $additionalLogging,
             $signatureMethod

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -3,7 +3,7 @@
 namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use OpenConext\EngineBlock\Authentication\Dto\Consent;
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
@@ -198,6 +198,16 @@ class IdentityProvider extends AbstractRole
         $this->shibMdScopes = $shibMdScopes;
         $this->singleSignOnServices = $singleSignOnServices;
         $this->consentSettings = $consentSettings;
+
+        $this->coins = Coins::createForIdentityProvider(
+            $guestQualifier,
+            $schacHomeOrganization,
+            $hidden,
+            $publishInEdugain,
+            $disableScoping,
+            $additionalLogging,
+            $signatureMethod
+        );
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -3,8 +3,6 @@
 namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
-use OpenConext\EngineBlock\Metadata\Coin;
-use OpenConext\EngineBlock\Metadata\CoinCollection;
 use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
@@ -286,7 +284,6 @@ class ServiceProvider extends AbstractRole
             $policyEnforcementDecisionRequired,
             $requesteridRequired,
             $signResponse,
-            $publishInEdugain,
             $disableScoping,
             $additionalLogging,
             $signatureMethod

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -3,6 +3,9 @@
 namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Coin;
+use OpenConext\EngineBlock\Metadata\CoinCollection;
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
 use OpenConext\EngineBlock\Metadata\Organization;
@@ -20,6 +23,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @SuppressWarnings(PHPMD.TooManyMethods)
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  */
 class ServiceProvider extends AbstractRole
 {
@@ -271,6 +275,22 @@ class ServiceProvider extends AbstractRole
         $this->signResponse = $signResponse;
         $this->supportUrlEn = $supportUrlEn;
         $this->supportUrlNl = $supportUrlNl;
+
+        $this->coins = Coins::createForServiceProvider(
+            $isConsentRequired,
+            $isTransparentIssuer,
+            $isTrustedProxy,
+            $displayUnconnectedIdpsWayf,
+            $termsOfServiceUrl,
+            $skipDenormalization,
+            $policyEnforcementDecisionRequired,
+            $requesteridRequired,
+            $signResponse,
+            $publishInEdugain,
+            $disableScoping,
+            $additionalLogging,
+            $signatureMethod
+        );
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
@@ -204,11 +204,11 @@ class InMemoryMetadataRepository extends AbstractMetadataRepository
 
         $identityProviders = $this->findIdentityProviders();
         foreach ($identityProviders as $identityProvider) {
-            if (!$identityProvider->schacHomeOrganization) {
+            if (!$identityProvider->getCoins()->schacHomeOrganization()) {
                 continue;
             }
 
-            $schacHomeOrganizations[] = $identityProvider->schacHomeOrganization;
+            $schacHomeOrganizations[] = $identityProvider->getCoins()->schacHomeOrganization();
         }
         return $schacHomeOrganizations;
     }

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/MetadataCoinType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/MetadataCoinType.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\Coins;
+
+class MetadataCoinType extends Type
+{
+    const NAME = 'engineblock_metadata_coins';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        if (!$value instanceof Coins) {
+            throw new ConversionException(
+                sprintf(
+                    'Value "%s" must be null or an instance of Coins to be able to ' .
+                    'convert it to a database value',
+                    is_object($value) ? get_class($value) : (string)$value
+                )
+            );
+        }
+
+        return $value->toJson();
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        try {
+            $coins = Coins::fromJson($value);
+        } catch (InvalidArgumentException $e) {
+            // get nice standard message, so we can throw it keeping the exception chain
+            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                'valid serialized coin json'
+            )->getMessage();
+
+            throw new ConversionException($doctrineExceptionMessage, 0, $e);
+        }
+
+        return $coins;
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -4,6 +4,7 @@ namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
 
 use Doctrine\ORM\EntityManager;
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
@@ -133,7 +134,7 @@ class ServiceRegistryFixture
             0
         );
 
-        $sp->termsOfServiceUrl = 'http://welcome.vm.openconext.org';
+        $this->setCoin($sp, 'termsOfServiceUrl', 'http://welcome.vm.openconext.org');
         $sp->logo = new Logo('/images/placeholder.png');
 
         // The repository does not allow us to retrieve all SP's for good reason. In functional testing mode the total
@@ -222,7 +223,7 @@ QUERY;
 
     public function setSpEntityNoConsent($entityId)
     {
-        $this->getServiceProvider($entityId)->isConsentRequired = false;
+        $this->setCoin($this->getServiceProvider($entityId), 'isConsentRequired', false);
 
         return $this;
     }
@@ -236,14 +237,14 @@ QUERY;
 
     public function setSpSignRepsones($entityId, $state = true)
     {
-        $this->getServiceProvider($entityId)->signResponse = (bool)$state;
+        $this->setCoin($this->getServiceProvider($entityId), 'signResponse', (bool)$state);
 
         return $this;
     }
 
     public function setSpEntityTrustedProxy($entityId)
     {
-        $this->getServiceProvider($entityId)->isTrustedProxy = true;
+        $this->setCoin($this->getServiceProvider($entityId), 'isTrustedProxy', true);
 
         return $this;
     }
@@ -278,7 +279,7 @@ QUERY;
 
     public function spRequiresPolicyEnforcementDecisionForSp($entityId)
     {
-        $this->getServiceProvider($entityId)->policyEnforcementDecisionRequired = true;
+        $this->setCoin($this->getServiceProvider($entityId), 'policyEnforcementDecisionRequired', true);
 
         return $this;
     }
@@ -301,12 +302,12 @@ QUERY;
 
     public function requireASignedResponse($entityId)
     {
-        $this->getServiceProvider($entityId)->signResponse = true;
+        $this->setCoin($this->getServiceProvider($entityId), 'signResponse', true);
     }
 
     public function displayUnconnectedIdpsForSp($entityId, $displayUnconnected = true)
     {
-        $this->getServiceProvider($entityId)->displayUnconnectedIdpsWayf = (bool) $displayUnconnected;
+        $this->setCoin($this->getServiceProvider($entityId), 'displayUnconnectedIdpsWayf', (bool) $displayUnconnected);
 
         return $this;
     }
@@ -403,5 +404,21 @@ QUERY;
         );
 
         return $this;
+    }
+
+    private function setCoin(ServiceProvider $sp, $key, $name)
+    {
+        $jsonData = $sp->getCoins()->toJson();
+        $data = json_decode($jsonData, true);
+        $data[$key] = $name;
+        $jsonData = json_encode($data);
+
+        $coins = Coins::fromJson($jsonData);
+
+        $object = new \ReflectionClass($sp);
+
+        $property = $object->getProperty('coins');
+        $property->setAccessible(true);
+        $property->setValue($sp, $coins);
     }
 }

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
@@ -2,14 +2,13 @@
 
 namespace OpenConext\EngineBlockBundle\Tests;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Query\QueryBuilder;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlockBundle\Configuration\Feature;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\Response;
-use PDO;
 
 class ConnectionsControllerTest extends WebTestCase
 {
@@ -169,13 +168,25 @@ class ConnectionsControllerTest extends WebTestCase
 
             // validate data
             $metadata = $this->getStoredMetadata();
+            $this->assertNotEmpty($metadata);
+
             foreach ($step as $role) {
                 $this->assertArrayHasKey($role['entityId'], $metadata);
 
                 $data = $metadata[$role['entityId']];
-                $this->assertSame($role['entityId'], $data['entity_id']);
-                $this->assertSame($role['name'], $data['name_en']);
-                $this->assertSame($role['type'], 'saml20-'.$data['type']);
+                $this->assertSame($role['entityId'], $data->entityId);
+                $this->assertSame($role['name'], $data->nameEn);
+
+                switch($role['type']) {
+                    case 'saml20-idp':
+                        $this->assertInstanceOf(IdentityProvider::class, $data);
+                        break;
+                    case 'saml20-sp':
+                        $this->assertInstanceOf(ServiceProvider::class, $data);
+                        break;
+                    default:
+                        throw new \Exception('Unknown role type encountered');
+                }
 
                 unset($metadata[$role['entityId']]);
             }
@@ -184,6 +195,62 @@ class ConnectionsControllerTest extends WebTestCase
         }
     }
 
+
+    /**
+     * @test
+     * @group Api
+     * @group Connections
+     * @group MetadataPush
+     *
+     */
+    public function pushing_data_with_coins_to_engineblock_should_succeed()
+    {
+        $this->clearMetadataFixtures();
+
+        $client = $this->makeClient([
+            'username' => $this->getContainer()->getParameter('api.users.metadataPush.username'),
+            'password' => $this->getContainer()->getParameter('api.users.metadataPush.password'),
+        ]);
+
+        $this->enableMetadataPushApiFeatureFor($client);
+
+        foreach ($this->validConnectionsWithCoinsData() as $connection) {
+
+            $payload = $this->createJsonData([$connection]);
+
+            $client->request(
+                'POST',
+                'https://engine-api.vm.openconext.org/api/connections',
+                [],
+                [],
+                [],
+                $payload
+            );
+            $this->assertStatusCode(Response::HTTP_OK, $client);
+
+            // check content type
+            $isContentTypeJson = $client->getResponse()->headers->contains('Content-Type', 'application/json');
+            $this->assertTrue($isContentTypeJson, 'Response should have Content-Type: application/json header');
+
+            // check response status
+            $body = $client->getResponse()->getContent();
+            $result = json_decode($body, true);
+            $this->assertTrue($result['success']);
+
+            // validate data
+            $metadata = $this->getStoredMetadata();
+
+            $this->assertArrayHasKey($connection['entityId'], $metadata);
+
+            $data = $metadata[$connection['entityId']];
+            $this->assertSame($connection['entityId'], $data->entityId);
+
+            // validate coins
+            foreach ($connection['expected-coins'] as $key => $value) {
+                $this->assertSame($value, $data->$key, "Coin value for '{$key}' expected to be '{$value}' but unexpected '{$data->$key}' encountered.");
+            }
+        }
+    }
 
     public function invalidHttpMethodProvider()
     {
@@ -233,20 +300,27 @@ class ConnectionsControllerTest extends WebTestCase
             ->execute();
     }
 
+    /**
+     * @return ServiceProvider[]|IdentityProvider[]
+     */
     private function getStoredMetadata()
     {
-        /** @var QueryBuilder $queryBuilder */
-        $queryBuilder = $this->getContainer()->get('doctrine')->getConnection()->createQueryBuilder();
-        $metadata = $queryBuilder
-            ->select('r.entity_id, r.name_en, r.type')
-            ->from('sso_provider_roles_eb5', 'r')
-            ->execute()
-            ->fetchAll(PDO::FETCH_ASSOC);
+        $doctrine = $this->getContainer()->get('doctrine');
+
+        $doctrine->getManager()->clear();
 
         $results = [];
-        foreach ($metadata as $role) {
-            $results[$role['entity_id']] = $role;
+
+        $idp = $doctrine->getManager()->getRepository(ServiceProvider::class)->findAll();
+        foreach ($idp as $role) {
+            $results[$role->entityId] = $role;
         }
+
+        $sp = $doctrine->getManager()->getRepository(IdentityProvider::class)->findAll();
+        foreach ($sp as $role) {
+            $results[$role->entityId] = $role;
+        }
+
         return $results;
     }
 
@@ -254,19 +328,25 @@ class ConnectionsControllerTest extends WebTestCase
     {
         $connectionsJson = [];
         foreach ($connections as $data) {
-            $connectionsJson[] = $this->createPayloadConnectionJson($data['uuid'], $data['entityId'], $data['name'], $data['type']);
+            $connectionsJson[] = $this->createPayloadConnectionJson($data['uuid'], $data['entityId'], $data['name'], $data['type'], $data['coins']);
         }
         $connectionsJson = implode(',', $connectionsJson);
 
         return sprintf('{"connections":{%s}}', $connectionsJson);
     }
 
-    private function createPayloadConnectionJson($uuid, $entityId, $name, $type)
+    private function createPayloadConnectionJson($uuid, $entityId, $name, $type, $coins = [])
     {
+        $coinsJson = '';
+        if (!empty($coins)) {
+            $coinsJson = '"coin": ' . json_encode($coins) . ',';
+        }
+
         return sprintf('"%1$s":{
             "allow_all_entities":true,
             "allowed_connections":[],
             "metadata":{
+                %5$s
                 "name":{
                     "en":"%3$s"
                     }
@@ -278,7 +358,8 @@ class ConnectionsControllerTest extends WebTestCase
             $uuid,
             $entityId,
             $name,
-            $type);
+            $type,
+            $coinsJson);
     }
 
     private function validConnectionsData()
@@ -329,6 +410,97 @@ class ConnectionsControllerTest extends WebTestCase
                     'name' => 'SP1',
                     'type' => 'saml20-sp',
                 ],
+            ],
+        ];
+    }
+
+
+    private function validConnectionsWithCoinsData()
+    {
+        return [
+            [
+                'uuid' => '00000000-0000-0000-0000-000000000000',
+                'entityId' => 'https://my-idp.test/1',
+                'name' => 'SP0',
+                'type' => 'saml20-sp',
+                'coins' => [
+                    'no_consent_required' => '0',
+                    'transparant_issuer' => '1',
+                    'trusted_proxy' => '1',
+                    'display_unconnected_idps_wayf' => '0',
+                    'eula' => 'eula',
+                    'do_not_add_attribute_aliases' => '1',
+                    'policy_enforcement_decision_required' => '0',
+                    'requesterid_required' => '1',
+                    'sign_response' => '0',
+                    // abstract
+                    'publish_in_edugain' => '1',
+                    'disable_scoping' => '0',
+                    'additional_logging' => '1',
+                    'signature_method' => 'signature-method',
+                ],
+                'expected-coins' => [
+                    'isConsentRequired' => true,
+                    'isTransparentIssuer' => true,
+                    'isTrustedProxy' => true,
+                    'displayUnconnectedIdpsWayf' => false,
+                    'termsOfServiceUrl' => 'eula',
+                    'skipDenormalization' => true,
+                    'policyEnforcementDecisionRequired' => false,
+                    'requesteridRequired' => true,
+                    'signResponse' => false,
+                    // abstract
+                    'publishInEdugain' => true,
+                    'disableScoping' => false,
+                    'additionalLogging' => true,
+                    'signatureMethod' => 'signature-method',
+                ]
+            ],
+            [
+                'uuid' => '00000000-0000-0000-0000-000000000001',
+                'entityId' => 'https://my-idp.test/2',
+                'name' => 'IDP1',
+                'type' => 'saml20-idp',
+                'coins' => [
+                    'guest_qualifier' => 'guest-qualifier',
+                    'schachomeorganization' => 'schac-home-organization',
+                    'hidden' => '0',
+                    // abstract
+                    'publish_in_edugain' => '1',
+                    'disable_scoping' => '0',
+                    'additional_logging' => '1',
+                    'signature_method' => 'signature-method',
+                ],
+                'expected-coins' => [
+                    'guestQualifier' => 'guest-qualifier',
+                    'schacHomeOrganization' => 'schac-home-organization',
+                    'hidden' => false,
+                    // abstract
+                    'publishInEdugain' => true,
+                    'disableScoping' => false,
+                    'additionalLogging' => true,
+                    'signatureMethod' => 'signature-method',
+                ]
+            ],
+            [
+                'uuid' => '00000000-0000-0000-0000-000000000002',
+                'entityId' => 'https://my-idp.test/1',
+                'name' => 'SP0',
+                'type' => 'saml20-sp',
+                'coins' => [
+                    'transparant_issuer' => true,
+                    'trusted_proxy' => false,
+                    'display_unconnected_idps_wayf' => '1',
+                    'requesterid_required' => '0',
+                    'policy_enforcement_decision_required' => '-1',
+                ],
+                'expected-coins' => [
+                    'isTransparentIssuer' => true,
+                    'isTrustedProxy' => false,
+                    'displayUnconnectedIdpsWayf' => true,
+                    'requesteridRequired' => false,
+                    'policyEnforcementDecisionRequired' => true,
+                ]
             ],
         ];
     }

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
@@ -247,7 +247,7 @@ class ConnectionsControllerTest extends WebTestCase
 
             // validate coins
             foreach ($connection['expected-coins'] as $key => $value) {
-                $this->assertSame($value, $data->$key, "Coin value for '{$key}' expected to be '{$value}' but unexpected '{$data->$key}' encountered.");
+                $this->assertSame($value, $data->getCoins()->$key(), "Coin value for '{$key}' expected to be '{$value}' but unexpected '{$data->getCoins()->$key()}' encountered.");
             }
         }
     }
@@ -378,11 +378,11 @@ class ConnectionsControllerTest extends WebTestCase
                     'name' => 'SP1',
                     'type' => 'saml20-sp',
                 ],[
-                'uuid' => '00000000-0000-0000-0000-000000000002',
-                'entityId' => 'https://my-idp.test/3',
-                'name' => 'IDP3',
-                'type' => 'saml20-idp',
-            ],
+                    'uuid' => '00000000-0000-0000-0000-000000000002',
+                    'entityId' => 'https://my-idp.test/3',
+                    'name' => 'IDP3',
+                    'type' => 'saml20-idp',
+                ],
             ],
             [
                 [
@@ -397,11 +397,11 @@ class ConnectionsControllerTest extends WebTestCase
                     'name' => 'SP1 updated',
                     'type' => 'saml20-sp',
                 ],[
-                'uuid' => '00000000-0000-0000-0000-000000000002',
-                'entityId' => 'https://my-idp.test/3',
-                'name' => 'IDP3 updated',
-                'type' => 'saml20-idp',
-            ],
+                    'uuid' => '00000000-0000-0000-0000-000000000002',
+                    'entityId' => 'https://my-idp.test/3',
+                    'name' => 'IDP3 updated',
+                    'type' => 'saml20-idp',
+                ],
             ],
             [
                 [
@@ -450,7 +450,6 @@ class ConnectionsControllerTest extends WebTestCase
                     'requesteridRequired' => true,
                     'signResponse' => false,
                     // abstract
-                    'publishInEdugain' => true,
                     'disableScoping' => false,
                     'additionalLogging' => true,
                     'signatureMethod' => 'signature-method',
@@ -476,7 +475,6 @@ class ConnectionsControllerTest extends WebTestCase
                     'schacHomeOrganization' => 'schac-home-organization',
                     'hidden' => false,
                     // abstract
-                    'publishInEdugain' => true,
                     'disableScoping' => false,
                     'additionalLogging' => true,
                     'signatureMethod' => 'signature-method',

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
@@ -378,11 +378,11 @@ class ConnectionsControllerTest extends WebTestCase
                     'name' => 'SP1',
                     'type' => 'saml20-sp',
                 ],[
-                    'uuid' => '00000000-0000-0000-0000-000000000002',
-                    'entityId' => 'https://my-idp.test/3',
-                    'name' => 'IDP3',
-                    'type' => 'saml20-idp',
-                ],
+                'uuid' => '00000000-0000-0000-0000-000000000002',
+                'entityId' => 'https://my-idp.test/3',
+                'name' => 'IDP3',
+                'type' => 'saml20-idp',
+            ],
             ],
             [
                 [
@@ -397,11 +397,11 @@ class ConnectionsControllerTest extends WebTestCase
                     'name' => 'SP1 updated',
                     'type' => 'saml20-sp',
                 ],[
-                    'uuid' => '00000000-0000-0000-0000-000000000002',
-                    'entityId' => 'https://my-idp.test/3',
-                    'name' => 'IDP3 updated',
-                    'type' => 'saml20-idp',
-                ],
+                'uuid' => '00000000-0000-0000-0000-000000000002',
+                'entityId' => 'https://my-idp.test/3',
+                'name' => 'IDP3 updated',
+                'type' => 'saml20-idp',
+            ],
             ],
             [
                 [

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
@@ -208,7 +208,7 @@ final class ConsentControllerTest extends WebTestCase
                         'en' => $serviceProvider->supportUrlEn,
                         'nl' => $serviceProvider->supportUrlNl,
                     ],
-                    'eula_url' => $serviceProvider->termsOfServiceUrl,
+                    'eula_url' => $serviceProvider->getCoins()->termsOfServiceUrl(),
                     'support_email' => $firstSupportContact->emailAddress,
                     'name_id_format' => $serviceProvider->nameIdFormat,
                 ],

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -126,7 +126,7 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
 
             $roles = $this->assembler->assemble($input);
 
-            $this->assertSame($assertion[1], $roles[0]->{$parameter}, "Invalid coin conversion for {$roleType}:{$coinName}($type) expected '{$assertion[1]}' but encountered '{$roles[0]->{$parameter}}'");
+            $this->assertSame($assertion[1], $roles[0]->getCoins()->{$parameter}(), "Invalid coin conversion for {$roleType}:{$coinName}($type) expected '{$assertion[1]}' but encountered '{$roles[0]->getCoins()->{$parameter}()}'");
         }
     }
 

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -83,6 +83,12 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider validCoins
+     *
+     * @param string $coinName The name of the coin and used to set the coin in the meta push data
+     * @param string $roleType The type of the role and used to set the coin in the meta push data
+     * @param string $parameter The name of the parameter used in the coin
+     * @param string $type The type of coin data to run possible assertions against see the validCoinValues* helper
+     *                     methods below which are used to assert the data after it went through the assembler.
      */
     public function testCoins($coinName, $roleType, $parameter, $type) {
         $connection = '{
@@ -164,6 +170,10 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    /**
+     * The first option is the manage coin value, the second is the expected entity coin value after assembling
+     * @return array
+     */
     private function validCoinValuesBool() {
         return [
             [null, false],
@@ -175,6 +185,10 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    /**
+     * The first option is the manage coin value, the second is the expected entity coin value after assembling
+     * @return array
+     */
     private function validCoinValuesBoolNegative() {
         return [
             [null, true],
@@ -186,6 +200,10 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    /**
+     * The first option is the manage coin value, the second is the expected entity coin value after assembling
+     * @return array
+     */
     private function validCoinValuesString() {
         return [
             [null, null],
@@ -194,6 +212,10 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    /**
+     * The first option is the manage coin value, the second is the expected entity coin value after assembling
+     * @return array
+     */
     private function validCoinValuesStringSignatureMethod() {
         return [
             [null, "http://www.w3.org/2000/09/xmldsig#rsa-sha1"],
@@ -202,6 +224,10 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    /**
+     * The first option is the manage coin value, the second is the expected entity coin value after assembling
+     * @return array
+     */
     private function validCoinValuesStringGuestQualifier() {
         return [
             [null, "All"],

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -81,11 +81,132 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
         $this->assembler->assemble($input);
     }
 
+    /**
+     * @dataProvider validCoins
+     */
+    public function testCoins($coinName, $roleType, $parameter, $type) {
+        $connection = '{
+            "2d96e27a-76cf-4ca2-ac70-ece5d4c49523": {
+                "allow_all_entities": true,
+                "allowed_connections": [],
+                "metadata": {
+                    "coin": {}
+                },
+                "name": "https:\/\/role/sp",
+                "state": "prodaccepted",
+                "type": "saml20-sp"
+            }
+        }';
+
+        $input = json_decode($connection);
+        $input->{"2d96e27a-76cf-4ca2-ac70-ece5d4c49523"}->type = $roleType;
+
+        switch ($type) {
+            case 'bool';
+                $values = $this->validCoinValuesBool();
+                break;
+            case 'bool-negative';
+                $values = $this->validCoinValuesBoolNegative();
+                break;
+            case 'string';
+                $values = $this->validCoinValuesString();
+                break;
+            case 'string-signature-method';
+                $values = $this->validCoinValuesStringSignatureMethod();
+                break;
+            case 'string-guest-qualifier';
+                $values = $this->validCoinValuesStringGuestQualifier();
+                break;
+            default:
+                throw new RuntimeException('Unknown coin type');
+        }
+
+        foreach ($values as $assertion) {
+            $input->{"2d96e27a-76cf-4ca2-ac70-ece5d4c49523"}->metadata->coin->$coinName = $assertion[0];
+
+            $roles = $this->assembler->assemble($input);
+
+            $this->assertSame($assertion[1], $roles[0]->{$parameter}, "Invalid coin conversion for {$roleType}:{$coinName}($type) expected '{$assertion[1]}' but encountered '{$roles[0]->{$parameter}}'");
+        }
+    }
+
     public function invalidAcsLocations()
     {
         return [
             'invalid-scheme' => ['javascript:alert("hello world");'],
             'no-scheme' => ['www.sp.example.com'],
+        ];
+    }
+
+    public function validCoins()
+    {
+        return [
+            // SP
+            ['no_consent_required', 'saml20-sp', 'isConsentRequired', 'bool-negative'],
+            ['transparant_issuer', 'saml20-sp', 'isTransparentIssuer', 'bool'],
+            ['trusted_proxy', 'saml20-sp', 'isTrustedProxy', 'bool'],
+            ['display_unconnected_idps_wayf', 'saml20-sp', 'displayUnconnectedIdpsWayf', 'bool'],
+            ['eula', 'saml20-sp', 'termsOfServiceUrl', 'string'],
+            ['do_not_add_attribute_aliases', 'saml20-sp', 'skipDenormalization', 'bool'],
+            ['policy_enforcement_decision_required', 'saml20-sp', 'policyEnforcementDecisionRequired', 'bool'],
+            ['requesterid_required', 'saml20-sp', 'requesteridRequired', 'bool'],
+            ['sign_response', 'saml20-sp', 'signResponse', 'bool'],
+
+            // IDP
+            ['guest_qualifier', 'saml20-idp', 'guestQualifier', 'string-guest-qualifier'],
+            ['schachomeorganization', 'saml20-idp', 'schacHomeOrganization', 'string'],
+            ['hidden', 'saml20-idp', 'hidden', 'bool'],
+
+            // Abstract
+            ['disable_scoping', 'saml20-idp', 'disableScoping', 'bool'],
+            ['additional_logging', 'saml20-idp', 'additionalLogging', 'bool'],
+            ['signature_method', 'saml20-idp', 'signatureMethod', 'string-signature-method'],
+        ];
+    }
+
+    private function validCoinValuesBool() {
+        return [
+            [null, false],
+            [true, true],
+            [false, false],
+            ["1", true],
+            ["0", false],
+            ["-1", true],
+        ];
+    }
+
+    private function validCoinValuesBoolNegative() {
+        return [
+            [null, true],
+            [true, false],
+            [false, true],
+            ["1", false],
+            ["0", true],
+            ["-1", false],
+        ];
+    }
+
+    private function validCoinValuesString() {
+        return [
+            [null, null],
+            ["", ""],
+            ["string", "string"],
+        ];
+    }
+
+    private function validCoinValuesStringSignatureMethod() {
+        return [
+            [null, "http://www.w3.org/2000/09/xmldsig#rsa-sha1"],
+            ["", ""],
+            ["string", "string"],
+        ];
+    }
+
+    private function validCoinValuesStringGuestQualifier() {
+        return [
+            [null, "All"],
+            ["", ""],
+            ["string", "string"],
         ];
     }
 }

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/ProvideConsentTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/ProvideConsentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
@@ -70,7 +71,7 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends PHPUnit_F
 
     public function testConsentIsSkippedWhenGloballyDisabled()
     {
-        $this->proxyServerMock->getRepository()->fetchServiceProviderByEntityId('testSp')->isConsentRequired = false;
+        $this->setCoin($this->proxyServerMock->getRepository()->fetchServiceProviderByEntityId('testSp'), 'isConsentRequired', false);
 
         $provideConsentService = $this->factoryService();
 
@@ -272,5 +273,21 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends PHPUnit_F
             $this->authStateHelperMock,
             $this->twig
         );
+    }
+
+    private function setCoin(ServiceProvider $sp, $key, $name)
+    {
+        $jsonData = $sp->getCoins()->toJson();
+        $data = json_decode($jsonData, true);
+        $data[$key] = $name;
+        $jsonData = json_encode($data);
+
+        $coins = Coins::fromJson($jsonData);
+
+        $object = new \ReflectionClass($sp);
+
+        $property = $object->getProperty('coins');
+        $property->setAccessible(true);
+        $property->setValue($sp, $coins);
     }
 }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
@@ -81,7 +81,7 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($identityProvider->workflowState, $cortoIdentityProvider['WorkflowState']);
         $this->assertEquals($identityProvider->guestQualifier, $cortoIdentityProvider['GuestQualifier']);
         $this->assertEquals($identityProvider->getConsentSettings()->getSpEntityIdsWithoutConsent(), $cortoIdentityProvider['SpsWithoutConsent']);
-        $this->assertEquals($identityProvider->hidden, $cortoIdentityProvider['isHidden']);
+        $this->assertEquals($identityProvider->getCoins()->hidden(), $cortoIdentityProvider['isHidden']);
         $this->assertEmpty($cortoIdentityProvider['shibmd:scopes']);
         $this->assertEquals($contact->contactType, $cortoIdentityProvider['ContactPersons'][0]['ContactType']);
         $this->assertEquals($contact->emailAddress, $cortoIdentityProvider['ContactPersons'][0]['EmailAddress']);

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
@@ -52,9 +52,9 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($serviceProvider->displayNameNl         , $cortoServiceProvider['DisplayName']['en']);
         $this->assertEquals('yes'                                   , $cortoServiceProvider['TransparentIssuer']);
         $this->assertEquals('yes'                                   , $cortoServiceProvider['DisplayUnconnectedIdpsWayf']);
-        $this->assertEquals(!$serviceProvider->isConsentRequired    , $cortoServiceProvider['NoConsentRequired']);
-        $this->assertEquals($serviceProvider->skipDenormalization   , $cortoServiceProvider['SkipDenormalization']);
-        $this->assertEquals($serviceProvider->policyEnforcementDecisionRequired   , $cortoServiceProvider['PolicyEnforcementDecisionRequired']);
+        $this->assertEquals(!$serviceProvider->getCoins()->isConsentRequired()    , $cortoServiceProvider['NoConsentRequired']);
+        $this->assertEquals($serviceProvider->getCoins()->skipDenormalization()   , $cortoServiceProvider['SkipDenormalization']);
+        $this->assertEquals($serviceProvider->getCoins()->policyEnforcementDecisionRequired()   , $cortoServiceProvider['PolicyEnforcementDecisionRequired']);
         $this->assertEquals($serviceProvider->isAttributeAggregationRequired()        , true);
         $this->assertEquals($serviceProvider->isAttributeAggregationRequired()        , $cortoServiceProvider['AttributeAggregationRequired']);
         $this->assertEquals($contact->contactType, $cortoServiceProvider['ContactPersons'][0]['ContactType']);

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
@@ -79,7 +79,7 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($cortoIdentityProvider['certificates']);
         $this->assertEquals($identityProvider->supportedNameIdFormats, $cortoIdentityProvider['NameIDFormats']);
         $this->assertEquals($identityProvider->workflowState, $cortoIdentityProvider['WorkflowState']);
-        $this->assertEquals($identityProvider->guestQualifier, $cortoIdentityProvider['GuestQualifier']);
+        $this->assertEquals($identityProvider->getCoins()->guestQualifier(), $cortoIdentityProvider['GuestQualifier']);
         $this->assertEquals($identityProvider->getConsentSettings()->getSpEntityIdsWithoutConsent(), $cortoIdentityProvider['SpsWithoutConsent']);
         $this->assertEquals($identityProvider->getCoins()->hidden(), $cortoIdentityProvider['isHidden']);
         $this->assertEmpty($cortoIdentityProvider['shibmd:scopes']);

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
@@ -6,6 +6,7 @@ use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Utils;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -16,14 +17,19 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
 {
     public function testSpDisassemble()
     {
-        $serviceProvider = new ServiceProvider('https://sp.example.edu');
-        $serviceProvider->displayNameNl = 'DisplayName';
-        $serviceProvider->displayNameEn = 'DisplayName';
-        $serviceProvider->isTransparentIssuer = true;
-        $serviceProvider->displayUnconnectedIdpsWayf = true;
-        $serviceProvider->isConsentRequired = false;
-        $serviceProvider->skipDenormalization = true;
-        $serviceProvider->policyEnforcementDecisionRequired = true;
+        $serviceProvider = Utils::instantiate(
+            ServiceProvider::class,
+            [
+                'entityId' => 'https://sp.example.edu',
+                'displayNameNl' => 'DisplayName',
+                'displayNameEn' => 'DisplayName',
+                'isTransparentIssuer' => true,
+                'displayUnconnectedIdpsWayf' => true,
+                'isConsentRequired' => false,
+                'skipDenormalization' => true,
+                'policyEnforcementDecisionRequired' => true,
+            ]
+        );
 
         // set a non-idp arp rule to enable attribute aggregation
         $serviceProvider->attributeReleasePolicy = new AttributeReleasePolicy([


### PR DESCRIPTION
Add logic to be able to persist and restore serialized coin data. This
is done to prevent extensive maintenance of migrations when a feature
is added due to rolling updates.

I've created two additional branches:
The initial validation status (feature/serialize-coins-validation):
[![Build Status](https://travis-ci.org/OpenConext/OpenConext-engineblock.svg?branch=feature%2Fserialize-coins-validation)](https://travis-ci.org/OpenConext/OpenConext-engineblock)

The cleanup on success (feature/serialize-coins-cleanup):
[![Build Status](https://travis-ci.org/OpenConext/OpenConext-engineblock.svg?branch=feature%2Fserialize-coins-cleanup)](https://travis-ci.org/OpenConext/OpenConext-engineblock)