### PR TITLE
Improve PDP error screen styling

### DIFF
--- a/theme/material/stylesheets/error-page/modules/_error-title.sass
+++ b/theme/material/stylesheets/error-page/modules/_error-title.sass
@@ -14,6 +14,11 @@
     font-weight: bold
     line-height: 1.5em
     text-align: justify
+    &--institution
+      font-weight: normal
+      font-style: italic
+      margin-bottom: 1em
+
     h2
       line-height: 3em
     i

--- a/theme/material/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
@@ -8,7 +8,7 @@
 
 {% block errorMessage %}
 
-    {{ 'error_authorization_policy_violation_info'|trans|raw }}
+    <h2>{{ 'error_authorization_policy_violation_info'|trans|raw }}</h2>
 
     {% if logo is not null %}
         <img src="{{ logo.url }}"
@@ -19,9 +19,15 @@
     {% endif %}
 
     {% if policyDecisionMessage is not null %}
-        <h2>{{ policyDecisionMessage }}</h2>
+        <p class="error-title__error-message--institution">{{ policyDecisionMessage }}</p>
+
+        <div class="horizontal-rule">
+            <hr class="horizontal-rule__line">
+        </div>
+
     {% endif %}
     {{ 'error_authorization_policy_violation_desc'|trans|raw }}
+
 {% endblock %}
 
 {# The PDP error page should not show the table with the feedback information and back button. #}


### PR DESCRIPTION
The HR is now always shown on the error page

The institution message is styled to be non-bold and italic. This makes
it far more distinctive.

Finally only the 'error_authorization_policy_violation_info' is rendered
in a h2 element. The error_authorization_policy_violation_desc is no
longer wrapped in a h2.

[Discussion and more details in Pivotal](https://www.pivotaltracker.com/story/show/167451965)

![Screenshot_2019-08-13 OpenConext - Error - No access(2)](https://user-images.githubusercontent.com/28252948/62950485-6c62fe00-bde8-11e9-9f51-b727ba802efc.png)
