### PR TITLE
Use redirect binding for sfo callout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ branches:
   only:
     - master
     - feature/sfo
+    - /^feature\/sfo.*$/
     - /^feature\/serialize-coins.*$/
     - feature/error-page-styling
 

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -20,7 +20,7 @@ use Doctrine\ORM\EntityManager;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\EngineBlock\Validator\AllowedSchemeValidator;
 use OpenConext\EngineBlockBundle\Stepup\StepupGatewayCallOutHelper;
-use OpenConext\EngineBlockBundle\Stepup\StepupIdentityProvider;
+use OpenConext\EngineBlockBundle\Stepup\StepupEntityFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 
 class EngineBlock_Application_DiContainer extends Pimple
@@ -325,7 +325,19 @@ class EngineBlock_Application_DiContainer extends Pimple
      */
     public function getStepupIdentityProvider(EngineBlock_Corto_ProxyServer $server)
     {
-        return StepupIdentityProvider::fromStepupEndpoint(
+        return StepupEntityFactory::idpFrom(
+            $this->getStepupEndpoint(),
+            $server->getUrl('stepupAssertionConsumerService')
+        );
+    }
+
+    /**
+     * @param EngineBlock_Corto_ProxyServer $server
+     * @return \OpenConext\EngineBlock\Metadata\Entity\ServiceProvider
+     */
+    public function getStepupServiceProvider(EngineBlock_Corto_ProxyServer $server)
+    {
+        return StepupEntityFactory::spFrom(
             $this->getStepupEndpoint(),
             $server->getUrl('stepupAssertionConsumerService')
         );

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -21,7 +21,7 @@ use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Validator\AllowedSchemeValidator;
 use OpenConext\EngineBlockBundle\Exception\ResponseProcessingFailedException;
-use OpenConext\EngineBlockBundle\Stepup\StepupIdentityProvider;
+use OpenConext\EngineBlockBundle\Stepup\StepupEntityFactory;
 use SAML2\AuthnRequest;
 use SAML2\Binding;
 use SAML2\Certificate\KeyLoader;
@@ -105,7 +105,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
     private $acsLocationSchemeValidator;
 
     /**
-     * @var StepupIdentityProvider
+     * @var IdentityProvider
      */
     private $stepupIdentityProvider;
 

--- a/library/EngineBlock/Corto/Module/Service/Metadata.php
+++ b/library/EngineBlock/Corto/Module/Service/Metadata.php
@@ -18,7 +18,6 @@
 
 use EngineBlock_Corto_Module_Service_Metadata_ServiceReplacer as ServiceReplacer;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
-use OpenConext\EngineBlockBundle\Stepup\StepupIdentityProvider;
 
 class EngineBlock_Corto_Module_Service_Metadata extends EngineBlock_Corto_Module_Service_Abstract
 {
@@ -43,7 +42,7 @@ class EngineBlock_Corto_Module_Service_Metadata extends EngineBlock_Corto_Module
                 $engineEntity = $this->_server->getRepository()->fetchServiceProviderByEntityId($engineEntityId);
                 break;
             case 'stepupMetadataService':
-                $engineEntity = $container->getStepupIdentityProvider($this->_server);
+                $engineEntity = $container->getStepupServiceProvider($this->_server);
                 break;
             default:
                 // If an unsupported serviceName is used, first try to resolve a SP, then try IdP. This is a fallback

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -440,7 +440,13 @@ class EngineBlock_Corto_ProxyServer
         $authnContextClassRef,
         NameID $nameId
     ) {
-        $ebRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest($spRequest, $identityProvider, $this);
+        $ebRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest(
+            $spRequest,
+            $identityProvider,
+            $this,
+            'stepupMetadataService',
+            'stepupAssertionConsumerService'
+        );
 
         $sspMessage = $ebRequest->getSspMessage();
         if (!$sspMessage instanceof AuthnRequest) {
@@ -454,28 +460,15 @@ class EngineBlock_Corto_ProxyServer
             ],
             'Comparison' => 'minimal',
         ]);
-        $sspMessage->setNameId([
+        $sspMessage->setNameId(NameID::fromArray([
             'Value' => $nameId->value,
             'Format' => Constants::NAMEID_UNSPECIFIED,
-        ]);
-
-        // Add gateway data
-        $sspMessage->setDestination($identityProvider->singleSignOnServices[0]->location);
-        $sspMessage->setAssertionConsumerServiceURL($this->_server->getUrl('stepupAssertionConsumerService'));
-        $sspMessage->setIssuer($this->_server->getUrl('stepupMetadataService'));
-
-        // Add the SP to the requesterIds
-        $requesterIds = $sspMessage->getRequesterID();
-        $requesterIds[] = $sspMessage->getIssuer();
-        $sspMessage->setRequesterID($requesterIds);
+        ]));
 
         // Link with the original Request
         $authnRequestRepository = new EngineBlock_Saml2_AuthnRequestSessionRepository($this->_logger);
         $authnRequestRepository->store($spRequest);
         $authnRequestRepository->link($ebRequest, $spRequest);
-
-        // Set binding
-        $ebRequest->setDeliverByBinding(Constants::BINDING_HTTP_REDIRECT);
 
         $this->getBindingsModule()->send($ebRequest, $identityProvider);
     }

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -462,7 +462,6 @@ class EngineBlock_Corto_ProxyServer
         // Add gateway data
         $sspMessage->setDestination($identityProvider->singleSignOnServices[0]->location);
         $sspMessage->setAssertionConsumerServiceURL($this->_server->getUrl('stepupAssertionConsumerService'));
-        $sspMessage->setProtocolBinding(Constants::BINDING_HTTP_POST);
         $sspMessage->setIssuer($this->_server->getUrl('stepupMetadataService'));
 
         // Add the SP to the requesterIds
@@ -474,6 +473,9 @@ class EngineBlock_Corto_ProxyServer
         $authnRequestRepository = new EngineBlock_Saml2_AuthnRequestSessionRepository($this->_logger);
         $authnRequestRepository->store($spRequest);
         $authnRequestRepository->link($ebRequest, $spRequest);
+
+        // Set binding
+        $ebRequest->setDeliverByBinding(Constants::BINDING_HTTP_REDIRECT);
 
         $this->getBindingsModule()->send($ebRequest, $identityProvider);
     }

--- a/library/EngineBlock/Saml2/AuthnRequestFactory.php
+++ b/library/EngineBlock/Saml2/AuthnRequestFactory.php
@@ -26,7 +26,8 @@ class EngineBlock_Saml2_AuthnRequestFactory
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $originalRequest,
         IdentityProvider $idpMetadata,
         EngineBlock_Corto_ProxyServer $server,
-        $serviceName = 'spMetadataService'
+        $issuerServiceName = 'spMetadataService',
+        $acsServiceName = 'assertionConsumerService'
     ) {
         $nameIdPolicy = array('AllowCreate' => true);
         /**
@@ -50,9 +51,9 @@ class EngineBlock_Saml2_AuthnRequestFactory
         $sspRequest->setDestination($idpMetadata->singleSignOnServices[0]->location);
         $sspRequest->setForceAuthn($originalRequest->getForceAuthn());
         $sspRequest->setIsPassive($originalRequest->getIsPassive());
-        $sspRequest->setAssertionConsumerServiceURL($server->getUrl('assertionConsumerService'));
+        $sspRequest->setAssertionConsumerServiceURL($server->getUrl($acsServiceName));
         $sspRequest->setProtocolBinding(Constants::BINDING_HTTP_POST);
-        $sspRequest->setIssuer($server->getUrl($serviceName));
+        $sspRequest->setIssuer($server->getUrl($issuerServiceName));
         $sspRequest->setNameIdPolicy($nameIdPolicy);
 
         if (empty($idpMetadata->getCoins()->disableScoping())) {

--- a/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayCallOutHelper.php
+++ b/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayCallOutHelper.php
@@ -75,6 +75,15 @@ final class StepupGatewayCallOutHelper
     }
 
     /**
+     * @param string $gatewayLoa
+     * @return string
+     */
+    public function getEbLoa($gatewayLoa)
+    {
+        return $this->gatewayLoaMapping->transformToEbLoa($gatewayLoa);
+    }
+
+    /**
      * @param IdentityProvider $identityProvider
      * @param ServiceProvider $serviceProvider
      * @return bool

--- a/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMapping.php
+++ b/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMapping.php
@@ -51,10 +51,25 @@ class StepupGatewayLoaMapping
     public function transformToGatewayLoa($input)
     {
         if (!array_key_exists($input, $this->mapping)) {
-            throw new RuntimeException('Unable to determine gateway LOA for manage LOA');
+            throw new RuntimeException('Unable to find the EngineBlock LoA in the configured stepup LoA mapping');
         }
 
         return $this->mapping[$input];
+    }
+
+
+    /**
+     * @param $input
+     * @return string
+     */
+    public function transformToEbLoa($input)
+    {
+        $loa = array_search($input, $this->mapping);
+        if ($loa === false) {
+            throw new RuntimeException('Unable to find the received stepup LoA in the configured EngineBlock LoA');
+        }
+
+        return $loa;
     }
 
     /**

--- a/src/OpenConext/EngineBlockBundle/Stepup/StepupIdentityProvider.php
+++ b/src/OpenConext/EngineBlockBundle/Stepup/StepupIdentityProvider.php
@@ -35,19 +35,54 @@ class StepupIdentityProvider extends ServiceProvider
      */
     public static function fromStepupEndpoint(StepupEndpoint $stepupEndpoint, $acsLocation)
     {
-        $entity = new IdentityProvider($stepupEndpoint->getEntityId());
-
-        $entity->responseProcessingService = new Service(
+        $publicKeyFactory = new EngineBlock_X509_CertificateFactory();
+        $certificates[] = $publicKeyFactory->fromFile($stepupEndpoint->getKeyFile());
+        $responseProcessingService = new Service(
             $acsLocation,
             Constants::BINDING_HTTP_POST
         );
+        $singleSignOnServices[] = new Service($stepupEndpoint->getSsoLocation(), Constants::BINDING_HTTP_POST);
 
-        $publicKeyFactory = new EngineBlock_X509_CertificateFactory();
-
-        $entity->certificates[] = $publicKeyFactory->fromFile($stepupEndpoint->getKeyFile());
-        $entity->singleSignOnServices[] = new Service($stepupEndpoint->getSsoLocation(), Constants::BINDING_HTTP_POST);
-        $entity->requestsMustBeSigned = true;
-        $entity->signatureMethod = XMLSecurityKey::RSA_SHA256;
+        $entity = new IdentityProvider(
+            $stepupEndpoint->getEntityId(),
+            null,
+            null,
+            null,
+            false,
+            $certificates,
+            [],
+            '',
+            '',
+            false,
+            '',
+            '',
+            '',
+            '',
+            null,
+            '',
+            '',
+            null,
+            array(
+                Constants::NAMEID_TRANSIENT,
+                Constants::NAMEID_PERSISTENT,
+            ),
+            null,
+            false,
+            true,
+            XMLSecurityKey::RSA_SHA256,
+            $responseProcessingService,
+            IdentityProvider::WORKFLOW_STATE_DEFAULT,
+            '',
+            null,
+            false,
+            IdentityProvider::GUEST_QUALIFIER_ALL,
+            true,
+            null,
+            [],
+            $singleSignOnServices,
+            null,
+            null
+        );
 
         return $entity;
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -18,7 +18,6 @@ Feature:
       And I select "SSO-IdP" on the WAYF
       And I pass through EngineBlock
       And I pass through the IdP
-      And I pass through EngineBlock
       And Stepup will successfully verify a user
       And I give my consent
       And I pass through EngineBlock
@@ -30,7 +29,6 @@ Feature:
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
         And I pass through the IdP
-        And I pass through EngineBlock
         And Stepup will successfully verify a user
         And I give my consent
         And I pass through EngineBlock
@@ -62,7 +60,6 @@ Feature:
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
         And I pass through the IdP
-        And I pass through EngineBlock
         And Stepup will fail if the LoA can not be given
         And I give my consent
         And I pass through EngineBlock
@@ -74,7 +71,6 @@ Feature:
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
         And I pass through the IdP
-        And I pass through EngineBlock
         And Stepup will fail if the LoA can not be given
       Then I should see "Error - No suitable token found"
         And the url should match "/feedback/stepup-callout-unmet-loa"
@@ -85,7 +81,6 @@ Feature:
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
         And I pass through the IdP
-        And I pass through EngineBlock
         And Stepup will fail as the user cancelled
       Then I should see "Error - Logging in cancelled"
         And the url should match "/feedback/stepup-callout-user-cancelled"
@@ -96,7 +91,6 @@ Feature:
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
         And I pass through the IdP
-        And I pass through EngineBlock
         And Stepup will fail on unknown invalid status
       Then I should see "Error - Unknown strong authentication failure"
         And the url should match "/feedback/stepup-callout-unknown"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockStepupGateway.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockStepupGateway.php
@@ -204,7 +204,9 @@ class MockStepupGateway
         $key->loadKey($this->gatewayConfiguration->getIdentityProviderPublicKeyCertData());
 
         // The query string to vaklidate needs to be urlencoded again because Symfony ha already decoded this for us
-        $query = self::PARAMETER_REQUEST . '=' . urlencode($requestData) . '&' . self::PARAMETER_SIGNATURE_ALGORITHM . '=' . urlencode($request->get(self::PARAMETER_SIGNATURE_ALGORITHM));
+        $query = self::PARAMETER_REQUEST . '=' . urlencode($requestData);
+        $query .= '&' . self::PARAMETER_SIGNATURE_ALGORITHM . '=' . urlencode($request->get(self::PARAMETER_SIGNATURE_ALGORITHM));
+
         $signature = base64_decode($request->get(self::PARAMETER_SIGNATURE));
 
         if (!$key->verifySignature($query, $signature)) {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockStepupGateway.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockStepupGateway.php
@@ -73,7 +73,7 @@ class MockStepupGateway
     public function handleSsoSuccess(Request $request, $fullRequestUri)
     {
         // parse the authnRequest
-         $authnRequest = $this->parseRequest($request, $fullRequestUri);
+        $authnRequest = $this->parseRequest($request, $fullRequestUri);
 
         // get parameters from authnRequest
         $nameId = $authnRequest->getNameId()->value;
@@ -203,7 +203,7 @@ class MockStepupGateway
         $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
         $key->loadKey($this->gatewayConfiguration->getIdentityProviderPublicKeyCertData());
 
-        // The query string to vaklidate needs to be urlencoded again because Symfony ha already decoded this for us
+        // The query string to validate needs to be urlencoded again because Symfony has already decoded this for us
         $query = self::PARAMETER_REQUEST . '=' . urlencode($requestData);
         $query .= '&' . self::PARAMETER_SIGNATURE_ALGORITHM . '=' . urlencode($request->get(self::PARAMETER_SIGNATURE_ALGORITHM));
 

--- a/tests/unit/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMappingTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMappingTest.php
@@ -19,6 +19,7 @@
 namespace OpenConext\EngineBlockBundle\Tests;
 
 use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Exception\RuntimeException;
 use OpenConext\EngineBlockBundle\Stepup\StepupGatewayLoaMapping;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -31,14 +32,14 @@ class StepupGatewayLoaMappingTest extends TestCase
     public function the_stepup_loa_mapping_object_should_be_successful_populated()
     {
         $stepupLoaMapping = new StepupGatewayLoaMapping([
-            'manageLoa2' => 'gatewayLoa2',
-            'manageLoa3' => 'gatewayLoa3',
+            'ebLoa2' => 'gatewayLoa2',
+            'ebLoa3' => 'gatewayLoa3',
         ],
             'gatewayLoa1'
         );
 
-        $this->assertSame('gatewayLoa2', $stepupLoaMapping->transformToGatewayLoa('manageLoa2'));
-        $this->assertSame('gatewayLoa2', $stepupLoaMapping->transformToGatewayLoa('manageLoa2'));
+        $this->assertSame('gatewayLoa2', $stepupLoaMapping->transformToGatewayLoa('ebLoa2'));
+        $this->assertSame('gatewayLoa2', $stepupLoaMapping->transformToGatewayLoa('ebLoa2'));
         $this->assertSame('gatewayLoa1', $stepupLoaMapping->getGatewayLoa1());
     }
 
@@ -68,7 +69,7 @@ class StepupGatewayLoaMappingTest extends TestCase
         $this->expectExceptionMessage('The stepup.gateway_loa_mapping configuration must be a map, value is not a string');
 
         $stepupLoaMapping = new StepupGatewayLoaMapping([
-            'manageLoa2' => 3,
+            'ebLoa2' => 3,
         ],
             'gatewayLoa1'
         );
@@ -84,9 +85,44 @@ class StepupGatewayLoaMappingTest extends TestCase
         $this->expectExceptionMessage('The stepup.gateway.loa.loa1 configuration must be a string');
 
         $stepupLoaMapping = new StepupGatewayLoaMapping([
-            'manageLoa2' => 'gatewayLoa2',
+            'ebLoa2' => 'gatewayLoa2',
         ],
             5
         );
+    }
+
+    /**
+     * @test
+     * @group Stepup
+     */
+    public function the_stepup_loa_mapping_object_should_successful_map_back()
+    {
+        $stepupLoaMapping = new StepupGatewayLoaMapping([
+            'ebLoa2' => 'gatewayLoa2',
+            'ebLoa3' => 'gatewayLoa3',
+        ],
+            'gatewayLoa1'
+        );
+
+        $this->assertSame('ebLoa2', $stepupLoaMapping->transformToEbLoa('gatewayLoa2'));
+        $this->assertSame('ebLoa3', $stepupLoaMapping->transformToEbLoa('gatewayLoa3'));
+    }
+
+    /**
+     * @test
+     * @group Stepup
+     */
+    public function the_stepup_loa_mapping_object_should_return_an_exception_when_unable_to_map_back()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to find the received stepup LoA in the configured EngineBlock LoA');
+
+        $stepupLoaMapping = new StepupGatewayLoaMapping([
+            'ebLoa2' => 'gatewayLoa2',
+        ],
+            'gatewayLoa1'
+        );
+
+        $stepupLoaMapping->transformToEbLoa('gatewayLoa3');
     }
 }


### PR DESCRIPTION
According to the specs GW should only support redirect binding.
Post binding however is supported in GW but only to support ADFS and
actually this is not official. Therefore we change the binding to
redirect binding so the specs are met.