### PR TITLE
Create gateway SFO mock

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/SfoMockController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/SfoMockController.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Controllers;
+
+use Exception;
+use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockSfoGateway;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Twig_Environment;
+
+class SfoMockController extends Controller
+{
+    const PARAMETER_REQUEST = 'SAMLRequest';
+    const PARAMETER_RELAY_STATE = 'RelayState';
+
+    /**
+     * @var MockSfoGateway
+     */
+    private $mockSfoGateway;
+    /**
+     * @var Twig_Environment
+     */
+    private $twig;
+
+    public function __construct(MockSfoGateway $mockSfoGateway, Twig_Environment $twig)
+    {
+        $this->mockSfoGateway = $mockSfoGateway;
+        $this->twig = $twig;
+    }
+
+    /**
+     * @param Request $request
+     * @return string|Response
+     */
+    public function ssoAction(Request $request)
+    {
+        try {
+            // Check binding
+            if (!$request->isMethod(Request::METHOD_POST)) {
+                throw new BadRequestHttpException(sprintf(
+                    'Could not receive AuthnRequest from HTTP Request: expected a POST method, got %s',
+                    $request->getMethod()
+                ));
+            }
+
+            // Decode samlrequest
+            $decodedSamlRequest = base64_decode($request->request->get(self::PARAMETER_REQUEST), true);
+
+            // Parse request
+            $samlResponse = $this->mockSfoGateway->handleSso($decodedSamlRequest, $this->getFullRequestUri($request));
+            $rawResponse = $this->mockSfoGateway->parsePostResponse($samlResponse);
+            $relayState = $request->request->get(self::PARAMETER_RELAY_STATE);
+
+            // Encode response
+            $encodedResponse = base64_encode($rawResponse);
+
+            // Present response
+            return $this->twig->render(
+                'EngineBlockFunctionalTestingBundle:Sso:consumeAssertion.html.twig',
+                [
+                    'acu' => $samlResponse->getDestination(),
+                    'response' => $encodedResponse,
+                    'relayState' => $relayState
+                ]
+            );
+        } catch (BadRequestHttpException $e) {
+            return new Response($e->getMessage(), $e->getStatusCode());
+        } catch (Exception $e) {
+            return new Response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     */
+    private function getFullRequestUri(Request $request)
+    {
+        return $request->getSchemeAndHttpHost() . $request->getBasePath() . $request->getRequestUri();
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/SfoContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/SfoContext.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
+
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingSfoGatewayMockConfiguration;
+use OpenConext\EngineBlockFunctionalTestingBundle\Mock\EntityRegistry;
+use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProviderFactory;
+use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockServiceProviderFactory;
+use SAML2\Constants;
+
+class SfoContext extends AbstractSubContext
+{
+    /**
+     * @var EntityRegistry
+     */
+    private $mockSpRegistry;
+    /**
+     * @var EntityRegistry
+     */
+    private $mockIdpRegistry;
+    /**
+     * @var FunctionalTestingSfoGatewayMockConfiguration
+     */
+    private $gatewayMockConfiguration;
+    /**
+     * @var MockIdentityProviderFactory
+     */
+    private $idpFactory;
+    /**
+     * @var MockServiceProviderFactory
+     */
+    private $spFactory;
+
+    /**
+     * @param EntityRegistry $mockSpRegistry
+     * @param EntityRegistry $mockIdpRegistry
+     * @param MockIdentityProviderFactory $idpFactory
+     * @param MockServiceProviderFactory $spFactory
+     * @param FunctionalTestingSfoGatewayMockConfiguration $gatewayMockConfiguration
+     */
+    public function __construct(
+        EntityRegistry $mockSpRegistry,
+        EntityRegistry $mockIdpRegistry,
+        MockIdentityProviderFactory $idpFactory,
+        MockServiceProviderFactory $spFactory,
+        FunctionalTestingSfoGatewayMockConfiguration $gatewayMockConfiguration
+    ) {
+        $this->mockSpRegistry = $mockSpRegistry;
+        $this->mockIdpRegistry = $mockIdpRegistry;
+        $this->gatewayMockConfiguration = $gatewayMockConfiguration;
+        $this->idpFactory = $idpFactory;
+        $this->spFactory = $spFactory;
+    }
+
+    /**
+     * @Given /^SFO is used$/
+     */
+    public function sfoIsUsed()
+    {
+        $mockIdp = $this->idpFactory->createNew('sfoHostedIdp');
+        $this->gatewayMockConfiguration->setMockIdentityProvider($mockIdp);
+
+        $mockSp = $this->spFactory->createNew('ebSfoSp');
+        $this->gatewayMockConfiguration->setMockServiceProvider($mockSp);
+    }
+
+    /**
+     * @Given /^SFO will successfully verify a user$/
+     */
+    public function sfoWillsSuccessfullyVerifyAUser()
+    {
+        $this->gatewayMockConfiguration->unsetMessage();
+    }
+
+    /**
+     * @Given /^SFO will fail as the user cancelled$/
+     */
+    public function sfoWillFailAsTheUserCancelled()
+    {
+        $this->gatewayMockConfiguration->setMessage(Constants::STATUS_RESPONDER, Constants::STATUS_AUTHN_FAILED, 'Authentication cancelled by user');
+    }
+
+    /**
+     * @Given /^SFO will fail as the loa can not be given$/
+     */
+    public function sfoWillFailAsTheLoaCanNotBeGiven()
+    {
+        $this->gatewayMockConfiguration->setMessage(Constants::STATUS_RESPONDER, Constants::STATUS_NO_AUTHN_CONTEXT);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Sfo.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Sfo.feature
@@ -1,0 +1,21 @@
+Feature:
+  In order to support 2FA we need to support gateway interactions
+  As EngineBlock
+  I want to support 2FA by utilizing the Stepup gateway SFO capabilities
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+      And no registered SPs
+      And no registered Idps
+      And an Identity Provider named "SSO-IdP"
+      And an Identity Provider named "SSO-Foobar"
+      And a Service Provider named "SSO-SP"
+      And a Service Provider named "SSO-Foobar"
+
+  Scenario: Sfo should be supported
+    When SFO is used
+     And SFO will successfully verify a user
+     And I log in at "SSO-SP"
+     And I select "SSO-IdP" on the WAYF
+     And I pass through EngineBlock
+    Then the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:NameIDPolicy[@AllowCreate="true" or @AllowCreate="1"]'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingSfoGatewayMockConfiguration.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingSfoGatewayMockConfiguration.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
+
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\AbstractDataStore;
+use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
+use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockServiceProvider;
+use RuntimeException;
+
+final class FunctionalTestingSfoGatewayMockConfiguration
+{
+    /**
+     * @var MockIdentityProvider|null
+     */
+    private $mockIdentityProvider = null;
+
+    /**
+     * @var MockServiceProvider|null
+     */
+    private $mockServiceProvider = null;
+
+    /**
+     * @var null|string
+     */
+    private $messageStatus = null;
+
+    /**
+     * @var null|string
+     */
+    private $messageSubStatus = null;
+
+    /**
+     * @var null|string
+     */
+    private $messageMessage = null;
+
+    /**
+     * @var AbstractDataStore
+     */
+    private $dataStore;
+
+    public function __construct(AbstractDataStore $dataStore)
+    {
+        $this->dataStore            = $dataStore;
+
+        $data = $dataStore->load();
+        $this->mockIdentityProvider = (isset($data['idp']) ? $data['idp'] : null);
+        $this->mockServiceProvider = (isset($data['sp']) ? $data['sp'] : null);
+
+        $this->messageStatus = (isset($data['messageStatus']) ? $data['messageStatus'] : []);
+        $this->messageSubStatus = (isset($data['messageSubStatus']) ? $data['messageSubStatus'] : []);
+        $this->messageMessage = (isset($data['messageMessage']) ? $data['messageMessage'] : []);
+    }
+
+    /**
+     * @return MockIdentityProvider|null
+     */
+    public function getMockIdentityProvider()
+    {
+        return $this->mockIdentityProvider;
+    }
+
+    /**
+     * @param MockIdentityProvider|null $mockIdentityProvider
+     */
+    public function setMockIdentityProvider($mockIdentityProvider)
+    {
+        $this->mockIdentityProvider = $mockIdentityProvider;
+    }
+
+    /**
+     * @return MockServiceProvider|null
+     */
+    public function getMockServiceProvider()
+    {
+        return $this->mockServiceProvider;
+    }
+
+    /**
+     * @param MockServiceProvider|null $mockServiceProvider
+     */
+    public function setMockServiceProvider($mockServiceProvider)
+    {
+        $this->mockServiceProvider = $mockServiceProvider;
+    }
+
+    /**
+     * @param $status
+     * @param null $subStatus
+     * @param array $message
+     */
+    public function setMessage($status, $subStatus = null, $message = null)
+    {
+        $this->messageStatus = $status;
+        $this->messageSubStatus = $subStatus;
+        $this->messageMessage = $message;
+    }
+
+    public function unsetMessage()
+    {
+        $this->messageStatus = null;
+        $this->messageSubStatus = null;
+        $this->messageMessage = null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStatus()
+    {
+        return $this->messageStatus;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSubStatus()
+    {
+        return $this->messageSubStatus;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMessage()
+    {
+        return $this->messageMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasFailure()
+    {
+        return !is_null($this->messageStatus);
+    }
+
+    public function save()
+    {
+        $data = [
+            'idp' => $this->mockIdentityProvider,
+            'sp' => $this->mockServiceProvider,
+            'messageStatus' => $this->messageStatus,
+            'messageSubStatus' => $this->messageSubStatus,
+            'messageMessage' => $this->messageMessage,
+        ];
+
+        $this->dataStore->save($data);
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockSfoGateway.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockSfoGateway.php
@@ -1,0 +1,408 @@
+<?php
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockFunctionalTestingBundle\Mock;
+
+use DateTime;
+use LogicException;
+use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingSfoGatewayMockConfiguration;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RuntimeException;
+use SAML2\Assertion;
+use SAML2\AuthnRequest as SAML2AuthnRequest;
+use SAML2\Constants;
+use SAML2\DOMDocumentFactory;
+use SAML2\Message;
+use SAML2\Response;
+use SAML2\XML\saml\SubjectConfirmation;
+use SAML2\XML\saml\SubjectConfirmationData;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class MockSfoGateway
+{
+    /**
+     * @var DateTime
+     */
+    private $currentTime;
+
+    /**
+     * @var FunctionalTestingSfoGatewayMockConfiguration
+     */
+    private $gatewayConfiguration;
+
+    /**
+     * @param FunctionalTestingSfoGatewayMockConfiguration $gatewayConfiguration
+     * @throws \Exception
+     */
+    public function __construct(
+        FunctionalTestingSfoGatewayMockConfiguration $gatewayConfiguration
+    ) {
+        $this->gatewayConfiguration = $gatewayConfiguration;
+        $this->currentTime = new DateTime();
+    }
+
+    /**
+     * @param string $samlRequest
+     * @param string $fullRequestUri
+     * @return Response
+     * @throws \Exception
+     */
+    public function handleSso($samlRequest, $fullRequestUri)
+    {
+        // parse the authnRequest
+        $authnRequest = $this->parsePostRequest($samlRequest, $fullRequestUri);
+
+        // get parameters from authnRequest
+        $nameId = $authnRequest->getNameId()->value;
+        $destination = $authnRequest->getDestination();
+        $authnContextClassRef = $authnRequest->getRequestedAuthnContext()['AuthnContextClassRef'];
+        $requesterId = current($authnRequest->getRequesterID());
+
+        // handle failure
+        if ($this->gatewayConfiguration->hasFailure()) {
+            $status = $this->gatewayConfiguration->getStatus();
+            $subStatus = $this->gatewayConfiguration->getSubStatus();
+            $message = $this->gatewayConfiguration->getMessage();
+
+            return $this->createFailureResponse($destination, $requesterId, $status, $subStatus, $message);
+        }
+
+        // handle success
+        return $this->createSecondFactorOnlyResponse(
+            $nameId,
+            $destination,
+            $authnContextClassRef,
+            $requesterId
+        );
+    }
+
+    /**
+     * @param string $nameId
+     * @param string $destination The ACS location
+     * @param string|null $authnContextClassRef The loa level
+     * @param string $requestId The requestId
+     * @return Response
+     */
+    private function createSecondFactorOnlyResponse($nameId, $destination, $authnContextClassRef, $requestId)
+    {
+        return $this->createNewAuthnResponse(
+            $this->createNewAssertion(
+                $nameId,
+                $authnContextClassRef,
+                $destination,
+                $requestId
+            ),
+            $destination,
+            $requestId
+        );
+    }
+
+    /**
+     * @param string $samlRequest
+     * @param string $fullRequestUri
+     * @return SAML2AuthnRequest
+     * @throws \Exception
+     */
+    private function parsePostRequest($samlRequest, $fullRequestUri)
+    {
+        // 1. Parse to xml object
+        // additional security against XXE Processing vulnerability
+        $previous = libxml_disable_entity_loader(true);
+        $document = DOMDocumentFactory::fromString($samlRequest);
+        libxml_disable_entity_loader($previous);
+
+        // 2. Parse saml request
+        $authnRequest = Message::fromXML($document->firstChild);
+
+        if (!$authnRequest instanceof SAML2AuthnRequest) {
+            throw new RuntimeException(sprintf(
+                'The received request is not an AuthnRequest, "%s" received instead',
+                substr(get_class($authnRequest), strrpos($authnRequest, '_') + 1)
+            ));
+        }
+
+        // 3. Validate destination
+        if (!$authnRequest->getDestination() === $fullRequestUri) {
+            throw new BadRequestHttpException(sprintf(
+                'Actual Destination "%s" does not match the AuthnRequest Destination "%s"',
+                $fullRequestUri,
+                $authnRequest->getDestination()
+            ));
+        }
+
+        // 4. Validate issuer
+        if (!$this->getServiceProvider()->entityId() !== $authnRequest->getIssuer()) {
+            throw new BadRequestHttpException(sprintf(
+                'Actual issuer "%s" does not match the AuthnRequest Issuer "%s"',
+                $this->getServiceProvider()->entityId(),
+                $authnRequest->getIssuer()
+            ));
+        }
+
+        // 5. Validate key
+        // Note: $authnRequest->validate throws an Exception when the signature does not match.
+        $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
+        $key->loadKey($this->getServiceProvider()->publicKeyCertData());
+        if (!$authnRequest->validate($key)) {
+            throw new BadRequestHttpException(
+                'Validation of the signature in the AuthnRequest failed'
+            );
+        }
+
+        return $authnRequest;
+    }
+
+    /**
+     * @param Response $response
+     * @return string
+     */
+    public function parsePostResponse(Response $response)
+    {
+        return $response->toUnsignedXML()->ownerDocument->saveXML();
+    }
+
+    /**
+     * @param string $destination The ACS location
+     * @param string $requestId The requestId
+     * @param string $status The response status (see \SAML2\Constants)
+     * @param string|null $subStatus An optional substatus (see \SAML2\Constants)
+     * @param string|null $message The textual message
+     * @return Response
+     */
+    private function createFailureResponse($destination, $requestId, $status, $subStatus = null, $message = null)
+    {
+        $response = new Response();
+        $response->setDestination($destination);
+        $response->setIssuer($this->getIdentityProvider()->entityId());
+        $response->setIssueInstant($this->getTimestamp());
+        $response->setInResponseTo($requestId);
+
+
+        if (!$this->isValidResponseStatus($status)) {
+            throw new LogicException(sprintf('Trying to set invalid Response Status'));
+        }
+
+        if ($subStatus && !$this->isValidResponseSubStatus($subStatus)) {
+            throw new LogicException(sprintf('Trying to set invalid Response SubStatus'));
+        }
+
+        $status = ['Code' => $status];
+        if ($subStatus) {
+            $status['SubCode'] = $subStatus;
+        }
+        if ($message) {
+            $status['Message'] = $message;
+        }
+
+        $response->setStatus($status);
+
+        return $response;
+    }
+
+    /**
+     * @param Response $response
+     * @return string
+     */
+    public function getResponseAsXML(Response $response)
+    {
+        return base64_encode($response->toUnsignedXML()->ownerDocument->saveXML());
+    }
+
+    /**
+     * @param Assertion $newAssertion
+     * @param string $destination The ACS location
+     * @param string $requestId The requestId
+     * @return Response
+     */
+    private function createNewAuthnResponse(Assertion $newAssertion, $destination, $requestId)
+    {
+        $response = new Response();
+        $response->setAssertions([$newAssertion]);
+        $response->setIssuer($this->getIdentityProvider()->entityId());
+        $response->setIssueInstant($this->getTimestamp());
+        $response->setDestination($destination);
+        $response->setInResponseTo($requestId);
+
+        return $response;
+    }
+
+    /**
+     * @param string $nameId
+     * @param string $authnContextClassRef
+     * @param string $destination The ACS location
+     * @param string $requestId The requestId
+     * @return Assertion
+     */
+    private function createNewAssertion($nameId, $authnContextClassRef, $destination, $requestId)
+    {
+        $newAssertion = new Assertion();
+        $newAssertion->setNotBefore($this->currentTime->getTimestamp());
+        $newAssertion->setNotOnOrAfter($this->getTimestamp('PT5M'));
+        $newAssertion->setIssuer($this->getIdentityProvider()->entityId());
+        $newAssertion->setIssueInstant($this->getTimestamp());
+        $this->signAssertion($newAssertion);
+        $this->addSubjectConfirmationFor($newAssertion, $destination, $requestId);
+        $newAssertion->setNameId([
+            'Format' => Constants::NAMEID_UNSPECIFIED,
+            'Value' => $nameId,
+        ]);
+        $newAssertion->setValidAudiences([$this->getServiceProvider()->entityId()]);
+        $this->addAuthenticationStatementTo($newAssertion, $authnContextClassRef);
+
+        return $newAssertion;
+    }
+
+    /**
+     * @param Assertion $newAssertion
+     * @param string $destination The ACS location
+     * @param string $requestId The requestId
+     */
+    private function addSubjectConfirmationFor(Assertion $newAssertion, $destination, $requestId)
+    {
+        $confirmation         = new SubjectConfirmation();
+        $confirmation->Method = Constants::CM_BEARER;
+
+        $confirmationData                      = new SubjectConfirmationData();
+        $confirmationData->InResponseTo        = $requestId;
+        $confirmationData->Recipient           = $destination;
+        $confirmationData->NotOnOrAfter        = $newAssertion->getNotOnOrAfter();
+
+        $confirmation->SubjectConfirmationData = $confirmationData;
+
+        $newAssertion->setSubjectConfirmation([$confirmation]);
+    }
+
+    /**
+     * @param Assertion $assertion
+     * @param $authnContextClassRef
+     */
+    private function addAuthenticationStatementTo(Assertion $assertion, $authnContextClassRef)
+    {
+        $assertion->setAuthnInstant($this->getTimestamp());
+        $assertion->setAuthnContextClassRef($authnContextClassRef);
+        $assertion->setAuthenticatingAuthority([$this->getIdentityProvider()->entityId()]);
+    }
+
+    /**
+     * @param string $interval a \DateInterval compatible interval to skew the time with
+     * @return int
+     */
+    private function getTimestamp($interval = null)
+    {
+        $time = clone $this->currentTime;
+
+        if ($interval) {
+            $time->add(new \DateInterval($interval));
+        }
+
+        return $time->getTimestamp();
+    }
+
+    /**
+     * @param Assertion $assertion
+     * @return Assertion
+     */
+    private function signAssertion(Assertion $assertion)
+    {
+        $assertion->setSignatureKey($this->loadPrivateKey());
+        $assertion->setCertificates([$this->getPublicCertificate()]);
+
+        return $assertion;
+    }
+
+    /**
+     * @return XMLSecurityKey
+     */
+    private function loadPrivateKey()
+    {
+        $xmlSecurityKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
+        $xmlSecurityKey->loadKey($this->getIdentityProvider()->getPrivateKeyPem());
+
+        return $xmlSecurityKey;
+    }
+
+    /**
+     * @return string
+     */
+    private function getPublicCertificate()
+    {
+        return $this->getIdentityProvider()->publicKeyCertData();
+    }
+
+    private function isValidResponseStatus($status)
+    {
+        return in_array($status, [
+            Constants::STATUS_SUCCESS,            // weeee!
+            Constants::STATUS_REQUESTER,          // Something is wrong with the AuthnRequest
+            Constants::STATUS_RESPONDER,          // Something went wrong with the Response
+            Constants::STATUS_VERSION_MISMATCH,   // The version of the request message was incorrect
+        ]);
+    }
+
+    private function isValidResponseSubStatus($subStatus)
+    {
+        return in_array($subStatus, [
+            Constants::STATUS_AUTHN_FAILED,               // failed authentication
+            Constants::STATUS_INVALID_ATTR,
+            Constants::STATUS_INVALID_NAMEID_POLICY,
+            Constants::STATUS_NO_AUTHN_CONTEXT,           // insufficient Loa or Loa cannot be met
+            Constants::STATUS_NO_AVAILABLE_IDP,
+            Constants::STATUS_NO_PASSIVE,
+            Constants::STATUS_NO_SUPPORTED_IDP,
+            Constants::STATUS_PARTIAL_LOGOUT,
+            Constants::STATUS_PROXY_COUNT_EXCEEDED,
+            Constants::STATUS_REQUEST_DENIED,
+            Constants::STATUS_REQUEST_UNSUPPORTED,
+            Constants::STATUS_REQUEST_VERSION_DEPRECATED,
+            Constants::STATUS_REQUEST_VERSION_TOO_HIGH,
+            Constants::STATUS_REQUEST_VERSION_TOO_LOW,
+            Constants::STATUS_RESOURCE_NOT_RECOGNIZED,
+            Constants::STATUS_TOO_MANY_RESPONSES,
+            Constants::STATUS_UNKNOWN_ATTR_PROFILE,
+            Constants::STATUS_UNKNOWN_PRINCIPAL,
+            Constants::STATUS_UNSUPPORTED_BINDING,
+        ]);
+    }
+
+    /**
+     * @return MockIdentityProvider
+     */
+    private function getIdentityProvider()
+    {
+        $identityProvider = $this->gatewayConfiguration->getMockIdentityProvider();
+        if (!$identityProvider) {
+            throw new RuntimeException('No hosted IDP configured in gateway mock');
+        }
+        return $identityProvider;
+    }
+
+    /**
+     * @return MockServiceProvider
+     */
+    private function getServiceProvider()
+    {
+        $serviceProvider = $this->gatewayConfiguration->getMockServiceProvider();
+        if (!$serviceProvider) {
+            throw new RuntimeException('No hosted IDP configured in gateway mock');
+        }
+
+        return $serviceProvider;
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/controllers.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/controllers.yml
@@ -23,3 +23,9 @@ services:
             - "@translator"
             - "@twig"
             - "@engineblock.compat.logger"
+
+    engineblock.functional_test.controller.sfo_mock:
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Controllers\SfoMockController
+        arguments:
+            - "@engineblock.mock_clients.mock_sfo_gateway"
+            - "@twig"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/mocks.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/mocks.yml
@@ -25,3 +25,8 @@ services:
     engineblock.mock_entities.data_store.mock_sps:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\SerializedDataStore
         arguments: ['%sp_fixture_file%']
+
+    engineblock.mock_clients.mock_sfo_gateway:
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockSfoGateway
+        arguments:
+            - "@engineblock.functional_testing.fixture.sfo_gateway_mock"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/routing.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/routing.yml
@@ -49,3 +49,8 @@ functional_testing_feedback:
     path: "/feedback"
     defaults:
         _controller: engineblock.functional_test.controller.feedback:feedbackAction
+
+functional_testing_gateway:
+    path: "/gateway/second-factor-only/single-sign-on"
+    defaults:
+        _controller: engineblock.functional_test.controller.sfo_mock:ssoAction

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
@@ -5,6 +5,7 @@ parameters:
     engineblock.functional_testing.authentication_loop_guard_data_store.file: "%kernel.root_dir%/../tmp/eb-fixtures/authentication-loop-guard.json"
     engineblock.functional_testing.pdp_data_store.file:                       "%kernel.root_dir%/../tmp/eb-fixtures/policy_decision.json"
     engineblock.functional_testing.attribute_aggregation_data_store.file:     "%kernel.root_dir%/../tmp/eb-fixtures/attribute_aggregation.json"
+    engineblock.functional_testing.sfo_gateway_mock_data_store.file:          "%kernel.root_dir%/../tmp/eb-fixtures/sfo_gateway_mock.json"
 
 services:
     engineblock.functional_testing.service.engine_block:
@@ -45,6 +46,11 @@ services:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingAttributeAggregationClient
         arguments:
             - '@engineblock.function_testing.data_store.attribute_aggregation_client'
+
+    engineblock.functional_testing.fixture.sfo_gateway_mock:
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingSfoGatewayMockConfiguration
+        arguments:
+        - '@engineblock.function_testing.data_store.sfo_gateway_mock'
     #endregion Fixtures
 
     #region Data Stores
@@ -67,6 +73,12 @@ services:
     engineblock.function_testing.data_store.attribute_aggregation_client:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore
         arguments: ['%engineblock.functional_testing.attribute_aggregation_data_store.file%']
+
+    engineblock.function_testing.data_store.sfo_gateway_mock:
+        class: OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\DataStore\JsonDataStore
+        arguments: ['%engineblock.functional_testing.sfo_gateway_mock_data_store.file%']
+
+
     #endregion Data Stores
 
     # test stand ins

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/views/Sso/consumeAssertion.html.twig
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/views/Sso/consumeAssertion.html.twig
@@ -1,0 +1,32 @@
+{% extends '::base.html.twig' %}
+{% block head_style %}
+    {% stylesheets
+        '@SurfnetStepupGatewayGatewayBundle/Resources/public/css/hiddensubmit.css' %}
+    <link href="{{ asset_url }}" type="text/css" rel="stylesheet" media="screen"/>
+    {% endstylesheets %}
+{% endblock head_style %}
+{% block head_script %}
+    {% javascripts
+    '@SurfnetStepupGatewayGatewayBundle/Resources/public/js/submitonload.js'%}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock head_script %}
+
+{% block page_title %}{{ 'gateway.gateway.consume_assertion.title'|trans }}{% endblock %}
+
+{% block body %}
+    <noscript>
+        <b>Note: </b> javascript is disabled, please click the button below to proceed
+    </noscript>
+    One moment please...
+    <form method="post" action="{{ acu }}">
+        <input type="hidden" name="SAMLResponse" value="{{ response }}" />
+    {% if relayState|length > 0 %}
+        <input type="hidden" name="RelayState" value="{{ relayState|escape }}" />
+    {% endif %}
+        <input type="submit" class="hidden" />
+    <noscript>
+        <input type="submit" value="Submit"/>
+    </noscript>
+    </form>
+{% endblock %}

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -32,6 +32,12 @@ default:
                     mockSpFactory: '@engineblock.mock_entities.sp_factory'
                     mockSpRegistry: '@engineblock.mock_entities.sp_registry'
                     mockIdpRegistry: '@engineblock.mock_entities.idp_registry'
+                - OpenConext\EngineBlockFunctionalTestingBundle\Features\Context\SfoContext:
+                    mockSpRegistry: '@engineblock.mock_entities.sp_registry'
+                    mockIdpRegistry: '@engineblock.mock_entities.idp_registry'
+                    idpFactory: '@engineblock.mock_entities.idp_factory'
+                    spFactory: '@engineblock.mock_entities.sp_factory'
+                    gatewayMockConfiguration: '@engineblock.functional_testing.fixture.sfo_gateway_mock'
                 - OpenConext\EngineBlockFunctionalTestingBundle\Features\Context\MinkContext
         selenium:
             paths:


### PR DESCRIPTION
In order to test the SFO functionality in EB a gateway mock is needed.
Therefore a new endpoint is created in the functional testing bundle.
The results could be mocked in order to fake the possible SFO results.

`functional-testing/gateway/second-factor-only/single-sign-on`