### PR TITLE
Prevent WAYF c-button from floating left

### DIFF
--- a/theme/material/stylesheets/application/modules/_results.css.sass
+++ b/theme/material/stylesheets/application/modules/_results.css.sass
@@ -163,10 +163,6 @@
     .action
       display: inline-block
 
-      +max-width($medium)
-        margin-right: auto
-        margin-left: 0
-
   // remove last line of last link
   .list:last-child
     a:last-child,


### PR DESCRIPTION
The button, displayed when the edit previously chosen selection editor is activated. Would float to the left when the viewport size decreased to <= medium. Resulting in a not so elegantly rendered list of previously chosen IdP's.

As a solution. The button now remains floated to the right, but still retains his own row. This to ensure the IdP labels are able to use the maximum width of the row.

See: https://www.pivotaltracker.com/story/show/166694766