### PR TITLE
Show custom error when metadata not found

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -259,6 +259,8 @@ Your %organisationNoun% has denied you access to this service. You will have to 
     'error_stepup_callout_unmet_loa_desc' => 'To continue to this service, a registered token with a certain level of assurance is required. Currently, you either haven\'t registered a token at all, or the level of assurance of token you did register is too low . See the link below for more information about the registration process.',
     'error_stepup_callout_user_cancelled_title' => 'Error - Logging in cancelled',
     'error_stepup_callout_user_cancelled_desc' => 'You have aborted the login process. Go back to the service if you want to try again.',
+    'error_metadata_entity_id_not_found' => 'Metadata can not be generated',
+    'error_metadata_entity_id_not_found_desc' => 'The following error occurred: %message%',
     'attributes_validation_succeeded' => 'Authentication success',
     'attributes_validation_failed'    => 'Some attributes failed validation',
     'attributes_data_mailed'          => 'Attribute data have been mailed',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -262,6 +262,8 @@ Je %organisationNoun% heeft je de toegang geweigerd tot deze dienst. Je zult dus
     'error_stepup_callout_unmet_loa_desc' => 'Om toegang te krijgen tot deze dienst heb je een geregistreerd token nodig met een bepaald zekerheidsniveau. Je hebt nu ofwel geen token geregistreerd, of het zekerheidsniveau van het token dat je hebt geregistreerd is te laag. Volg de link hieronder voor meer informatie over het registratieproces.<br/><br/><a target="_blank" href="https://support.surfconext.nl/stepup-noauthncontext-nl">Lees meer over het registratieproces.</a>',
     'error_stepup_callout_user_cancelled_title' => 'Fout - Inloggen afgebroken',
     'error_stepup_callout_user_cancelled_desc' => 'Je hebt het inloggen afgebroken. Ga terug naar de dienst als je het opnieuw wilt proberen.',
+    'error_metadata_entity_id_not_found' => 'Metadata kan niet gegenereerd worden',
+    'error_metadata_entity_id_not_found_desc' => 'De volgende fout is opgetreden: %message%',
     'attributes_validation_succeeded' => 'Authenticatie geslaagd',
     'attributes_validation_failed'    => 'Sommige attributen kunnen niet gevalideerd worden',
     'attributes_data_mailed'          => 'De attribuutdata zijn gemaild',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -256,6 +256,8 @@ A sua %organisationNoun% negou-lhe acesso a este serviço. Terá de entrar em co
     'error_stepup_callout_unmet_loa_desc' => 'Para continuar neste serviço, é necessário que o token registado tenho um determinado nível de confiança. Atualmente, você não tem um token registado, ou o nível de confiança do seu token é muito baixo. Veja o endereço abaixo para mais informações sobre o processo de registo.<br/><br/><a target="_blank" href="https://support.surfconext.nl/stepup-noauthncontext">Leia mais sobre o processo de registro.</a>',
     'error_stepup_callout_user_cancelled_title' => 'Erro - Carregamento cancelado',
     'error_stepup_callout_user_cancelled_desc' => 'Você cancelou o processo de autenticação. Volte ao serviço se você pretender tentar de novo.',
+    'error_metadata_entity_id_not_found' => 'Metadata can not be generated',
+    'error_metadata_entity_id_not_found_desc' => 'The following error occurred: %message%',
     'attributes_validation_succeeded' => 'Autenticação com sucesso',
     'attributes_validation_failed'    => 'Alguns atributos falharam na validação',
     'attributes_data_mailed'          => 'Os dados dos atributos foram enviados',

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -245,6 +245,29 @@ class FeedbackController
         );
     }
 
+    public function metadataEntityNotFoundAction(Request $request)
+    {
+        // The exception message is used on the error page. As mostly developers or other tech-savvy people will see
+        // this message. The ExceptionListener is responsible for setting the message on the feedback_custom field.
+        $session = $request->getSession();
+        if ($session->has('feedback_custom')) {
+            $message = $session->get('feedback_custom');
+        } else {
+            // This should never occur, when it does, this error page is called from outside the application context
+            // or the exception that shows this page was triggered elsewhere in code without a message.
+            $message = 'More elaborate error details could not be found..';
+        }
+
+        return new Response(
+            $this->twig->render(
+                '@theme/Authentication/View/Feedback/metadata-entity-not-found.html.twig',
+                [
+                    'message' => $message,
+                ]
+            ),
+            404
+        );
+    }
 
     /**
      * @param Request $request

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -46,6 +46,7 @@ use OpenConext\EngineBlock\Exception\InvalidBindingException;
 use OpenConext\EngineBlock\Exception\InvalidRequestMethodException;
 use OpenConext\EngineBlock\Exception\MissingParameterException;
 use OpenConext\EngineBlockBridge\ErrorReporter;
+use OpenConext\EngineBlockBundle\Exception\EntityCanNotBeFoundException;
 use OpenConext\EngineBlockBundle\Exception\StuckInAuthenticationLoopException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -196,6 +197,9 @@ class RedirectToFeedbackPageExceptionListener
         } else if ($exception instanceof EngineBlock_Corto_Exception_InvalidStepupCalloutResponse) {
             $message = $exception->getMessage();
             $redirectToRoute = 'authentication_feedback_stepup_callout_unknown';
+        } else if ($exception instanceof EntityCanNotBeFoundException) {
+            $event->getRequest()->getSession()->set('feedback_custom', $exception->getMessage());
+            $redirectToRoute = 'authentication_feedback_metadata_entity_not_found';
         } else {
             return;
         }

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
@@ -132,3 +132,8 @@ authentication_feedback_stepup_callout_unknown:
     path:       '/stepup-callout-unknown'
     methods:    [GET]
     defaults:    { _controller: engineblock.controller.authentication.feedback:stepupCalloutUnknownAction }
+
+authentication_feedback_metadata_entity_not_found:
+    path:       '/metadata-entity-not-found'
+    methods:    [GET]
+    defaults:    { _controller: engineblock.controller.authentication.feedback:metadataEntityNotFoundAction }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/FrontPage.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/FrontPage.feature
@@ -32,8 +32,8 @@ Feature:
      And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext SP Proxy"
      And I should see URL "/authentication/sp/metadata"
      And I should see URL "/authentication/sp/metadata/key:default"
-     And I should see text matching "Stepup authentication Certificate and Metadata"
-     And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext stepup authentication Proxy"
+     And I should see text matching "Step-up authentication Certificate and Metadata"
+     And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext step-up authentication Proxy"
      And I should see URL "/authentication/stepup/metadata"
      And I should see URL "/authentication/stepup/metadata/key:default"
      # eduGAIN metadata is no longer created by EngineBlock

--- a/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
+++ b/theme/material/javascripts/tests/visual-regression/error-page/ErrorPage.test.js
@@ -114,6 +114,10 @@ const errorPages = [
         name: 'stepup-callout-unknown',
         url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=stepup-callout-unknown&feedback-info=%7B%22statusCode%22%3A%22Responder%2FAuthnFailed%22%2C%22statusMessage%22%3A%22Authentication+cancelled+by+user%22%2C%22requestId%22%3A%225cb4bd3879b49%22%2C%22ipAddress%22%3A%22192.168.66.98%22%2C%22artCode%22%3A%2231914%22%7D&lang=nl'
     },
+    {
+        name: 'metadata-entity-id-not-found',
+        url: 'https://engine.vm.openconext.org/functional-testing/feedback?template=metadata-entity-not-found&parameters={"message":"Could not find your entity"}&feedback-info={"requestId":"5cb4bd3879b49","artCode":"31914", "ipAddress":"192.168.66.98"}'
+    },
 ];
 
 const viewports = [

--- a/theme/material/templates/modules/Authentication/View/Feedback/metadata-entity-not-found.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Feedback/metadata-entity-not-found.html.twig
@@ -1,0 +1,9 @@
+{% extends '@theme/Default/View/Error/error.html.twig' %}
+
+{% set pageTitle = 'error_metadata_entity_id_not_found'|trans %}
+{% set template = _self.getTemplateName().__toString %}
+{% block pageTitle %}{{ pageTitle }}{% endblock %}
+{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block pageHeading %}{{ pageTitle }}{% endblock %}
+
+{% block errorMessage %}<p>{{ 'error_metadata_entity_id_not_found_desc'|trans({'%message%': message}) }}</p>{% endblock %}

--- a/theme/material/templates/modules/Authentication/View/Index/index.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Index/index.html.twig
@@ -117,7 +117,7 @@
           <h2>Step-up authentication Certificate and Metadata</h2>
           <dl class="metadata-certificates-list">
               <dt>
-                  The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} stepup authentication Proxy
+                  The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} step-up authentication Proxy
               </dt>
               <dd>
                   <ul>


### PR DESCRIPTION
The metadata actions where results can be modified using an SP entity ID would result in a generic 500 error. This is not terribly user-friendly. And this PR aims to make the error more clear to the end user by
providing a custom error message. This message is partly built up out of the exception message (which states what entity id was referenced) and a custom error message (translatable).

See: https://www.pivotaltracker.com/story/show/168258776