### PR TITLE
Get termsOfServiceUrl from coins, not SP metadata entity

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -22,11 +22,11 @@
                 <p>
                     {{ 'consent_header_text'|trans({'%arg1%': spName})|raw }}
                 </p>
-                {% if sp.termsOfServiceUrl is not null %}
+                {% if sp.coins.termsOfServiceUrl is not null %}
                     <p>
                         <br>
                         <a class="small"
-                           href="{{ sp.termsOfServiceUrl }}"
+                           href="{{ sp.coins.termsOfServiceUrl }}"
                            target="_blank"><span>{{ 'consent_privacy_link'|trans }}</span></a>
                     </p>
                 {% endif %}


### PR DESCRIPTION
After moving the COIN properties from the SP/AbstractRole metadata entity, the termsOfServiceUrl property was not migrated in the twig template.

I've looked through the templates for other (mis)usages of coins in the twig templates. To no avail.

https://www.pivotaltracker.com/story/show/168565818