### PR TITLE
Store coin properties in a single column

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,6 @@ script:
 branches:
   only:
     - master
-    - release/5.11
-    - feature/error-page-styling
 
 after_failure:
   - sudo tail -500 /var/log/apache2/error.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ We will continue to post relevant release notes on the GitHub release page. More
 
 More information about our release strategy can be found in the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes) on the EngineBlock wiki.
 
+## 5.12.0
+We've changed the way how coin entity properties are stored in the database. As of now, they will be stored in a serialized manner, in a single column. This greatly simplifies adding or removing coins in the future, as this no longer requires database schema changes. 
+
+ *  Store coin properties in a single column #752  
+
 ## 5.11.3
 The footer links have been made configurable to a greater extent in this release.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,21 @@
 # UPGRADE NOTES
 
+## 5.11 > 5.12.0
+
+### Serialised column cleanup
+In version 5.12.0 multiple `coin` columns are serialised into a single column with serialised data.
+This change will allow easier maintenance because then no migrations are needed when adding or removing a `coin`.
+There is no migration to populate the old `coin` columns to the new serialised column while this is needed to let EB function properly with the new changes. 
+Therefore you should push the data from Manage after you have updated the codebase and ran the `Version20190703235333`.
+
+Be aware that you need to be logged in into manage to push the data after updating the codebase and database schema. 
+
+In order to let this work you need to do the following:
+ 1. Login into manage
+ 1. Update codebase
+ 1. Run migrations
+ 1. Push metadata
+
 ## 5.10 -> 5.11
 
 ### Improved error feedback

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -100,6 +100,7 @@ doctrine:
         types:
             engineblock_collab_person_id: OpenConext\EngineBlockBundle\Doctrine\Type\CollabPersonIdType
             engineblock_collab_person_uuid: OpenConext\EngineBlockBundle\Doctrine\Type\CollabPersonUuidType
+            engineblock_metadata_coins: OpenConext\EngineBlockBundle\Doctrine\Type\MetadataCoinType
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
         proxy_dir: '%kernel.cache_dir%/doctrine/orm/Proxies'

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     },
     "require": {
         "php": ">=5.6,<7",
+        "ext-json": "*",
         "ext-mbstring": "*",
         "beberlei/assert": "^2.6",
         "doctrine/doctrine-bundle": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "350a860ca2e1e7fc3187a62a13b0baa0",
+    "content-hash": "c16949605a9251ebc612ab0b0b99b4d1",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -5174,6 +5174,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
         {
@@ -5840,6 +5841,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.6,<7",
+        "ext-json": "*",
         "ext-mbstring": "*"
     },
     "platform-dev": [],

--- a/database/DoctrineMigrations/Version20190703235333.php
+++ b/database/DoctrineMigrations/Version20190703235333.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190703235333 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD coins LONGTEXT NOT NULL COMMENT \'(DC2Type:engineblock_metadata_coins)\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP coins');
+    }
+}

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -140,7 +140,7 @@ class EngineBlock_Corto_Adapter
         $serviceProvider = $repository->fetchServiceProviderByEntityId($request->getIssuer());
 
         if (!$serviceProvider->allowAll) {
-            if ($serviceProvider->displayUnconnectedIdpsWayf) {
+            if ($serviceProvider->getCoins()->displayUnconnectedIdpsWayf()) {
                 $repository->appendVisitor(
                     new DisableDisallowedEntitiesInWayfVisitor($serviceProvider->allowedIdpEntityIds)
                 );

--- a/library/EngineBlock/Corto/Filter/Command/AddGuestStatus.php
+++ b/library/EngineBlock/Corto/Filter/Command/AddGuestStatus.php
@@ -33,18 +33,18 @@ class EngineBlock_Corto_Filter_Command_AddGuestStatus extends EngineBlock_Corto_
      */
     protected function _addIsMemberOfSurfNlAttribute()
     {
-        if ($this->_identityProvider->guestQualifier === IdentityProvider::GUEST_QUALIFIER_ALL) {
+        if ($this->_identityProvider->getCoins()->guestQualifier() === IdentityProvider::GUEST_QUALIFIER_ALL) {
             // All users from this IdP are guests, so no need to add the isMemberOf
             return;
         }
 
-        if ($this->_identityProvider->guestQualifier === IdentityProvider::GUEST_QUALIFIER_NONE) {
+        if ($this->_identityProvider->getCoins()->guestQualifier() === IdentityProvider::GUEST_QUALIFIER_NONE) {
             $this->_setIsMember();
             return;
         }
 
         $log = EngineBlock_ApplicationSingleton::getLog();
-        if ($this->_identityProvider->guestQualifier === IdentityProvider::GUEST_QUALIFIER_SOME) {
+        if ($this->_identityProvider->getCoins()->guestQualifier() === IdentityProvider::GUEST_QUALIFIER_SOME) {
             if (isset($this->_responseAttributes[static::URN_SURF_PERSON_AFFILIATION][0])) {
                 if ($this->_responseAttributes[static::URN_SURF_PERSON_AFFILIATION][0] === 'member') {
                     $this->_setIsMember();

--- a/library/EngineBlock/Corto/Filter/Command/DenormalizeAttributes.php
+++ b/library/EngineBlock/Corto/Filter/Command/DenormalizeAttributes.php
@@ -13,7 +13,7 @@ class EngineBlock_Corto_Filter_Command_DenormalizeAttributes extends EngineBlock
 
     public function execute()
     {
-        if ($this->_serviceProvider->skipDenormalization) {
+        if ($this->_serviceProvider->getCoins()->skipDenormalization()) {
             return;
         }
 

--- a/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
+++ b/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
@@ -18,7 +18,7 @@ class EngineBlock_Corto_Filter_Command_EnforcePolicy extends EngineBlock_Corto_F
             $serviceProvider = $this->_serviceProvider;
         }
 
-        if (!$serviceProvider->policyEnforcementDecisionRequired) {
+        if (!$serviceProvider->getCoins()->policyEnforcementDecisionRequired()) {
             return;
         }
 

--- a/library/EngineBlock/Corto/Filter/Command/ValidateRequiredAttributes.php
+++ b/library/EngineBlock/Corto/Filter/Command/ValidateRequiredAttributes.php
@@ -20,9 +20,9 @@ class EngineBlock_Corto_Filter_Command_ValidateRequiredAttributes extends Engine
     {
         // ServiceRegistry override of SchacHomeOrganization, set it and skip validation
         $excluded = array();
-        if ($this->_identityProvider->schacHomeOrganization) {
+        if ($this->_identityProvider->getCoins()->schacHomeOrganization()) {
             $this->_responseAttributes[self::URN_MACE_TERENA_SCHACHOMEORG] = array(
-                $this->_identityProvider->schacHomeOrganization
+                $this->_identityProvider->getCoins()->schacHomeOrganization()
             );
             $excluded[] = static::URN_MACE_TERENA_SCHACHOMEORG;
         }

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -568,7 +568,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             $sspMessage->setCertificates(array($keyPair->getCertificate()->toPem()));
             $sspMessage->setSignatureKey(
                 $keyPair->getPrivateKey()->toXmlSecurityKey(
-                    $remoteEntity->signatureMethod
+                    $remoteEntity->getCoins()->signatureMethod()
                 )
             );
         }
@@ -588,7 +588,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
                 // This suffices for most SP's. However, some SP's require the outer Response element to be signed directly.
                 // If configured to do so for that SP, Engineblock will sign the outer response element in addition to the signed Assertion element.
                 // It might make sense in the future to always sign both, if it has been shown that this causes no problems.
-                if ($remoteEntity instanceof ServiceProvider && $remoteEntity->signResponse) {
+                if ($remoteEntity instanceof ServiceProvider && $remoteEntity->getCoins()->signResponse()) {
                     $messageElement = $sspMessage->toSignedXML();
                 } else {
                     $messageElement = $sspMessage->toUnsignedXML();

--- a/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
+++ b/library/EngineBlock/Corto/Module/Service/IdpsMetadata.php
@@ -42,7 +42,7 @@ class EngineBlock_Corto_Module_Service_IdpsMetadata extends EngineBlock_Corto_Mo
                 continue;
             }
 
-            if ($entity->hidden) {
+            if ($entity->getCoins()->hidden()) {
                 continue;
             }
 

--- a/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
@@ -203,7 +203,7 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
     private function isConsentDisabled(array $serviceProviders, IdentityProvider $identityProvider)
     {
         foreach ($serviceProviders as $serviceProvider) {
-            if (!$serviceProvider->isConsentRequired) {
+            if (!$serviceProvider->getCoins()->isConsentRequired()) {
                 return true;
             }
 

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -27,7 +27,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
 
         // When dealing with an SP that acts as a trusted proxy, we should perform SSO on the proxying SP and not the
         // proxy itself.
-        if ($sp->isTrustedProxy) {
+        if ($sp->getCoins()->isTrustedProxy()) {
             // Overwrite the trusted proxy SP instance with that of the SP that uses the trusted proxy.
             $sp = $this->findOriginalServiceProvider($request, $log);
         }
@@ -367,7 +367,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
                 'backLink' => $container->isUiOptionReturnToSpActive(),
                 'cutoffPointForShowingUnfilteredIdps' => $container->getCutoffPointForShowingUnfilteredIdps(),
                 'rememberChoiceFeature' => $rememberChoiceFeature,
-                'showRequestAccess' => $serviceProvider->displayUnconnectedIdpsWayf,
+                'showRequestAccess' => $serviceProvider->getCoins()->displayUnconnectedIdpsWayf(),
                 'requestId' => $request->getId(),
                 'serviceProvider' => $serviceProvider,
                 'idpList' => $idpList,
@@ -420,7 +420,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
                 continue;
             }
 
-            if ($identityProvider->hidden) {
+            if ($identityProvider->getCoins()->hidden()) {
                 continue;
             }
 

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -476,7 +476,7 @@ class EngineBlock_Corto_ProxyServer
         // Unless of course we are in 'stealth' / transparent mode, in which case,
         // pretend to be the Identity Provider.
         $serviceProvider = $this->getRepository()->fetchServiceProviderByEntityId($request->getIssuer());
-        $mustProxyTransparently = ($request->isTransparent() || $serviceProvider->isTransparentIssuer);
+        $mustProxyTransparently = ($request->isTransparent() || $serviceProvider->getCoins()->isTransparentIssuer());
         if (!$this->isInProcessingMode() && $mustProxyTransparently) {
             $newResponse->setIssuer($newResponse->getOriginalIssuer());
             $newAssertion->setIssuer($newResponse->getOriginalIssuer());

--- a/library/EngineBlock/Saml2/AuthnRequestFactory.php
+++ b/library/EngineBlock/Saml2/AuthnRequestFactory.php
@@ -38,7 +38,7 @@ class EngineBlock_Saml2_AuthnRequestFactory
         $sspRequest->setIssuer($server->getUrl('spMetadataService'));
         $sspRequest->setNameIdPolicy($nameIdPolicy);
 
-        if (empty($idpMetadata->disableScoping)) {
+        if (empty($idpMetadata->getCoins()->disableScoping())) {
             // Copy over the Idps that are allowed to answer this request.
             $sspRequest->setIDPList($originalRequest->getIDPList());
 

--- a/library/EngineBlock/SamlHelper.php
+++ b/library/EngineBlock/SamlHelper.php
@@ -15,7 +15,7 @@ class EngineBlock_SamlHelper
     public static function doRemoteEntitiesRequireAdditionalLogging(array $entities)
     {
         return array_reduce($entities, function($carry, AbstractRole $entity) {
-            return $carry | $entity->additionalLogging;
+            return $carry | $entity->getCoins()->additionalLogging();
         }, false);
     }
 
@@ -75,7 +75,7 @@ class EngineBlock_SamlHelper
         MetadataRepositoryInterface $repository,
         \Psr\Log\LoggerInterface $logger = null
     ) {
-        if (!$serviceProvider->isTrustedProxy) {
+        if (!$serviceProvider->getCoins()->isTrustedProxy()) {
             return null;
         }
 
@@ -89,7 +89,7 @@ class EngineBlock_SamlHelper
         $lastRequesterEntityId = end($requesterIds);
 
         if (!$lastRequesterEntityId) {
-            if ($serviceProvider->requesteridRequired) {
+            if ($serviceProvider->getCoins()->requesteridRequired()) {
                 throw new EngineBlock_Exception_UnknownServiceProvider(
                     $serviceProvider,
                     'No RequesterID specified'

--- a/src/OpenConext/EngineBlock/Authentication/Dto/Consent.php
+++ b/src/OpenConext/EngineBlock/Authentication/Dto/Consent.php
@@ -56,7 +56,7 @@ final class Consent
                 'en' => $this->serviceProvider->supportUrlEn,
                 'nl' => $this->serviceProvider->supportUrlNl,
             ],
-            'eula_url' => $this->serviceProvider->termsOfServiceUrl,
+            'eula_url' => $this->serviceProvider->getCoins()->termsOfServiceUrl(),
             'support_email' => $supportEmail,
             'name_id_format' => $this->serviceProvider->nameIdFormat,
         ];

--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class Coins
+{
+    private $values = [];
+
+    public static function createForServiceProvider(
+        $isConsentRequired,
+        $isTransparentIssuer,
+        $isTrustedProxy,
+        $displayUnconnectedIdpsWayf,
+        $termsOfServiceUrl,
+        $skipDenormalization,
+        $policyEnforcementDecisionRequired,
+        $requesteridRequired,
+        $signResponse,
+        $disableScoping,
+        $additionalLogging,
+        $signatureMethod
+    ) {
+        return new self([
+            'isConsentRequired' => $isConsentRequired,
+            'isTransparentIssuer' => $isTransparentIssuer,
+            'isTrustedProxy' => $isTrustedProxy,
+            'displayUnconnectedIdpsWayf' => $displayUnconnectedIdpsWayf,
+            'termsOfServiceUrl' => $termsOfServiceUrl,
+            'skipDenormalization' => $skipDenormalization,
+            'policyEnforcementDecisionRequired' => $policyEnforcementDecisionRequired,
+            'requesteridRequired' => $requesteridRequired,
+            'signResponse' => $signResponse,
+            'disableScoping' => $disableScoping,
+            'additionalLogging' => $additionalLogging,
+            'signatureMethod' => $signatureMethod,
+        ]);
+    }
+
+    public static function createForIdentityProvider(
+        $guestQualifier,
+        $schacHomeOrganization,
+        $hidden,
+        $disableScoping,
+        $additionalLogging,
+        $signatureMethod
+    ) {
+        return new self([
+            'guestQualifier' => $guestQualifier,
+            'schacHomeOrganization' => $schacHomeOrganization,
+            'hidden' => $hidden,
+            'disableScoping' => $disableScoping,
+            'additionalLogging' => $additionalLogging,
+            'signatureMethod' => $signatureMethod,
+        ]);
+    }
+
+    private function __construct(array $values)
+    {
+        $this->values = [];
+        foreach ($values as $key => $value) {
+            if (!is_null($value)) {
+                $this->values[$key] = $value;
+            }
+        }
+    }
+
+    /**
+     * @return false|string
+     */
+    public function toJson()
+    {
+        return json_encode($this->values);
+    }
+
+    /**
+     * @param string $data
+     * @return Coins
+     */
+    public static function fromJson($data)
+    {
+        $data = json_decode($data, true);
+
+        return new self($data);
+    }
+
+    // SP
+    public function isConsentRequired()
+    {
+        return $this->getValue('isConsentRequired', true);
+    }
+
+    public function isTransparentIssuer()
+    {
+        return $this->getValue('isTransparentIssuer', false);
+    }
+
+    public function isTrustedProxy()
+    {
+        return $this->getValue('isTrustedProxy', false);
+    }
+
+    public function displayUnconnectedIdpsWayf()
+    {
+        return $this->getValue('displayUnconnectedIdpsWayf', false);
+    }
+
+    public function termsOfServiceUrl()
+    {
+        return $this->getValue('termsOfServiceUrl');
+    }
+
+    public function skipDenormalization()
+    {
+        return $this->getValue('skipDenormalization', false);
+    }
+
+    public function policyEnforcementDecisionRequired()
+    {
+        return $this->getValue('policyEnforcementDecisionRequired', false);
+    }
+
+    public function requesteridRequired()
+    {
+        return $this->getValue('requesteridRequired', false);
+    }
+
+    public function signResponse()
+    {
+        return $this->getValue('signResponse', false);
+    }
+
+    // IDP
+    public function guestQualifier()
+    {
+        return $this->getValue('guestQualifier', IdentityProvider::GUEST_QUALIFIER_ALL);
+    }
+
+    public function schacHomeOrganization()
+    {
+        return $this->getValue('schacHomeOrganization');
+    }
+
+    public function hidden()
+    {
+        return $this->getValue('hidden', false);
+    }
+
+    // Abstract
+    public function disableScoping()
+    {
+        return $this->getValue('disableScoping', false);
+    }
+
+    public function additionalLogging()
+    {
+        return $this->getValue('additionalLogging', false);
+    }
+
+    public function signatureMethod()
+    {
+        return $this->getValue('signatureMethod', XMLSecurityKey::RSA_SHA1);
+    }
+
+    private function getValue($key, $default = null)
+    {
+        if (!array_key_exists($key, $this->values)) {
+            return $default;
+        }
+        return $this->values[$key];
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
@@ -4,6 +4,7 @@ namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
@@ -251,6 +252,13 @@ abstract class AbstractRole
     public $manipulation;
 
     /**
+     * @var Coins
+     *
+     * @ORM\Column(name="coins", type="engineblock_metadata_coins")
+     */
+    protected $coins = array();
+
+    /**
      * @param $entityId
      * @param Organization $organizationEn
      * @param Organization $organizationNl
@@ -367,5 +375,13 @@ abstract class AbstractRole
         }
 
         throw new \RuntimeException('Unknown workflow state');
+    }
+
+    /**
+     * @return Coins
+     */
+    public function getCoins()
+    {
+        return $this->coins;
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -153,21 +153,21 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
 
         $properties += $this->assembleAttributeReleasePolicy($connection);
         $properties += $this->assembleAssertionConsumerServices($connection);
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:transparant_issuer'
             ),
             'isTransparentIssuer'
         );
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:trusted_proxy'
             ),
             'isTrustedProxy'
         );
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:display_unconnected_idps_wayf'
@@ -177,21 +177,21 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
 
         $properties += $this->assembleIsConsentRequired($connection);
 
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectString(
             array(
                 $connection,
                 'metadata:coin:eula'
             ),
             'termsOfServiceUrl'
         );
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:do_not_add_attribute_aliases'
             ),
             'skipDenormalization'
         );
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:policy_enforcement_decision_required'
@@ -199,7 +199,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
             'policyEnforcementDecisionRequired'
         );
 
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:requesterid_required'
@@ -207,7 +207,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
             'requesteridRequired'
         );
 
-        $properties += $this->setPathFromObject(
+        $properties += $this->setPathFromObjectBool(
             array(
                 $connection,
                 'metadata:coin:sign_response'
@@ -216,7 +216,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         );
 
         return Utils::instantiate(
-            'OpenConext\EngineBlock\Metadata\Entity\ServiceProvider',
+            ServiceProvider::class,
             $properties
         );
     }
@@ -230,14 +230,14 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         $properties = $this->assembleCommon($connection);
 
         $properties += $this->assembleSingleSignOnServices($connection);
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:guest_qualifier'), 'guestQualifier');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:schachomeorganization'), 'schacHomeOrganization');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:guest_qualifier'), 'guestQualifier');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:schachomeorganization'), 'schacHomeOrganization');
         $properties += $this->assembleConsentSettings($connection);
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:hidden'), 'hidden');
+        $properties += $this->setPathFromObjectBool(array($connection, 'metadata:coin:hidden'), 'hidden');
         $properties += $this->assembleShibMdScopes($connection);
 
         return Utils::instantiate(
-            'OpenConext\EngineBlock\Metadata\Entity\IdentityProvider',
+            IdentityProvider::class,
             $properties
         );
     }
@@ -246,33 +246,33 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
     {
         $properties = array();
 
-        $properties += $this->setPathFromObject(array($connection, 'name'), 'entityId');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:name:nl'), 'nameNl');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:name:en'), 'nameEn');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:displayName:nl'), 'displayNameNl');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:displayName:en'), 'displayNameEn');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:description:nl'), 'descriptionNl');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:description:en'), 'descriptionEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'name'), 'entityId');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:name:nl'), 'nameNl');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:name:en'), 'nameEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:displayName:nl'), 'displayNameNl');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:displayName:en'), 'displayNameEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:description:nl'), 'descriptionNl');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:description:en'), 'descriptionEn');
         $properties += $this->assembleLogo($connection);
         $properties += $this->assembleOrganization($connection, 'nl');
         $properties += $this->assembleOrganization($connection, 'en');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:keywords:en'), 'keywordsEn');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:keywords:nl'), 'keywordsNl');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:publish_in_edugain'), 'publishInEdugain');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:keywords:en'), 'keywordsEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:keywords:nl'), 'keywordsNl');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:publish_in_edugain'), 'publishInEdugain');
         $properties += $this->assembleCertificates($connection);
-        $properties += $this->setPathFromObject(array($connection, 'state'), 'workflowState');
+        $properties += $this->setPathFromObjectString(array($connection, 'state'), 'workflowState');
         $properties += $this->assembleContactPersons($connection);
-        $properties += $this->setPathFromObject(array($connection, 'metadata:NameIDFormat'), 'nameIdFormat');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:NameIDFormats'), 'supportedNameIdFormats');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:NameIDFormat'), 'nameIdFormat');
+        $properties += $this->setPathFromObjectArray(array($connection, 'metadata:NameIDFormats'), 'supportedNameIdFormats');
         $properties += $this->assembleSingleLogoutServices($connection);
         $properties += $this->assemblePublishInEdugainDate($connection);
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:disable_scoping'), 'disableScoping');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:additional_logging'), 'additionalLogging');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:signature_method'), 'signatureMethod');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:redirect:sign'), 'requestsMustBeSigned');
-        $properties += $this->setPathFromObject(array($connection, 'manipulation_code'), 'manipulation');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:url:en'), 'supportUrlEn');
-        $properties += $this->setPathFromObject(array($connection, 'metadata:url:nl'), 'supportUrlNl');
+        $properties += $this->setPathFromObjectBool(array($connection, 'metadata:coin:disable_scoping'), 'disableScoping');
+        $properties += $this->setPathFromObjectBool(array($connection, 'metadata:coin:additional_logging'), 'additionalLogging');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:signature_method'), 'signatureMethod');
+        $properties += $this->setPathFromObjectBool(array($connection, 'metadata:redirect:sign'), 'requestsMustBeSigned');
+        $properties += $this->setPathFromObjectString(array($connection, 'manipulation_code'), 'manipulation');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:url:en'), 'supportUrlEn');
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:url:nl'), 'supportUrlNl');
 
         return $properties;
     }
@@ -390,19 +390,47 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         ));
     }
 
-    private function setPathFromObject($from, $to)
+    private function setPathFromObjectString($from, $to)
+    {
+        $reference = $this->getValueFromPath($from);
+        if (is_null($reference)) {
+            return array($to => null);
+        }
+        return array($to => (string)$reference);
+    }
+
+    private function setPathFromObjectArray($from, $to)
+    {
+        $reference = $this->getValueFromPath($from);
+        if (!array($reference)) {
+            return array();
+        }
+        return array($to => $reference);
+    }
+
+    private function setPathFromObjectBool($from, $to)
+    {
+        $reference = $this->getValueFromPath($from);
+        if (is_null($reference)) {
+            return array($to => null);
+        }
+        return array($to => (bool)$reference);
+    }
+
+    private function getValueFromPath($from)
     {
         $pathParts = explode(':', $from[1]);
 
         $reference = $from[0];
         while ($pathPart = array_shift($pathParts)) {
             if (!isset($reference->$pathPart)) {
-                return array();
+                return null;
             }
 
             $reference = $reference->$pathPart;
         }
-        return array($to => $reference);
+
+        return $reference;
     }
 
     private function assembleSingleSignOnServices($connection)

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
@@ -31,10 +31,10 @@ class CortoDisassembler
 
         $cortoEntity = $this->translateCommon($entity, $cortoEntity);
 
-        if ($entity->isTransparentIssuer) {
+        if ($entity->getCoins()->isTransparentIssuer()) {
             $cortoEntity['TransparentIssuer'] = 'yes';
         }
-        if ($entity->displayUnconnectedIdpsWayf) {
+        if ($entity->getCoins()->displayUnconnectedIdpsWayf()) {
             $cortoEntity['DisplayUnconnectedIdpsWayf'] = 'yes';
         }
         foreach ($entity->assertionConsumerServices as $service) {
@@ -47,19 +47,19 @@ class CortoDisassembler
                 'Location' => $service->location,
             );
         }
-        if (!$entity->isConsentRequired) {
+        if (!$entity->getCoins()->isConsentRequired()) {
             $cortoEntity['NoConsentRequired'] = true;
         }
-        if ($entity->skipDenormalization) {
+        if ($entity->getCoins()->skipDenormalization()) {
             $cortoEntity['SkipDenormalization'] = true;
         }
-        if ($entity->policyEnforcementDecisionRequired) {
+        if ($entity->getCoins()->policyEnforcementDecisionRequired()) {
             $cortoEntity['PolicyEnforcementDecisionRequired'] = true;
         }
         if ($entity->isAttributeAggregationRequired()) {
             $cortoEntity['AttributeAggregationRequired'] = true;
         }
-        if ($entity->requesteridRequired) {
+        if ($entity->getCoins()->requesteridRequired()) {
             $cortoEntity['requesteridRequired'] = true;
         }
 
@@ -87,14 +87,14 @@ class CortoDisassembler
             );
         }
 
-        $cortoEntity['GuestQualifier'] = $entity->guestQualifier;
+        $cortoEntity['GuestQualifier'] = $entity->getCoins()->guestQualifier();
 
-        if ($entity->schacHomeOrganization) {
-            $cortoEntity['SchacHomeOrganization'] = $entity->schacHomeOrganization;
+        if ($entity->getCoins()->schacHomeOrganization()) {
+            $cortoEntity['SchacHomeOrganization'] = $entity->getCoins()->schacHomeOrganization();
         }
 
         $cortoEntity['SpsWithoutConsent'] = $entity->getConsentSettings()->getSpEntityIdsWithoutConsent();
-        $cortoEntity['isHidden'] = $entity->hidden;
+        $cortoEntity['isHidden'] = $entity->getCoins()->hidden();
 
         $cortoEntity['shibmd:scopes'] = array();
         foreach ($entity->shibMdScopes as $scope) {
@@ -121,11 +121,11 @@ class CortoDisassembler
         if ($entity->publishInEduGainDate) {
             $cortoEntity['PublishInEdugainDate'] = $entity->publishInEduGainDate->format(DateTime::W3C);
         }
-        if ($entity->disableScoping) {
+        if ($entity->getCoins()->disableScoping()) {
             $cortoEntity['DisableScoping'] = true;
         }
-        if ($entity->additionalLogging) {
-            $cortoEntity['AdditionalLogging'] = $entity->additionalLogging;
+        if ($entity->getCoins()->additionalLogging()) {
+            $cortoEntity['AdditionalLogging'] = $entity->getCoins()->additionalLogging();
         }
         $cortoEntity = $this->translateCommonCertificates($entity, $cortoEntity);
         if ($entity->logo) {

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -3,7 +3,7 @@
 namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use OpenConext\EngineBlock\Authentication\Dto\Consent;
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
@@ -198,6 +198,15 @@ class IdentityProvider extends AbstractRole
         $this->shibMdScopes = $shibMdScopes;
         $this->singleSignOnServices = $singleSignOnServices;
         $this->consentSettings = $consentSettings;
+
+        $this->coins = Coins::createForIdentityProvider(
+            $guestQualifier,
+            $schacHomeOrganization,
+            $hidden,
+            $disableScoping,
+            $additionalLogging,
+            $signatureMethod
+        );
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
 use OpenConext\EngineBlock\Metadata\Organization;
@@ -20,6 +21,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @SuppressWarnings(PHPMD.TooManyMethods)
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  */
 class ServiceProvider extends AbstractRole
 {
@@ -271,6 +273,21 @@ class ServiceProvider extends AbstractRole
         $this->signResponse = $signResponse;
         $this->supportUrlEn = $supportUrlEn;
         $this->supportUrlNl = $supportUrlNl;
+
+        $this->coins = Coins::createForServiceProvider(
+            $isConsentRequired,
+            $isTransparentIssuer,
+            $isTrustedProxy,
+            $displayUnconnectedIdpsWayf,
+            $termsOfServiceUrl,
+            $skipDenormalization,
+            $policyEnforcementDecisionRequired,
+            $requesteridRequired,
+            $signResponse,
+            $disableScoping,
+            $additionalLogging,
+            $signatureMethod
+        );
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/InMemoryMetadataRepository.php
@@ -204,11 +204,11 @@ class InMemoryMetadataRepository extends AbstractMetadataRepository
 
         $identityProviders = $this->findIdentityProviders();
         foreach ($identityProviders as $identityProvider) {
-            if (!$identityProvider->schacHomeOrganization) {
+            if (!$identityProvider->getCoins()->schacHomeOrganization()) {
                 continue;
             }
 
-            $schacHomeOrganizations[] = $identityProvider->schacHomeOrganization;
+            $schacHomeOrganizations[] = $identityProvider->getCoins()->schacHomeOrganization();
         }
         return $schacHomeOrganizations;
     }

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/MetadataCoinType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/MetadataCoinType.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\Coins;
+
+class MetadataCoinType extends Type
+{
+    const NAME = 'engineblock_metadata_coins';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        if (!$value instanceof Coins) {
+            throw new ConversionException(
+                sprintf(
+                    'Value "%s" must be null or an instance of Coins to be able to ' .
+                    'convert it to a database value',
+                    is_object($value) ? get_class($value) : (string)$value
+                )
+            );
+        }
+
+        return $value->toJson();
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        try {
+            $coins = Coins::fromJson($value);
+        } catch (InvalidArgumentException $e) {
+            // get nice standard message, so we can throw it keeping the exception chain
+            $doctrineExceptionMessage = ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                'valid serialized coin json'
+            )->getMessage();
+
+            throw new ConversionException($doctrineExceptionMessage, 0, $e);
+        }
+
+        return $coins;
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -4,6 +4,7 @@ namespace OpenConext\EngineBlockFunctionalTestingBundle\Fixtures;
 
 use Doctrine\ORM\EntityManager;
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
@@ -133,7 +134,7 @@ class ServiceRegistryFixture
             0
         );
 
-        $sp->termsOfServiceUrl = 'http://welcome.vm.openconext.org';
+        $this->setCoin($sp, 'termsOfServiceUrl', 'http://welcome.vm.openconext.org');
         $sp->logo = new Logo('/images/placeholder.png');
 
         // The repository does not allow us to retrieve all SP's for good reason. In functional testing mode the total
@@ -222,7 +223,7 @@ QUERY;
 
     public function setSpEntityNoConsent($entityId)
     {
-        $this->getServiceProvider($entityId)->isConsentRequired = false;
+        $this->setCoin($this->getServiceProvider($entityId), 'isConsentRequired', false);
 
         return $this;
     }
@@ -236,14 +237,14 @@ QUERY;
 
     public function setSpSignRepsones($entityId, $state = true)
     {
-        $this->getServiceProvider($entityId)->signResponse = (bool)$state;
+        $this->setCoin($this->getServiceProvider($entityId), 'signResponse', (bool)$state);
 
         return $this;
     }
 
     public function setSpEntityTrustedProxy($entityId)
     {
-        $this->getServiceProvider($entityId)->isTrustedProxy = true;
+        $this->setCoin($this->getServiceProvider($entityId), 'isTrustedProxy', true);
 
         return $this;
     }
@@ -278,7 +279,7 @@ QUERY;
 
     public function spRequiresPolicyEnforcementDecisionForSp($entityId)
     {
-        $this->getServiceProvider($entityId)->policyEnforcementDecisionRequired = true;
+        $this->setCoin($this->getServiceProvider($entityId), 'policyEnforcementDecisionRequired', true);
 
         return $this;
     }
@@ -301,12 +302,12 @@ QUERY;
 
     public function requireASignedResponse($entityId)
     {
-        $this->getServiceProvider($entityId)->signResponse = true;
+        $this->setCoin($this->getServiceProvider($entityId), 'signResponse', true);
     }
 
     public function displayUnconnectedIdpsForSp($entityId, $displayUnconnected = true)
     {
-        $this->getServiceProvider($entityId)->displayUnconnectedIdpsWayf = (bool) $displayUnconnected;
+        $this->setCoin($this->getServiceProvider($entityId), 'displayUnconnectedIdpsWayf', (bool) $displayUnconnected);
 
         return $this;
     }
@@ -403,5 +404,21 @@ QUERY;
         );
 
         return $this;
+    }
+
+    private function setCoin(ServiceProvider $sp, $key, $name)
+    {
+        $jsonData = $sp->getCoins()->toJson();
+        $data = json_decode($jsonData, true);
+        $data[$key] = $name;
+        $jsonData = json_encode($data);
+
+        $coins = Coins::fromJson($jsonData);
+
+        $object = new \ReflectionClass($sp);
+
+        $property = $object->getProperty('coins');
+        $property->setAccessible(true);
+        $property->setValue($sp, $coins);
     }
 }

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
@@ -208,7 +208,7 @@ final class ConsentControllerTest extends WebTestCase
                         'en' => $serviceProvider->supportUrlEn,
                         'nl' => $serviceProvider->supportUrlNl,
                     ],
-                    'eula_url' => $serviceProvider->termsOfServiceUrl,
+                    'eula_url' => $serviceProvider->getCoins()->termsOfServiceUrl(),
                     'support_email' => $firstSupportContact->emailAddress,
                     'name_id_format' => $serviceProvider->nameIdFormat,
                 ],

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/ProvideConsentTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/ProvideConsentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
@@ -70,7 +71,7 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends PHPUnit_F
 
     public function testConsentIsSkippedWhenGloballyDisabled()
     {
-        $this->proxyServerMock->getRepository()->fetchServiceProviderByEntityId('testSp')->isConsentRequired = false;
+        $this->setCoin($this->proxyServerMock->getRepository()->fetchServiceProviderByEntityId('testSp'), 'isConsentRequired', false);
 
         $provideConsentService = $this->factoryService();
 
@@ -272,5 +273,21 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends PHPUnit_F
             $this->authStateHelperMock,
             $this->twig
         );
+    }
+
+    private function setCoin(ServiceProvider $sp, $key, $name)
+    {
+        $jsonData = $sp->getCoins()->toJson();
+        $data = json_decode($jsonData, true);
+        $data[$key] = $name;
+        $jsonData = json_encode($data);
+
+        $coins = Coins::fromJson($jsonData);
+
+        $object = new \ReflectionClass($sp);
+
+        $property = $object->getProperty('coins');
+        $property->setAccessible(true);
+        $property->setValue($sp, $coins);
     }
 }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassemblerTest.php
@@ -6,6 +6,7 @@ use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Utils;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -16,14 +17,19 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
 {
     public function testSpDisassemble()
     {
-        $serviceProvider = new ServiceProvider('https://sp.example.edu');
-        $serviceProvider->displayNameNl = 'DisplayName';
-        $serviceProvider->displayNameEn = 'DisplayName';
-        $serviceProvider->isTransparentIssuer = true;
-        $serviceProvider->displayUnconnectedIdpsWayf = true;
-        $serviceProvider->isConsentRequired = false;
-        $serviceProvider->skipDenormalization = true;
-        $serviceProvider->policyEnforcementDecisionRequired = true;
+        $serviceProvider = Utils::instantiate(
+            ServiceProvider::class,
+            [
+                'entityId' => 'https://sp.example.edu',
+                'displayNameNl' => 'DisplayName',
+                'displayNameEn' => 'DisplayName',
+                'isTransparentIssuer' => true,
+                'displayUnconnectedIdpsWayf' => true,
+                'isConsentRequired' => false,
+                'skipDenormalization' => true,
+                'policyEnforcementDecisionRequired' => true,
+            ]
+        );
 
         // set a non-idp arp rule to enable attribute aggregation
         $serviceProvider->attributeReleasePolicy = new AttributeReleasePolicy([
@@ -52,9 +58,9 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($serviceProvider->displayNameNl         , $cortoServiceProvider['DisplayName']['en']);
         $this->assertEquals('yes'                                   , $cortoServiceProvider['TransparentIssuer']);
         $this->assertEquals('yes'                                   , $cortoServiceProvider['DisplayUnconnectedIdpsWayf']);
-        $this->assertEquals(!$serviceProvider->isConsentRequired    , $cortoServiceProvider['NoConsentRequired']);
-        $this->assertEquals($serviceProvider->skipDenormalization   , $cortoServiceProvider['SkipDenormalization']);
-        $this->assertEquals($serviceProvider->policyEnforcementDecisionRequired   , $cortoServiceProvider['PolicyEnforcementDecisionRequired']);
+        $this->assertEquals(!$serviceProvider->getCoins()->isConsentRequired()    , $cortoServiceProvider['NoConsentRequired']);
+        $this->assertEquals($serviceProvider->getCoins()->skipDenormalization()   , $cortoServiceProvider['SkipDenormalization']);
+        $this->assertEquals($serviceProvider->getCoins()->policyEnforcementDecisionRequired()   , $cortoServiceProvider['PolicyEnforcementDecisionRequired']);
         $this->assertEquals($serviceProvider->isAttributeAggregationRequired()        , true);
         $this->assertEquals($serviceProvider->isAttributeAggregationRequired()        , $cortoServiceProvider['AttributeAggregationRequired']);
         $this->assertEquals($contact->contactType, $cortoServiceProvider['ContactPersons'][0]['ContactType']);
@@ -79,9 +85,9 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($cortoIdentityProvider['certificates']);
         $this->assertEquals($identityProvider->supportedNameIdFormats, $cortoIdentityProvider['NameIDFormats']);
         $this->assertEquals($identityProvider->workflowState, $cortoIdentityProvider['WorkflowState']);
-        $this->assertEquals($identityProvider->guestQualifier, $cortoIdentityProvider['GuestQualifier']);
+        $this->assertEquals($identityProvider->getCoins()->guestQualifier(), $cortoIdentityProvider['GuestQualifier']);
         $this->assertEquals($identityProvider->getConsentSettings()->getSpEntityIdsWithoutConsent(), $cortoIdentityProvider['SpsWithoutConsent']);
-        $this->assertEquals($identityProvider->hidden, $cortoIdentityProvider['isHidden']);
+        $this->assertEquals($identityProvider->getCoins()->hidden(), $cortoIdentityProvider['isHidden']);
         $this->assertEmpty($cortoIdentityProvider['shibmd:scopes']);
         $this->assertEquals($contact->contactType, $cortoIdentityProvider['ContactPersons'][0]['ContactType']);
         $this->assertEquals($contact->emailAddress, $cortoIdentityProvider['ContactPersons'][0]['EmailAddress']);


### PR DESCRIPTION
The coin serialization should be available for the next (5.12) release.

The new column is added, but the dedicated fields are kept in place for version roll-back compatibility. We intend to drop these columns in release 5.14 also know as version 6.0.