### PR TITLE
Implement new metadata logic to old endpoints

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Controller/StepupController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/StepupController.php
@@ -21,10 +21,9 @@ namespace OpenConext\EngineBlockBundle\Controller;
 
 use EngineBlock_ApplicationSingleton;
 use EngineBlock_Corto_Adapter;
-use EngineBlock_Corto_Exception_ReceivedErrorStatusCode;
-use EngineBlock_Corto_Exception_UserCancelledStepupCallout;
 use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
+use OpenConext\EngineBlockBundle\Metadata\Service\MetadataService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -72,23 +71,6 @@ class StepupController implements AuthenticationLoopThrottlingController
 
         $proxyServer = new EngineBlock_Corto_Adapter();
         $proxyServer->stepupConsumeAssertion();
-
-        return ResponseFactory::fromEngineBlockResponse($this->engineBlockApplicationSingleton->getHttpResponse());
-    }
-
-    /**
-     * @param null|string $keyId
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
-     */
-    public function metadataAction($keyId = null)
-    {
-        $proxyServer = new EngineBlock_Corto_Adapter();
-
-        if ($keyId !== null) {
-            $proxyServer->setKeyId($keyId);
-        }
-
-        $proxyServer->stepupMetadata();
 
         return ResponseFactory::fromEngineBlockResponse($this->engineBlockApplicationSingleton->getHttpResponse());
     }

--- a/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataService.php
+++ b/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataService.php
@@ -18,9 +18,12 @@
 
 namespace OpenConext\EngineBlockBundle\Metadata\Service;
 
+use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\EngineBlockBundle\Exception\EntityCanNotBeFoundException;
 use OpenConext\EngineBlockBundle\Metadata\MetadataEntityFactory;
 use OpenConext\EngineBlockBundle\Metadata\MetadataFactory;
+use OpenConext\EngineBlockBundle\Stepup\StepupEndpoint;
+use OpenConext\EngineBlockBundle\Stepup\StepupEntityFactory;
 
 class MetadataService
 {
@@ -32,19 +35,31 @@ class MetadataService
      * @var MetadataEntityFactory
      */
     private $metadataEntityFactory;
+    /**
+     * @var MetadataRepositoryInterface
+     */
+    private $metadataRepository;
+    /**
+     * @var StepupEndpoint
+     */
+    private $stepupEndpoint;
 
     /**
      * @param MetadataFactory $factory
      * @param MetadataEntityFactory $metadataEntityFactory
+     * @param MetadataRepositoryInterface $metadataRepository
+     * @param StepupEndpoint $stepupEndpoint
      */
-    public function __construct(MetadataFactory $factory, MetadataEntityFactory $metadataEntityFactory)
+    public function __construct(MetadataFactory $factory, MetadataEntityFactory $metadataEntityFactory, MetadataRepositoryInterface $metadataRepository, StepupEndpoint $stepupEndpoint)
     {
         $this->factory = $factory;
         $this->metadataEntityFactory = $metadataEntityFactory;
+        $this->metadataRepository = $metadataRepository;
+        $this->stepupEndpoint = $stepupEndpoint;
     }
 
     /**
-     * Generate XML metadata for a SP
+     * Generate XML metadata for an SP
      *
      * @param string $entityId
      * @param string $acsLocation
@@ -60,7 +75,6 @@ class MetadataService
         }
         throw new EntityCanNotBeFoundException(sprintf('Unable to find the SP with entity ID "%s".', $entityId));
     }
-
 
     /**
      * Generate XML metadata for an IdP
@@ -78,5 +92,44 @@ class MetadataService
             return $this->factory->fromIdentityProviderEntity($identityProvider, $keyId);
         }
         throw new EntityCanNotBeFoundException(sprintf('Unable to find the SP with entity ID "%s".', $entityId));
+    }
+
+
+    /**
+     * Generate XML proxy metadata for the IdP's of an SP
+     * This will be used to generate the WAYF
+     *
+     * @param string $entityId
+     * @param string $keyId
+     * @param string|null $serviceProviderEntityId
+     * @return string
+     */
+    public function metadataForIdpsOfSp(string $entityId, string $keyId, string $serviceProviderEntityId = null): string
+    {
+        $identityProviders = $this->metadataRepository->findIdentityProviders();
+
+        // Todo: implement sp filter sp-entity-id to list only allowed idps
+        // Todo: hide on coin hidden
+
+        return $this->factory->fromIdentityProviderEntities($identityProviders, $keyId);
+    }
+
+
+    /**
+     * Generate XML metadata for the internal used stepup authentication SP
+     *
+     * @param string $acsLocation
+     * @param string $keyId
+     * @return string
+     * @throws \EngineBlock_Exception
+     */
+    public function metadataForStepup(string $acsLocation, string $keyId): string
+    {
+        $serviceProvider = StepupEntityFactory::spFrom(
+            $this->stepupEndpoint,
+            $acsLocation
+        );
+
+        return $this->factory->fromServiceProviderEntity($serviceProvider, $keyId);
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Metadata/ValueObjects/IdentityProviderMetadataCollection.php
+++ b/src/OpenConext/EngineBlockBundle/Metadata/ValueObjects/IdentityProviderMetadataCollection.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Metadata\ValueObjects;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+class IdentityProviderMetadataCollection implements IteratorAggregate
+{
+    /**
+     * @var IdentityProviderMetadata[]
+     */
+    private $entities = [];
+
+    /**
+     * @param IdentityProviderMetadata $identityProvider
+     */
+    public function add(IdentityProviderMetadata $identityProvider)
+    {
+        $this->entities[] = $identityProvider;
+    }
+
+    /**
+     * @return Traversable
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->entities);
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/metadata.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/metadata.yml
@@ -49,17 +49,17 @@ metadata_all_idps_key:
         keyId: .+
 
 ### Stepup
-metdata_stepup:
-    path:       'authentication/stepup/metadata'
+metadata_stepup:
+    path:       '/authentication/stepup/metadata'
     methods:    [GET]
     defaults:
-        _controller: engineblock.controller.authentication.stepup:metadataAction
+        _controller: engineblock.controller.authentication.metadata:stepupMetadataAction
         keyId: ~
 
-metdata_stepup_key:
+metadata_stepup_key:
     path:       '/authentication/stepup/metadata/key:{keyId}'
     methods:    [GET]
     defaults:
-        _controller: engineblock.controller.authentication.stepup:metadataAction
+        _controller: engineblock.controller.authentication.metadata:stepupMetadataAction
     requirements:
         keyId: .+

--- a/theme/material/templates/modules/Authentication/View/Metadata/idps.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/idps.html.twig
@@ -1,0 +1,50 @@
+{% spaceless %}
+<md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                       validUntil="2019-10-05T09:08:44Z" ID="{{ id }}">
+    {% for metadata in metadataCollection %}
+        <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="{{ metadata.entityId }}">
+            <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                <md:Extensions>
+                    <mdui:UIInfo xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
+                        <mdui:DisplayName xml:lang="nl">OpenConext Engine</mdui:DisplayName>
+                        <mdui:DisplayName xml:lang="en">OpenConext Engine</mdui:DisplayName>
+                        <mdui:Description xml:lang="nl">OpenConext SSO Proxy</mdui:Description>
+                        <mdui:Description xml:lang="en">OpenConext SSO Proxy</mdui:Description>
+                        <mdui:Logo height="96" width="96">https://static.vm.openconext.org/media/conext_logo.png</mdui:Logo>
+                        <mdui:Keywords xml:lang="en">openconext engine engineblock proxy sso saml2</mdui:Keywords>
+                        <mdui:Keywords xml:lang="nl">openconext engine engineblock proxy sso saml2</mdui:Keywords>
+                    </mdui:UIInfo>
+                </md:Extensions>
+                {% for key in metadata.publicKeys %}
+                    <md:KeyDescriptor use="signing">
+                        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                            <ds:X509Data>
+                                <ds:X509Certificate>{{ key }}</ds:X509Certificate>
+                            </ds:X509Data>
+                        </ds:KeyInfo>
+                    </md:KeyDescriptor>
+                {% endfor %}
+                <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+                <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+                <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+                <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ metadata.ssoLocation }}"></md:SingleSignOnService>
+            </md:IDPSSODescriptor>
+            <md:ContactPerson contactType="technical">
+                <md:GivenName>Support</md:GivenName>
+                <md:SurName>OpenConext</md:SurName>
+                <md:EmailAddress>help@example.org</md:EmailAddress>
+            </md:ContactPerson>
+            <md:ContactPerson contactType="support">
+                <md:GivenName>Support</md:GivenName>
+                <md:SurName>OpenConext</md:SurName>
+                <md:EmailAddress>help@example.org</md:EmailAddress>
+            </md:ContactPerson>
+            <md:ContactPerson contactType="administrative">
+                <md:GivenName>Support</md:GivenName>
+                <md:SurName>OpenConext</md:SurName>
+                <md:EmailAddress>help@example.org</md:EmailAddress>
+            </md:ContactPerson>
+        </md:EntityDescriptor>
+    {% endfor %}
+</md:EntitiesDescriptor>
+{% endspaceless %}


### PR DESCRIPTION
The old metadata endpoints are updated in order to use the new
metadata endpoint generation logic with the help of twig.

https://www.pivotaltracker.com/story/show/168258709

The filtering of the proxy IdP's of an SP still needs to be implemented:
`library/EngineBlock/Corto/Module/Service/IdpsMetadata.php`
https://www.pivotaltracker.com/story/show/168979140

