### PR TITLE
Hide language switch on 400 and 405 page

### DIFF
--- a/theme/material/templates/modules/Default/View/Error/method-not-allowed.html.twig
+++ b/theme/material/templates/modules/Default/View/Error/method-not-allowed.html.twig
@@ -3,8 +3,10 @@
 {# Prepare the page title #}
 {% set pageTitle = 'error_405'|trans %}
 
-{% block content %}
+{% block languageSwitcher %}
+{% endblock %}
 
+{% block content %}
 <div class="error-container">
 
   <div class="error-container__content">

--- a/theme/material/templates/modules/Default/View/Error/not-found.html.twig
+++ b/theme/material/templates/modules/Default/View/Error/not-found.html.twig
@@ -3,6 +3,9 @@
 {# Prepare the page title #}
 {% set pageTitle = 'error_404'|trans %}
 
+{% block languageSwitcher %}
+{% endblock %}
+
 {% block content %}
   <div class="error-container">
 


### PR DESCRIPTION
The language switch is hidden because it will not work out of the box
because the lang parameter is read from the request but the parameters
are empty when on a 404 page.

See: https://www.pivotaltracker.com/story/show/167202103/comments/204653786