### PR TITLE
Remove idp metadata with sp-entity-id from home

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
+use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\MinkContext as BaseMinkContext;
 use DOMDocument;
@@ -85,6 +86,22 @@ class MinkContext extends BaseMinkContext
     }
 
     /**
+     * @Given /^I should see URL "([^"]*)"$/
+     */
+    public function iShouldSeeUrl($url)
+    {
+        $this->assertSession()->responseContains($url);
+    }
+
+    /**
+     * @Given /^I should not see URL "([^"]*)"$/
+     */
+    public function iShouldNotSeeUrl($url)
+    {
+        $this->assertSession()->responseNotContains($url);
+    }
+
+    /**
      * @Given /^I open (\d+) browser tabs identified by "([^"]*)"$/
      */
     public function iOpenTwoBrowserTabsIdentifiedBy($numberOfTabs, $tabNames)
@@ -130,5 +147,22 @@ class MinkContext extends BaseMinkContext
             throw new RuntimeException(sprintf('Unknown window/tab name "%s"', $windowName));
         }
         $this->getSession()->switchToWindow($this->windows[$windowName]);
+    }
+
+    /**
+     * @Then /^I should see (\d+) links on the front page$/
+     */
+    public function iShouldSeeLinksOnTheFrontPage($expectedNumberOfLinks)
+    {
+        $anchors = $this->getSession()->getPage()->findAll('css', '.mod-content a');
+        if (count($anchors) != $expectedNumberOfLinks) {
+            throw new ExpectationException(
+                sprintf(
+                    'The expected amount (%d) of metadata links could not be found on the page',
+                    $expectedNumberOfLinks
+                ),
+                $this->getSession()
+            );
+        }
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/FrontPage.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/FrontPage.feature
@@ -1,0 +1,44 @@
+Feature:
+  In order to inform users of EngineBlock's capabilities
+  As EngineBlock
+  I want to display a front page with links to my metadata endpoints and other features
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+      And no registered SPs
+      And no registered Idps
+
+  Scenario: The user can see all available metadata links
+    When I go to Engineblock URL "/"
+    Then I should see 15 links on the front page
+     And I should see text matching "The Public SAML Signing certificate of the OpenConext IdP"
+     And I should see URL "/authentication/idp/certificate"
+     And I should see URL "/authentication/idp/certificate/key:default"
+     And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext IdP Proxy"
+     And I should see URL "/authentication/idp/metadata"
+     And I should see URL "/authentication/idp/metadata/key:default"
+     And I should see text matching "The Public SAML metadata \(the entities descriptor\) for all the OpenConext IdPs"
+     And I should see URL "/authentication/proxy/idps-metadata"
+     And I should see URL "/authentication/proxy/idps-metadata/key:default"
+     And I should see text matching "The Public SAML metadata \(the entities descriptor\) of the OpenConext IdPs which"
+     And I should see URL "/authentication/proxy/idps-metadata?sp-entity-id=urn:example.org"
+     And I should see URL "/authentication/proxy/idps-metadata/key:default?sp-entity-id=urn:example.org"
+     # The test debug link is present on the page
+     And I should see text matching "Test authentication with an identity provider."
+     And I should see URL "/authentication/sp/debug"
+     And I should see text matching "The Public SAML Signing certificate of the OpenConext SP"
+     And I should see URL "/authentication/sp/certificate"
+     And I should see URL "/authentication/sp/certificate/key:default"
+     And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext SP Proxy"
+     And I should see URL "/authentication/sp/metadata"
+     And I should see URL "/authentication/sp/metadata/key:default"
+     And I should see text matching "Stepup authentication Certificate and Metadata"
+     And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext stepup authentication Proxy"
+     And I should see URL "/authentication/stepup/metadata"
+     And I should see URL "/authentication/stepup/metadata/key:default"
+     # eduGAIN metadata is no longer created by EngineBlock
+     And I should not see text matching "eduGAIN"
+     # IdP / SP metadata combination (for Shiboleth entities) is no longer supported
+     And I should not see text matching "The Public SAML metadata \(the entity descriptor\) of the SURFconext IdP Proxy for SP with entityID"
+     And I should not see URL "/authentication/idp/metadata?sp-entity-id=urn:example.org"
+     And I should not see URL "/authentication/idp/metadata/key:default?sp-entity-id=urn:example.org"

--- a/theme/material/templates/modules/Authentication/View/Index/index.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Index/index.html.twig
@@ -48,21 +48,6 @@
                     case you want a custom WAYF for your SP</p>
             </dt>
             <dt>
-                The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} IdP Proxy for SP
-                with entityID "urn:example.org". Please replace "urn:example.org" with the entityID
-                of your own SP before testing this metadata request. The resulting metadata will include
-                the public key specific to your Service Provider, which, in the case of key rollover,
-                MAY be different from the regular public key.
-            </dt>
-            <dd>
-                <ul>
-                    <li><a href="/authentication/idp/metadata?sp-entity-id=urn:example.org">Open link</a></li>
-                    {% for keyId in keyPairIds %}
-                    <li><a href="/authentication/idp/metadata/key:{{ keyId }}?sp-entity-id=urn:example.org">Open link</a></li>
-                    {% endfor %}
-                </ul>
-            </dd>
-            <dt>
                 The Public SAML metadata (the entities descriptor) of the {{ 'suite_name'|trans }} IdPs which allow
                 access to SP with entityID "urn:example.org". Please replace "urn:example.org" with
                 the entityID of your own SP before testing. The resulting metadata will include all


### PR DESCRIPTION
The EB homepage advertised the possibility to open IdP metadata with the certificate of a specified SP. This feature was not longer supported in Engine. At least, I was not able to reproduce the behavior described for this feature.

There was not a lot to clean up, so only the homepage links have been removed.

See: https://www.pivotaltracker.com/story/show/168249086