### PR TITLE
Add AuthnContextClassRef attribute blacklist filter

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -162,6 +162,12 @@ pdp.password = "secret"
 pdp.client_id = "EngineBlock"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;; SFO SETTINGS ;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; This PCRE regex is used to blacklist incoming AuthnContextClassRef attributes on
+sfo.authn_context_class_ref_blacklist_regex = ""
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; PROFILE SETTINGS ;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -236,7 +236,10 @@ $ymlContent = array(
                 'attributeDefinitionFile', $projectRoot . 'application/configs/attributes-v2.2.0.json'
             )
         ),
-        'monitor_database_health_check_query'                     => $config->get('openconext.monitor_bundle_health_query', '')
+        'monitor_database_health_check_query'                     => $config->get('openconext.monitor_bundle_health_query', ''),
+
+        // SFO
+        'sfo.authn_context_class_ref_blacklist_regex'             => escapeYamlValue($config->get('sfo.authn_context_class_ref_blacklist_regex'))
     )
 );
 

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -247,6 +247,8 @@ Your %organisationNoun% has denied you access to this service. You will have to 
     'error_stuck_in_authentication_loop_desc' => '<p>
         You\'ve successfully authenticated at your Identity Provider but the service you are trying to access sends you back again to %suiteName%. Because you are already logged in, %suiteName% then forwards you back to the service, which results in an infinite black hole. Likely, this is caused by an error at the Service Provider.
     </p>',
+    'error_authn_context_class_ref_blacklisted'                     => 'Error - AuthnContextClassRef value is disallowed',
+    'error_authn_context_class_ref_blacklisted_desc'                => '<p>You cannot login because your %organisationNoun% sent a value for AuthnContextClassRef that is not allowed.</p>',
     'error_no_authentication_request_received' => 'No authentication request received.',
     /**
      * %1 AttributeName

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -244,6 +244,8 @@ Je %organisationNoun% heeft je de toegang geweigerd tot deze dienst. Je zult dus
     'error_stuck_in_authentication_loop_desc' => '<p>
         Je bent succesvol ingelogd bij je Identity Provider maar de dienst waar je naartoe wilt stuurt je weer terug naar %suiteName%. Omdat je succesvol bent ingelogd, stuurt %suiteName% je weer naar de dienst, wat resulteert in een oneindig zwart gat. Dit komt waarschijnlijk door een foutje aan de kant van de dienst.
     </p>',
+    'error_authn_context_class_ref_blacklisted'                     => 'Error - Waarde van AuthnContextClassRef is niet toegestaan',
+    'error_authn_context_class_ref_blacklisted_desc'                => '<p>Je kunt niet inloggen omdat je %organisationNoun% een waarde stuurde voor AuthnContextClassRef die niet is toegestaan.</p>',
     'error_no_authentication_request_received' => 'Geen authenticatie-aanvraag ontvangen.',
     /**
      * %1 AttributeName

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -224,6 +224,8 @@ A sua %organisationNoun% negou-lhe acesso a este serviço. Terá de entrar em co
     'error_stuck_in_authentication_loop_desc' => '<p>
         Autenticou-se com sucesso no seu Fornecedor de Identidade, mas o serviço ao qual está a tentar aceder reencaminhou-o de volta para %suiteName%. Como já está autenticado, o %suiteName% o reencaminha de volta para o serviço, o que resulta num ciclo infinito. Muito provavelmente, isto é provocado por um erro no Fornecedor de Serviço.
     </p>',
+    'error_authn_context_class_ref_blacklisted'                     => 'Erro - O valor para AuthnContextClassRef não é permitido',
+    'error_authn_context_class_ref_blacklisted_desc'                => '<p>Não pode autenticar-se porque a sua %organisationNoun% enviou um valor para AuthnContextClassRef que não é permitido.</p>',
     'error_no_authentication_request_received' => 'Nenhuma solicitação de autenticação recebida.',
     /**
      * %1 AttributeName

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -441,4 +441,12 @@ class EngineBlock_Application_DiContainer extends Pimple
     {
         return (string) $this->container->getParameter('attribute_definition_file_path');
     }
+
+    /**
+     * @return string
+     */
+    public function getAuthnContextClassRefBlacklistRegex()
+    {
+        return (string) $this->container->getParameter('sfo.authn_context_class_ref_blacklist_regex');
+    }
 }

--- a/library/EngineBlock/Application/FunctionalTestDiContainer.php
+++ b/library/EngineBlock/Application/FunctionalTestDiContainer.php
@@ -41,4 +41,9 @@ class EngineBlock_Application_FunctionalTestDiContainer extends EngineBlock_Appl
     {
         return $this->getSymfonyContainer()->get('engineblock.functional_testing.fixture.attribute_aggregation_client');
     }
+
+    public function getAuthnContextClassRefBlacklistRegex()
+    {
+        return '/invalid-authn-context-class-ref/';
+    }
 }

--- a/library/EngineBlock/Corto/Exception/AuthnContextClassRefBlacklisted.php
+++ b/library/EngineBlock/Corto/Exception/AuthnContextClassRefBlacklisted.php
@@ -1,0 +1,9 @@
+<?php
+
+class EngineBlock_Corto_Exception_AuthnContextClassRefBlacklisted extends EngineBlock_Exception
+{
+    public function __construct($message, $severity = self::CODE_NOTICE, Exception $previous = null)
+    {
+        parent::__construct($message, $severity, $previous);
+    }
+}

--- a/library/EngineBlock/Corto/Filter/Command/ValidateAuthnContextClassRef.php
+++ b/library/EngineBlock/Corto/Filter/Command/ValidateAuthnContextClassRef.php
@@ -1,0 +1,65 @@
+<?php
+
+use OpenConext\EngineBlock\Assert\Assertion;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The validator will block any incoming IdP assertion with a AuthnContextClassRef value in the configured namespace
+ * with an error. As it MUST be impossible for an IdP to 'impersonate' the blacklisted values used for AuthnContextClassRef.
+ **/
+class EngineBlock_Corto_Filter_Command_ValidateAuthnContextClassRef extends EngineBlock_Corto_Filter_Command_Abstract
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var string
+     */
+    private $authnContextClassRefBlacklistPattern;
+
+    public function __construct(LoggerInterface $logger, $authnContextClassRefBlacklistPattern)
+    {
+        Assertion::nullOrString($authnContextClassRefBlacklistPattern, 'The authnContextClassRefBlacklistPattern must be a string or null');
+
+        $this->logger = $logger;
+        $this->authnContextClassRefBlacklistPattern = $authnContextClassRefBlacklistPattern;
+    }
+
+    /**
+     * @throws EngineBlock_Corto_Exception_AuthnContextClassRefBlacklisted
+     */
+    public function execute()
+    {
+        if (empty($this->authnContextClassRefBlacklistPattern)) {
+            $this->logger->notice('No authn_context_class_ref_blacklist_regex found in the configuration, not validating AuthnContextClassRef');
+            return;
+        }
+
+        $authnContextClassRef = $this->_response->getAssertion()->getAuthnContextClassRef();
+
+        if (!$this->validateAuthnContextClassRef($authnContextClassRef, $this->authnContextClassRefBlacklistPattern)) {
+            throw new EngineBlock_Corto_Exception_AuthnContextClassRefBlacklisted(
+                sprintf(
+                    'Assertion from IdP contains a blacklisted AuthnContextClassRef "%s"',
+                    $authnContextClassRef
+                )
+            );
+        }
+    }
+
+    /**
+     * @param string $value
+     * @param string $regex
+     * @return bool
+     */
+    private function validateAuthnContextClassRef($value, $regex)
+    {
+        if (preg_match($regex, $value)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/library/EngineBlock/Corto/Filter/Input.php
+++ b/library/EngineBlock/Corto/Filter/Input.php
@@ -21,8 +21,12 @@ class EngineBlock_Corto_Filter_Input extends EngineBlock_Corto_Filter_Abstract
         $logger               = EngineBlock_ApplicationSingleton::getLog();
 
         $blockUsersOnViolation = $featureConfiguration->isEnabled('eb.block_user_on_violation');
+        $authnContextClassRefBlacklistPattern = $diContainer->getAuthnContextClassRefBlacklistRegex();
 
         $commands = array(
+            // Validate if the authnContextClassRef is not blacklisted
+            new EngineBlock_Corto_Filter_Command_ValidateAuthnContextClassRef($logger, $authnContextClassRefBlacklistPattern),
+
             // Convert all OID attributes to URN and remove the OID variant
             new EngineBlock_Corto_Filter_Command_NormalizeAttributes(),
 

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -14,6 +14,7 @@ use Twig_Environment;
 /**
  * @SuppressWarnings(PHPMD.TooManyPublicMethods) Mimics the previous methodology, will be refactored
  *  see https://www.pivotaltracker.com/story/show/107565968
+ * @SuppressWarnings(PMD.TooManyMethods)
  */
 class FeedbackController
 {
@@ -191,6 +192,17 @@ class FeedbackController
         return new Response(
             $this->twig->render('@theme/Authentication/View/Feedback/missing-required-fields.html.twig'),
             400
+        );
+    }
+
+    /**
+     * @return Response
+     */
+    public function authnContextClassRefBlacklistedAction()
+    {
+        return new Response(
+            $this->twig->render('@theme/Authentication/View/Feedback/authn-context-class-ref-blacklisted.html.twig'),
+            403
         );
     }
 

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -20,6 +20,7 @@ namespace OpenConext\EngineBlockBundle\EventListener;
 
 use EngineBlock_ApplicationSingleton;
 use EngineBlock_Attributes_Manipulator_CustomException;
+use EngineBlock_Corto_Exception_AuthnContextClassRefBlacklisted;
 use EngineBlock_Corto_Exception_InvalidAcsLocation;
 use EngineBlock_Corto_Exception_MissingRequiredFields;
 use EngineBlock_Corto_Exception_NoConsentProvided;
@@ -124,6 +125,9 @@ class RedirectToFeedbackPageExceptionListener
         } elseif ($exception instanceof EngineBlock_Corto_Exception_MissingRequiredFields) {
             $message         = 'Missing Required Fields';
             $redirectToRoute = 'authentication_feedback_missing_required_fields';
+        } elseif ($exception instanceof EngineBlock_Corto_Exception_AuthnContextClassRefBlacklisted) {
+            $message         = $exception->getMessage();
+            $redirectToRoute = 'authentication_authn_context_class_ref_blacklisted';
         } elseif ($exception instanceof EngineBlock_Attributes_Manipulator_CustomException) {
             // @todo this must be done differently, for now don't see how as state is managed by EB.
             $event->getRequest()->getSession()->set('feedback_custom', $exception->getFeedback());

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
@@ -48,6 +48,11 @@ authentication_feedback_missing_required_fields:
     methods:    [GET]
     defaults:   { _controller: engineblock.controller.authentication.feedback:missingRequiredFieldsAction }
 
+authentication_authn_context_class_ref_blacklisted:
+    path:       '/authn_context_class_ref_blacklisted'
+    methods:    [GET]
+    defaults:   { _controller: engineblock.controller.authentication.feedback:authnContextClassRefBlacklistedAction }
+
 authentication_feedback_invalid_attribute_value:
     path:       '/invalid-attribute-value'
     methods:    [GET]

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -320,6 +320,15 @@ Feature:
       # The session is lost, so the feedback information (containing the request id) can no longer be rendered on page
     Then I should not see the same request id on the error page
 
+  Scenario: I log in at my Identity Provider, that has an invalid AuthnContextClassRef attribute.
+    Given the IdP "Dummy Idp" sends AuthnContextClassRef with value "invalid-authn-context-class-ref"
+    When I log in at "Dummy SP"
+      And I pass through EngineBlock
+      And I pass through the IdP
+      And I give my consent
+    Then I should see "Error - AuthnContextClassRef value is disallowed"
+
+
 
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a location
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a binding

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -3,6 +3,7 @@
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\ServiceRegistryFixture;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\EntityRegistry;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
@@ -289,6 +290,22 @@ class MockIdpContext extends AbstractSubContext
         $mockIdp->setAttribute($attributeName, $explosion, $attributeValueType);
         $this->mockIdpRegistry->save();
     }
+
+    /**
+     * @Given /^the IdP "([^"]*)" sends AuthnContextClassRef with value "([^"]*)"$/
+     * @param string $idpName
+     * @param string $authnContextClassRefValue
+     */
+    public function theIdPSendsAuthnContextClassRefValue($idpName, $authnContextClassRefValue)
+    {
+        /** @var MockIdentityProvider $mockIdp */
+        $mockIdp = $this->mockIdpRegistry->get($idpName);
+
+        $mockIdp->setAuthnContextClassRef($authnContextClassRefValue);
+
+        $this->mockIdpRegistry->save();
+    }
+
 
     /**
      * @Given /^the IdP "([^"]*)" requires minimal consent for SP "([^"]*)"$/

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockIdentityProvider.php
@@ -9,6 +9,7 @@ use SAML2\XML\md\IDPSSODescriptor;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyPublicMethods) Allows for better control
+ * @SuppressWarnings(PMD.ExcessiveClassComplexity)
  */
 class MockIdentityProvider extends AbstractMockEntityRole
 {
@@ -234,6 +235,18 @@ class MockIdentityProvider extends AbstractMockEntityRole
 
         $assertions[0]->setAttributes($newAttributes);
     }
+
+    public function setAuthnContextClassRef($authnContextClassRefValue)
+    {
+        $role = $this->getSsoRole();
+
+        /** @var Response $response */
+        $response = $role->Extensions['SAMLResponse'];
+        $assertions = $response->getAssertions();
+
+        $assertions[0]->setAuthnContextClassRef($authnContextClassRefValue);
+    }
+
 
     public function useResponseSigning()
     {

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/ValidateAuthnContextClassRefTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/ValidateAuthnContextClassRefTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
+use PHPUnit_Framework_TestCase as UnitTest;
+use SAML2\Assertion;
+use SAML2\Response;
+
+class EngineBlock_Test_Corto_Filter_Command_ValidateAuthnContextClassRefTest extends UnitTest
+{
+    /**
+     * @var TestHandler
+     */
+    private $handler;
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @var EngineBlock_Saml2_ResponseAnnotationDecorator
+     */
+    private $response;
+
+    public function setUp()
+    {
+        $this->handler = new TestHandler();
+        $this->logger  = new Logger('Test', array($this->handler));
+
+        $assertion = new Assertion();
+        $assertion->setAuthnContextClassRef('urn:oasis:names:tc:SAML:2.0:ac:classes:Password');
+
+        $response = new Response();
+        $response->setAssertions(array($assertion));
+
+        $this->response = new EngineBlock_Saml2_ResponseAnnotationDecorator($response);
+    }
+
+    public function testNoConfiguredBlacklistRegexLeadsToNoValidation()
+    {
+        $verifier = new EngineBlock_Corto_Filter_Command_ValidateAuthnContextClassRef($this->logger, '');
+        $verifier->setResponse($this->response);
+        $verifier->setIdentityProvider(new IdentityProvider('OpenConext'));
+
+        $verifier->execute();
+
+        $notConfiguredMessageLogged = $this->handler->hasNotice(
+            'No authn_context_class_ref_blacklist_regex found in the configuration, not validating AuthnContextClassRef'
+        );
+
+        $this->assertTrue($notConfiguredMessageLogged, 'Logging that no shibmd:scope is configured is required');
+    }
+
+    public function testNotMatchedBlacklistedRegexpPasses()
+    {
+        $verifier = new EngineBlock_Corto_Filter_Command_ValidateAuthnContextClassRef($this->logger, '/test/');
+        $verifier->setResponse($this->response);
+        $verifier->setIdentityProvider(new IdentityProvider('OpenConext'));
+
+        $verifier->execute();
+    }
+
+    public function testMatchedBlacklistedRegexpThrowsException()
+    {
+        $this->expectException(EngineBlock_Corto_Exception_AuthnContextClassRefBlacklisted::class);
+        $this->expectExceptionMessage('Assertion from IdP contains a blacklisted AuthnContextClassRef "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"');
+
+        $verifier = new EngineBlock_Corto_Filter_Command_ValidateAuthnContextClassRef($this->logger, '/urn:oasis:names:tc:SAML:2\.0:ac:classes:Password/');
+        $verifier->setResponse($this->response);
+        $verifier->setIdentityProvider(new IdentityProvider('OpenConext'));
+
+        $verifier->execute();
+    }
+}

--- a/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
+++ b/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
@@ -96,6 +96,10 @@ const errorPages = [
     {
         name: 'uncaught-error',
         url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=feedback_unknown_error&feedback-info={"requestId":"5cb4bd3879b49","artCode":"31914", "ipAddress":"192.168.66.98","serviceProvider":"https://current-sp.entity-id.org/metadata","serviceProviderName":"OpenConext Drop Supplies SP","identityProvider":"https://current-idp.entity-id.org/metadata"}'
+    },
+    {
+        name: 'authn-context-class-ref-blacklisted',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=authn-context-class-ref-blacklisted&feedback-info={"requestId":"5cb4bd3879b49","artCode":"31914", "ipAddress":"192.168.66.98","serviceProvider":"https://current-sp.entity-id.org/metadata","serviceProviderName":"OpenConext Drop Supplies SP","identityProvider":"https://current-idp.entity-id.org/metadata"}'
     }
 ];
 

--- a/theme/material/templates/modules/Authentication/View/Feedback/authn-context-class-ref-blacklisted.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/authn-context-class-ref-blacklisted.html.twig
@@ -1,0 +1,8 @@
+{% extends '@theme/Default/View/Error/error.html.twig' %}
+
+{% set pageTitle = 'error_authn_context_class_ref_blacklisted'|trans %}
+{% block pageTitle %}{{ pageTitle }}{% endblock %}
+{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block pageHeading %}{{ pageTitle }}{% endblock %}
+
+{% block errorMessage %}{{ 'error_authn_context_class_ref_blacklisted_desc'|trans|raw }}{% endblock %}


### PR DESCRIPTION
Add a configurable regex filter to be able to blacklist certain AuthnContextClassRef attribute values. This will be used to prevent the use of internally used attributes by IdP's other than EngineBlock. And to allow second factor only (SFO) flow in EB.

Also created a [PR](https://github.com/OpenConext/OpenConext-deploy/pull/237) to support the configuration parameter in deploy.

See: https://www.pivotaltracker.com/story/show/166702153