### PR TITLE
Add Sfo/2fa documentation

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -164,13 +164,19 @@ pdp.client_id = "EngineBlock"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; SFO SETTINGS ;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; This PCRE regex is used to blacklist incoming AuthnContextClassRef attributes on
+;; This PCRE regex is used to blacklist incoming AuthnContextClassRef attributes on. If an empty string is used
+;; the validation is skipped. The validator will throw an exception if the used regex is invalid.
 sfo.authn_context_class_ref_blacklist_regex = "/http:\/\/test\.openconext\.nl\/assurance\/loa[1-3]/"
+;; The loa mapping from the internal used LoA's to the Stepup Gateway LOA's
 sfo.gateway.loa.mapping[http://test.openconext.nl/assurance/loa2] = "https://gateway.tld/authentication/loa2"
 sfo.gateway.loa.mapping[http://test.openconext.nl/assurance/loa3] = "https://gateway.tld/authentication/loa3"
+;; The fallback LoA to return when the Stepup authentication fails but is not required
 sfo.gateway.loa.loa1 = "https://gateway.tld/authentication/loa1"
+;; The EntityId (metadata URL) used in the callout to the SFO endpoint of the configured Stepup Gateway
 sfo.gateway.sso.entityId = "https://engine.vm.openconext.org/authentication/sfo/metadata"
+;; The single sign-on endpoint used for Stepup Gateway SFO callouts
 sfo.gateway.sso.ssoLocation = "https://engine.vm.openconext.org/functional-testing/gateway/second-factor-only/single-sign-on"
+;; The public key from the Stepup Gateway IdP
 sfo.gateway.sso.keyFile = "/etc/openconext/engineblock.crt"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/docs/filter_commands.md
+++ b/docs/filter_commands.md
@@ -93,7 +93,7 @@ Modifies:
 log a warning if received `schacHomeOrganization` is not allowed by the configured shibmd:scopes for the used IdP.
 Log a notice otherwise.
 
-If the `eb.block_user_on_violation` feature toggle however is set it will throw an exception which will prevent access.
+If however the eb.block_user_on_violation feature toggle is set, it will throw an exception which will prevent access.
 
 Uses:
 - EngineBlock_Saml2_ResponseAnnotationDecorator
@@ -103,7 +103,7 @@ Uses:
 log a warning if received `eduPersonPrincipalName` is not allowed by configured shibmd:scopes for the used IdP. Log a
 notice otherwise.
 
-If the `eb.block_user_on_violation` feature toggle however is set it will throw an exception which will prevent access.
+If however the eb.block_user_on_violation feature toggle is set, it will throw an exception which will prevent access.
 
 Uses:
 - EngineBlock_Saml2_ResponseAnnotationDecorator
@@ -336,9 +336,13 @@ Uses:
 
 
 ### ValidateAuthnContextClassRef
-The validator will block any incoming IdP assertion with a blacklisted `AuthnContextClassRef`.
-It will prevent an IdP to use the blacklisted values used for AuthnContextClassRef.
-This is being used to prevent the use internal used AuthnContextClassRef values which are currently being used for Stepup 2fa gateway authentications.
+Block any incoming IdP assertion with a blacklisted `AuthnContextClassRef`.
+This is used to prevent an IdP to impersonate 'our' AuthnContextClassRef values.
+
+
+
+Configured with:
+ - `sfo.authn_context_class_ref_blacklist_regex`
 
 Uses:
 - EngineBlock_Saml2_ResponseAnnotationDecorator

--- a/docs/filter_commands.md
+++ b/docs/filter_commands.md
@@ -93,6 +93,8 @@ Modifies:
 log a warning if received `schacHomeOrganization` is not allowed by the configured shibmd:scopes for the used IdP.
 Log a notice otherwise.
 
+If the `eb.block_user_on_violation` feature toggle however is set it will throw an exception which will prevent access.
+
 Uses:
 - EngineBlock_Saml2_ResponseAnnotationDecorator
 - OpenConext\EngineBlock\Metadata\Entity\IdentityProvider
@@ -100,6 +102,8 @@ Uses:
 ### VerifyShibMdScopingAllowsEduPersonPrincipalName
 log a warning if received `eduPersonPrincipalName` is not allowed by configured shibmd:scopes for the used IdP. Log a
 notice otherwise.
+
+If the `eb.block_user_on_violation` feature toggle however is set it will throw an exception which will prevent access.
 
 Uses:
 - EngineBlock_Saml2_ResponseAnnotationDecorator
@@ -213,16 +217,6 @@ handling an internal request (e.g. from a received Reponse to Consent).
 
 Uses:
  - EngineBlock_Corto_ProxyServer
-
-### AddCollabPersonIdAttribute
-Sets the collabPersonId attribute on the Response Attributes
-
-Uses:
-- responseAttributes
-- collabPersonId
-
-Modifies:
-- responseAttributes
 
 ### RunAttributeManipulations (for SP)
 Run the configured Attribute Manipulations for the current Service Provider. Attribute Manipulations are code that is
@@ -338,6 +332,18 @@ Uses:
 - OpenConext\EngineBlock\Metadata\Entity\ServiceProvider
 - OpenConext\EngineBlock\Metadata\Entity\IdentityProvider
 - EngineBlock_Saml2_AuthnRequestAnnotationDecorator
+
+
+
+### ValidateAuthnContextClassRef
+The validator will block any incoming IdP assertion with a blacklisted `AuthnContextClassRef`.
+It will prevent an IdP to use the blacklisted values used for AuthnContextClassRef.
+This is being used to prevent the use internal used AuthnContextClassRef values which are currently being used for Stepup 2fa gateway authentications.
+
+Uses:
+- EngineBlock_Saml2_ResponseAnnotationDecorator
+
+
 
 [input]: https://github.com/OpenConext/OpenConext-engineblock/tree/master/library/EngineBlock/Corto/Filter/Input.php
 [output]: https://github.com/OpenConext/OpenConext-engineblock/tree/master/library/EngineBlock/Corto/Filter/Output.php


### PR DESCRIPTION
Some documentation is added to the added SFO logic in order to clarify the SFO/2fa configuration and validation options.

https://www.pivotaltracker.com/story/show/167320950