### PR TITLE
Update changelog, readme, and the upgrading notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ We will continue to post relevant release notes on the GitHub release page. More
 
 More information about our release strategy can be found in the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes) on the EngineBlock wiki.
 
+## 6.0.0
+In this release, PHP 5.6 support was dropped in favour of PHP 7.2. We are not migrating to the latest PHP version for some reasons. Chief amongst which is that PHP 7.2 was best compatible with the current EngineBlock code base. 
+An upgrade to 7.3 or even 7.4 would force us to upgrade many third party dependencies at the same time, making this release much bigger.
+
+For installation instructions, see the UPGRADING.md entry for this version.
+
+The following changes where introduced in this release:
+
+**Improvements**
+* PHP 7.2 compatibility changes #713
+* Prevent WAYF button from floating left #760
+
+**Bugfix**
+* Get termsOfServiceUrl from coins, not SP metadata entity #756
+
+**Other chores**
+* Cleanup old coin columns #755
+* Bump handlebars to version 4.3.1 #761
+
 ## 5.13.0
 Add stepup authentication to EB to be able to reap the benefits of the SFO functionality of the strong authentication stack.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The following changes where introduced in this release:
 **Other chores**
 * Cleanup old coin columns #755
 * Bump handlebars to version 4.3.1 #761
+* Update Composer settings for improved PHP 7.2 support #763 
 
 ## 5.13.0
 Add stepup authentication to EB to be able to reap the benefits of the SFO functionality of the strong authentication stack.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ To setup the required tooling on the VM, the following steps might be useful:
 
 * Linux
 * Apache
-* PHP 5.6:
+* PHP 7.2:
     - libxml
+    - apcu
+    - apcu-bc (a requirement while we are using an older Doctrine version)
 * MySQL > 5.x with settings:
     - default-storage-engine=InnoDB
     - default-collation=utf8_unicode_ci
@@ -189,8 +191,7 @@ If you are using this pattern, an update can be done with the following:
 
 1. Download and deploy a new version in a new directory.
 
-2. Check out the release notes in docs/release_notes/X.Y.Z.md (where X.Y.Z is the version number) for any
-   additional steps.
+2. Check out the release notes in UPGRADING.md
 
 3. Prepare your environment (see above)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,31 @@
 # UPGRADE NOTES
 
+## 5.x > 6.0
+In version 6 EngineBlock dropped PHP 5.6 support. The amount of backwards breaking changes was kept to a minimum. For example we did not yet upgrade to Symfony 4. But we did use some PHP 7.2 features like the Throwable interface.
+
+Expect more significant upgrades from a PHP 7 standpoint in the near future.  
+
+### For OpenConext-deploy users
+Use an OpenConext-deploy release containing [this revision](https://github.com/OpenConext/OpenConext-deploy/commit/21e75357b1802f346aea0077b8081393865c6112). No release has been tagged after adding the PHP 7.2 support.
+
+In order to get the setup to work afterwards follow the steps described in [this PR](https://github.com/OpenConext/OpenConext-engineblock/pull/713#issue-287892008). Expect updates to OpenConext-deploy in the near future.
+
+### For non-OpencCnext-deploy users
+In order to upgrade your EngineBlock instance, simply upgrade your PHP version to 7.2 and install the following PHP extensions for that version:
+- fpm (if you are using php-fpm)
+- cli
+- pecl-apcu
+- pecl-apcu-bc
+- curl
+- mbstring
+- mysql
+- soap
+- xml
+- gd
+- xdebug (if you plan to do some development)
+
+Upgrade your webserver to use PHP 7.2 for your EngineBlock application.
+
 ## 5.11 > 5.12.0
 
 ### Serialised column cleanup

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,9 +8,7 @@ Expect more significant upgrades from a PHP 7 standpoint in the near future.
 ### For OpenConext-deploy users
 Use an OpenConext-deploy release containing [this revision](https://github.com/OpenConext/OpenConext-deploy/commit/21e75357b1802f346aea0077b8081393865c6112). No release has been tagged after adding the PHP 7.2 support.
 
-In order to get the setup to work afterwards follow the steps described in [this PR](https://github.com/OpenConext/OpenConext-engineblock/pull/713#issue-287892008). Expect updates to OpenConext-deploy in the near future.
-
-### For non-OpencCnext-deploy users
+### For non-OpenConext-deploy users
 In order to upgrade your EngineBlock instance, simply upgrade your PHP version to 7.2 and install the following PHP extensions for that version:
 - fpm (if you are using php-fpm)
 - cli


### PR DESCRIPTION
With the EngineBlock 6.0 release, the different user facing documentation needed some updates. The release notes and upgrading notes received some background information about the 6.0 release. And from the readme, some outdated information was removed. And some important requirements have been added.