### PR TITLE
Fix the use of SFO on homepage

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Index/index.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Index/index.html.twig
@@ -120,10 +120,10 @@
 
 
       <div class="main">
-          <h1>SFO Certificate and Metadata</h1>
+          <h1>Stepup authentication Certificate and Metadata</h1>
           <dl class="metadata-certificates-list">
               <dt>
-                  The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} SFO Proxy
+                  The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} stepup authentication Proxy
               </dt>
               <dd>
                   <ul>


### PR DESCRIPTION
On the homepage the SFO term was still being used.

https://www.pivotaltracker.com/story/show/167864360/comments/205827824