### PR TITLE
Decrease the surfboard offset on the error page

### DIFF
--- a/theme/material/stylesheets/theme/openconext/error-page/_background.sass
+++ b/theme/material/stylesheets/theme/openconext/error-page/_background.sass
@@ -12,15 +12,14 @@
     display: none
 
   &__front
-    background: url(/images/background-front.svg) left bottom no-repeat
+    background: url(/images/background-front.svg) no-repeat left bottom
+    background-size: contain
     bottom: 0
-    left: 10%
+    left: 2%
     position: absolute
-    height: 100%
-    width: 100%
+    height: 40%
+    width: 20%
     z-index: 1
-    +max-width($large)
-      left: -8%
 
   &__back
     background: url(/images/background-back.svg) left bottom repeat-x


### PR DESCRIPTION
The surfboard could be better aligned on wide screens. The surfboard
scales better now with the use of css.

https://www.pivotaltracker.com/story/show/167202154