### PR TITLE
Increase language switch z-index on the error page

### DIFF
--- a/theme/material/stylesheets/application/base/_layout.css.sass
+++ b/theme/material/stylesheets/application/base/_layout.css.sass
@@ -1,5 +1,6 @@
 .l-container
   max-width: $container-width
+  z-index: 0
   padding: 1rem
   .lt-ie9 &
     max-width: $container-width-em

--- a/theme/material/stylesheets/shared/components/_language.css.sass
+++ b/theme/material/stylesheets/shared/components/_language.css.sass
@@ -1,4 +1,6 @@
 .comp-language
+  z-index: 10000
+  position: relative
   margin-right: 1rem
   line-height: 1.75rem
   display: flex


### PR DESCRIPTION
The language switcher lays below the page container. Therefore
the language switcher isn;t clickable on the error page. After changing
the z-index the required behaviour is restored.