### PR TITLE
Create metadata entity factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ script:
 branches:
   only:
     - master
-    - /^feature/metadata-*.$/
+    - /^feature\/metadata-.*$/
 
 after_failure:
   - sudo tail -500 /var/log/apache2/error.log

--- a/src/OpenConext/EngineBlock/Entities/Adapter/IdentityProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Entities/Adapter/IdentityProviderEntity.php
@@ -1,0 +1,259 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Adapter;
+
+use DateTime;
+use OpenConext\EngineBlock\Entities\IdentityProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ConsentSettings;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+
+class IdentityProviderEntity implements IdentityProviderEntityInterface
+{
+    /**
+     * @var IdentityProvider
+     */
+    private $entity;
+
+    public function __construct(IdentityProvider $entity)
+    {
+        $this->entity = $entity;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->entity->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId(): string
+    {
+        return $this->entity->entityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameNl(): string
+    {
+        return $this->entity->nameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameEn(): string
+    {
+        return $this->entity->nameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl(): string
+    {
+        return $this->entity->descriptionNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn(): string
+    {
+        return $this->entity->descriptionEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameNl(): string
+    {
+        return $this->entity->displayNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameEn(): string
+    {
+        return $this->entity->displayNameEn;
+    }
+
+    /**
+     * @return Logo
+     */
+    public function getLogo(): Logo
+    {
+        return $this->entity->logo;
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationNl(): Organization
+    {
+        return $this->entity->organizationNl;
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationEn(): Organization
+    {
+        return $this->entity->organizationEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywordsNl(): string
+    {
+        return $this->entity->keywordsNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywordsEn(): string
+    {
+        return $this->entity->keywordsEn;
+    }
+
+    /**
+     * @return X509Certificate[]
+     */
+    public function getCertificates(): array
+    {
+        return $this->entity->certificates;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWorkflowState(): string
+    {
+        return $this->entity->workflowState;
+    }
+
+    /**
+     * @return ContactPerson[]
+     */
+    public function getContactPersons(): array
+    {
+        return $this->entity->contactPersons;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameIdFormat(): string
+    {
+        return $this->entity->nameIdFormat;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedNameIdFormats(): array
+    {
+        return $this->entity->supportedNameIdFormats;
+    }
+
+    /**
+     * @return Service
+     */
+    public function getSingleLogoutService(): Service
+    {
+        return $this->entity->singleLogoutService;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequestsMustBeSigned(): bool
+    {
+        return $this->entity->requestsMustBeSigned;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponseProcessingService(): string
+    {
+        return $this->entity->responseProcessingService;
+    }
+
+    /**
+     * @return string
+     */
+    public function getManipulation(): string
+    {
+        return $this->entity->manipulation;
+    }
+
+    /**
+     * @return Coins
+     */
+    public function getCoins(): Coins
+    {
+        return $this->entity->getCoins();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabledInWayf(): bool
+    {
+        return $this->entity->enabledInWayf;
+    }
+
+    /**
+     * @return Service[]
+     */
+    public function getSingleSignOnServices(): array
+    {
+        return $this->entity->singleSignOnServices;
+    }
+
+    /**
+     * @return ConsentSettings
+     */
+    public function getConsentSettings(): ConsentSettings
+    {
+        return $this->entity->getConsentSettings();
+    }
+
+    /**
+     * @return ShibMdScope[]
+     */
+    public function getShibMdScopes(): array
+    {
+        return $this->entity->shibMdScopes;
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Adapter/ServiceProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Entities/Adapter/ServiceProviderEntity.php
@@ -1,0 +1,283 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Adapter;
+
+use OpenConext\EngineBlock\Entities\ServiceProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\IndexedService;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\RequestedAttribute;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+
+class ServiceProviderEntity implements ServiceProviderEntityInterface
+{
+    /**
+     * @var ServiceProvider
+     */
+    private $entity;
+
+    public function __construct(ServiceProvider $entity)
+    {
+        $this->entity = $entity;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->entity->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId(): string
+    {
+        return $this->entity->entityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameNl(): string
+    {
+        return $this->entity->nameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameEn(): string
+    {
+        return $this->entity->nameEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl(): string
+    {
+        return $this->entity->descriptionNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn(): string
+    {
+        return $this->entity->descriptionEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameNl(): string
+    {
+        return $this->entity->displayNameNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameEn(): string
+    {
+        return $this->entity->displayNameEn;
+    }
+
+    /**
+     * @return Logo
+     */
+    public function getLogo(): Logo
+    {
+        return $this->entity->logo;
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationNl(): Organization
+    {
+        return $this->entity->organizationNl;
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationEn(): Organization
+    {
+        return $this->entity->organizationEn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywordsNl(): string
+    {
+        return $this->entity->keywordsNl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywordsEn(): string
+    {
+        return $this->entity->keywordsEn;
+    }
+
+    /**
+     * @return X509Certificate[]
+     */
+    public function getCertificates(): array
+    {
+        return $this->entity->certificates;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWorkflowState(): string
+    {
+        return $this->entity->workflowState;
+    }
+
+    /**
+     * @return ContactPerson[]
+     */
+    public function getContactPersons(): array
+    {
+        return $this->entity->contactPersons;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameIdFormat(): string
+    {
+        return $this->entity->nameIdFormat;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedNameIdFormats(): array
+    {
+        return $this->entity->supportedNameIdFormats;
+    }
+
+    /**
+     * @return Service
+     */
+    public function getSingleLogoutService(): Service
+    {
+        return $this->entity->singleLogoutService;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequestsMustBeSigned(): bool
+    {
+        return $this->entity->requestsMustBeSigned;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponseProcessingService(): string
+    {
+        return $this->entity->responseProcessingService;
+    }
+
+    /**
+     * @return string
+     */
+    public function getManipulation(): string
+    {
+        return $this->entity->manipulation;
+    }
+
+    /**
+     * @return Coins
+     */
+    public function getCoins(): Coins
+    {
+        return $this->entity->getCoins();
+    }
+
+    /**
+     * @return AttributeReleasePolicy|null
+     */
+    public function getAttributeReleasePolicy(): ?AttributeReleasePolicy
+    {
+        return $this->entity->attributeReleasePolicy;
+    }
+
+    /**
+     * @return IndexedService[]
+     */
+    public function getAssertionConsumerServices(): array
+    {
+        return $this->entity->assertionConsumerServices;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedIdpEntityIds(): array
+    {
+        return $this->entity->allowedIdpEntityIds;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllowAll(): bool
+    {
+        return $this->entity->allowAll;
+    }
+
+    /**
+     * @return RequestedAttribute[]|null
+     */
+    public function getRequestedAttributes(): ?array
+    {
+        return $this->entity->requestedAttributes;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSupportUrlEn(): ?string
+    {
+        return $this->entity->supportUrlEn;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSupportUrlNl(): ?string
+    {
+        return $this->entity->supportUrlNl;
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Decorator/AbstractIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Entities/Decorator/AbstractIdentityProvider.php
@@ -1,0 +1,264 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Decorator;
+
+use DateTime;
+use OpenConext\EngineBlock\Entities\IdentityProviderEntityInterface;
+use OpenConext\EngineBlock\Entities\ServiceProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ConsentSettings;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+
+class AbstractIdentityProvider implements IdentityProviderEntityInterface
+{
+
+    /**
+     * @var IdentityProviderEntityInterface
+     */
+    protected $entity;
+
+    /**
+     * @param IdentityProviderEntityInterface $entity
+     */
+    public function __construct(IdentityProviderEntityInterface $entity)
+    {
+        $this->entity = $entity;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->entity->getId();
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId(): string
+    {
+        return $this->entity->getEntityId();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameNl(): string
+    {
+        return $this->entity->getNameNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameEn(): string
+    {
+        return $this->entity->getNameEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl(): string
+    {
+        return $this->entity->getDescriptionNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn(): string
+    {
+        return $this->entity->getDescriptionEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameNl(): string
+    {
+        return $this->entity->getDisplayNameNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameEn(): string
+    {
+        return $this->entity->getDisplayNameEn();
+    }
+
+    /**
+     * @return Logo
+     */
+    public function getLogo(): Logo
+    {
+        return $this->entity->getLogo();
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationNl(): Organization
+    {
+        return $this->entity->getOrganizationNl();
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationEn(): Organization
+    {
+        return $this->entity->getOrganizationEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywordsNl(): string
+    {
+        return $this->entity->getKeywordsNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywordsEn(): string
+    {
+        return $this->entity->getKeywordsEn();
+    }
+
+    /**
+     * @return X509Certificate[]
+     */
+    public function getCertificates(): array
+    {
+        return $this->entity->getCertificates();
+    }
+
+    /**
+     * @return string
+     */
+    public function getWorkflowState(): string
+    {
+        return $this->entity->getWorkflowState();
+    }
+
+    /**
+     * @return ContactPerson[]
+     */
+    public function getContactPersons(): array
+    {
+        return $this->entity->getContactPersons();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameIdFormat(): string
+    {
+        return $this->entity->getNameIdFormat();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedNameIdFormats(): array
+    {
+        return $this->entity->getSupportedNameIdFormats();
+    }
+
+    /**
+     * @return Service
+     */
+    public function getSingleLogoutService(): Service
+    {
+        return $this->entity->getSingleLogoutService();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequestsMustBeSigned(): bool
+    {
+        return $this->entity->isRequestsMustBeSigned();
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponseProcessingService(): string
+    {
+        return $this->entity->getResponseProcessingService();
+    }
+
+    /**
+     * @return string
+     */
+    public function getManipulation(): string
+    {
+        return $this->entity->getManipulation();
+    }
+
+    /**
+     * @return Coins
+     */
+    public function getCoins(): Coins
+    {
+        return $this->entity->getCoins();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabledInWayf(): bool
+    {
+        return $this->entity->isEnabledInWayf();
+    }
+
+    /**
+     * @return Service[]
+     */
+    public function getSingleSignOnServices(): array
+    {
+        return $this->entity->getSingleSignOnServices();
+    }
+
+    /**
+     * @return ConsentSettings
+     */
+    public function getConsentSettings(): ConsentSettings
+    {
+        return $this->entity->getConsentSettings();
+    }
+
+    /**
+     * @return ShibMdScope[]
+     */
+    public function getShibMdScopes(): array
+    {
+        return $this->entity->getShibMdScopes();
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Decorator/AbstractServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Entities/Decorator/AbstractServiceProvider.php
@@ -1,0 +1,291 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Decorator;
+
+use DateTime;
+use OpenConext\EngineBlock\Entities\IdentityProviderEntityInterface;
+use OpenConext\EngineBlock\Entities\ServiceProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ConsentSettings;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\IndexedService;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\RequestedAttribute;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+
+class AbstractServiceProvider implements ServiceProviderEntityInterface
+{
+
+    /**
+     * @var ServiceProviderEntityInterface
+     */
+    protected $entity;
+
+    /**
+     * @param ServiceProviderEntityInterface $entity
+     */
+    public function __construct(ServiceProviderEntityInterface $entity)
+    {
+        $this->entity = $entity;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->entity->getId();
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityId(): string
+    {
+        return $this->entity->getEntityId();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameNl(): string
+    {
+        return $this->entity->getNameNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameEn(): string
+    {
+        return $this->entity->getNameEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl(): string
+    {
+        return $this->entity->getDescriptionNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn(): string
+    {
+        return $this->entity->getDescriptionEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameNl(): string
+    {
+        return $this->entity->getDisplayNameNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameEn(): string
+    {
+        return $this->entity->getDisplayNameEn();
+    }
+
+    /**
+     * @return Logo
+     */
+    public function getLogo(): Logo
+    {
+        return $this->entity->getLogo();
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationNl(): Organization
+    {
+        return $this->entity->getOrganizationNl();
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationEn(): Organization
+    {
+        return $this->entity->getOrganizationEn();
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywordsNl(): string
+    {
+        return $this->entity->getKeywordsNl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywordsEn(): string
+    {
+        return $this->entity->getKeywordsEn();
+    }
+
+    /**
+     * @return X509Certificate[]
+     */
+    public function getCertificates(): array
+    {
+        return $this->entity->getCertificates();
+    }
+
+    /**
+     * @return string
+     */
+    public function getWorkflowState(): string
+    {
+        return $this->entity->getWorkflowState();
+    }
+
+    /**
+     * @return ContactPerson[]
+     */
+    public function getContactPersons(): array
+    {
+        return $this->entity->getContactPersons();
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameIdFormat(): string
+    {
+        return $this->entity->getNameIdFormat();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedNameIdFormats(): array
+    {
+        return $this->entity->getSupportedNameIdFormats();
+    }
+
+    /**
+     * @return Service
+     */
+    public function getSingleLogoutService(): Service
+    {
+        return $this->entity->getSingleLogoutService();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequestsMustBeSigned(): bool
+    {
+        return $this->entity->isRequestsMustBeSigned();
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponseProcessingService(): string
+    {
+        return $this->entity->getResponseProcessingService();
+    }
+
+    /**
+     * @return string
+     */
+    public function getManipulation(): string
+    {
+        return $this->entity->getManipulation();
+    }
+
+    /**
+     * @return Coins
+     */
+    public function getCoins(): Coins
+    {
+        return $this->entity->getCoins();
+    }
+
+    /**
+     * @return AttributeReleasePolicy|null
+     */
+    public function getAttributeReleasePolicy(): ?AttributeReleasePolicy
+    {
+        return $this->entity->getAttributeReleasePolicy();
+    }
+
+    /**
+     * @return IndexedService[]
+     */
+    public function getAssertionConsumerServices(): array
+    {
+        return $this->entity->getAssertionConsumerServices();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedIdpEntityIds(): array
+    {
+        return $this->entity->getAllowedIdpEntityIds();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllowAll(): bool
+    {
+        return $this->entity->isAllowAll();
+    }
+
+    /**
+     * @return RequestedAttribute[]|null
+     */
+    public function getRequestedAttributes(): ?array
+    {
+        return $this->entity->getRequestedAttributes();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSupportUrlEn(): ?string
+    {
+        return $this->entity->getSupportUrlEn();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSupportUrlNl(): ?string
+    {
+        return $this->entity->getSupportUrlNl();
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Decorator/IdentityProviderProxy.php
+++ b/src/OpenConext/EngineBlock/Entities/Decorator/IdentityProviderProxy.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Decorator;
+
+use OpenConext\EngineBlock\Entities\IdentityProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
+use SAML2\Constants;
+
+class IdentityProviderProxy extends AbstractIdentityProvider
+{
+    /**
+     * @var X509KeyPair
+     */
+    private $keyPair;
+
+    public function __construct(
+        IdentityProviderEntityInterface $entity,
+        X509KeyPair $keyPair
+    ) {
+        parent::__construct($entity);
+
+        $this->keyPair = $keyPair;
+    }
+
+    public function getCertificates(): array
+    {
+        return [$this->keyPair->getCertificate()];
+    }
+
+    public function getSupportedNameIdFormats(): array
+    {
+        return [
+            Constants::NAMEID_PERSISTENT,
+            Constants::NAMEID_TRANSIENT,
+            Constants::NAMEID_UNSPECIFIED,
+        ];
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Decorator/IdentityProviderStepup.php
+++ b/src/OpenConext/EngineBlock/Entities/Decorator/IdentityProviderStepup.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Decorator;
+
+class IdentityProviderStepup extends AbstractIdentityProvider
+{
+    public function getSsoLocation(): string
+    {
+        return $this->entity->getSingleSignOnServices()[0]->location;
+    }
+
+    public function getPublicKeys(): array
+    {
+        $keys = [];
+        foreach ($this->entity->getCertificates() as $certificate) {
+            $pem = $certificate->toCertData();
+            $keys[$pem] = $pem;
+        }
+        return $keys;
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Decorator/ServiceProviderProxy.php
+++ b/src/OpenConext/EngineBlock/Entities/Decorator/ServiceProviderProxy.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Decorator;
+
+use EngineBlock_Attributes_Metadata as AttributesMetadata;
+use OpenConext\EngineBlock\Entities\ServiceProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\RequestedAttribute;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
+use SAML2\Constants;
+
+class ServiceProviderProxy extends AbstractServiceProvider
+{
+    /**
+     * @var X509KeyPair
+     */
+    private $keyPair;
+    /**
+     * @var AttributesMetadata
+     */
+    private $attributes;
+    /**
+     * @var Service
+     */
+    private $consentService;
+
+    public function __construct(
+        ServiceProviderEntityInterface $entity,
+        X509KeyPair $keyPair,
+        AttributesMetadata $attributes,
+        Service $consentService
+    ) {
+        parent::__construct($entity);
+
+        $this->keyPair = $keyPair;
+        $this->attributes = $attributes;
+        $this->consentService = $consentService;
+    }
+
+
+    public function getCertificates(): array
+    {
+        return [$this->keyPair->getCertificate()];
+    }
+
+    public function getSupportedNameIdFormats(): array
+    {
+        return [
+            Constants::NAMEID_PERSISTENT,
+            Constants::NAMEID_TRANSIENT,
+            Constants::NAMEID_UNSPECIFIED,
+        ];
+    }
+
+    public function getRequestedAttributes(): ?array
+    {
+        $attributes = [];
+        foreach ($this->attributes->findRequestedAttributeIds() as $attributeId) {
+            $attributes[] = new RequestedAttribute($attributeId);
+        }
+
+        foreach ($this->attributes->findRequiredAttributeIds() as $attributeId) {
+            $attributes[] = new RequestedAttribute($attributeId, true);
+        }
+
+        return $attributes;
+    }
+
+    public function getResponseProcessingService(): string
+    {
+        return $this->consentService;
+    }
+
+    public function isAllowAll(): bool
+    {
+        return true;
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Decorator/ServiceProviderStepup.php
+++ b/src/OpenConext/EngineBlock/Entities/Decorator/ServiceProviderStepup.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Decorator;
+
+class ServiceProviderStepup extends AbstractServiceProvider
+{
+    public function getAcsLocation(): string
+    {
+        return $this->entity->getAssertionConsumerServices()[0]->location;
+    }
+
+    public function getPublicKeys(): array
+    {
+        $keys = [];
+        foreach ($this->entity->getCertificates() as $certificate) {
+            $pem = $certificate->toCertData();
+            $keys[$pem] = $pem;
+        }
+        return $keys;
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Factory/IdentityProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Entities/Factory/IdentityProviderFactory.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Factory;
+
+use OpenConext\EngineBlock\Entities\Adapter\IdentityProviderEntity;
+use OpenConext\EngineBlock\Entities\Decorator\IdentityProviderProxy;
+use OpenConext\EngineBlock\Entities\Decorator\IdentityProviderStepup;
+use OpenConext\EngineBlock\Entities\IdentityProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
+use SAML2\Constants;
+
+class IdentityProviderFactory
+{
+    /**
+     * @var X509KeyPair
+     */
+    private $proxyKeyPair;
+
+    public function __construct(X509KeyPair $proxyKeyPair)
+    {
+        $this->proxyKeyPair = $proxyKeyPair;
+    }
+
+    public function createEntityFromEntity(IdentityProvider $entity): IdentityProviderEntityInterface
+    {
+        return new IdentityProviderEntity($entity);
+    }
+
+    public function createProxyFromEntity(IdentityProvider $entity): IdentityProviderEntityInterface
+    {
+        return new IdentityProviderProxy($this->createEntityFromEntity($entity), $this->proxyKeyPair);
+    }
+
+    public function createStepupFromEntity(IdentityProvider $entity): IdentityProviderEntityInterface
+    {
+        return new IdentityProviderStepup($this->createEntityFromEntity($entity));
+    }
+
+    public function createMinimalEntity(
+        string $entityId,
+        string $ssoLocation,
+        X509Certificate $certificate,
+        string $ssoBindingMethod = Constants::BINDING_HTTP_REDIRECT
+    ): IdentityProviderEntityInterface {
+        $entity = new IdentityProvider($entityId);
+        $entity->singleSignOnServices[] = new Service($ssoLocation, $ssoBindingMethod);
+        $entity->certificates[] = $certificate;
+
+        return $this->createEntityFromEntity($entity);
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/Factory/ServiceProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Entities/Factory/ServiceProviderFactory.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities\Factory;
+
+use EngineBlock_Attributes_Metadata as AttributesMetadata;
+use OpenConext\EngineBlock\Entities\Adapter\ServiceProviderEntity;
+use OpenConext\EngineBlock\Entities\Decorator\ServiceProviderProxy;
+use OpenConext\EngineBlock\Entities\ServiceProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\IndexedService;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
+use SAML2\Constants;
+
+class ServiceProviderFactory
+{
+    /**
+     * @var X509KeyPair
+     */
+    private $proxyKeyPair;
+    /**
+     * @var AttributesMetadata
+     */
+    private $attributes;
+    /**
+     * @var Service
+     */
+    private $consentService;
+
+    public function __construct(
+        X509KeyPair $proxyKeyPair,
+        AttributesMetadata $attributes,
+        Service $consentService
+    ) {
+        $this->proxyKeyPair = $proxyKeyPair;
+        $this->attributes = $attributes;
+        $this->consentService = $consentService;
+    }
+
+    public function createEntityFromEntity(ServiceProvider $entity): ServiceProviderEntityInterface
+    {
+        return new ServiceProviderEntity($entity);
+    }
+
+    public function createProxyFromEntity(ServiceProvider $entity): ServiceProviderEntityInterface
+    {
+        return new ServiceProviderProxy($this->createEntityFromEntity($entity), $this->proxyKeyPair, $this->attributes, $this->consentService);
+    }
+
+    public function createMinimalEntity(
+        string $entityId,
+        string $acsLocation,
+        X509Certificate $certificate,
+        string $acsBindingMethod = Constants::BINDING_HTTP_POST
+    ): ServiceProviderEntityInterface {
+        $entity = new ServiceProvider($entityId);
+        $entity->certificates[] = $certificate;
+        $entity->assertionConsumerServices[] = new IndexedService(
+            $acsLocation,
+            $acsBindingMethod,
+            0
+        );
+
+        return $this->createEntityFromEntity($entity);
+    }
+}

--- a/src/OpenConext/EngineBlock/Entities/IdentityProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Entities/IdentityProviderEntityInterface.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities;
+
+use DateTime;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ConsentSettings;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+
+interface IdentityProviderEntityInterface
+{
+
+    /**
+     * @return int
+     */
+    public function getId(): int;
+
+    /**
+     * @return string
+     */
+    public function getEntityId(): string;
+
+    /**
+     * @return string
+     */
+    public function getNameNl(): string;
+
+    /**
+     * @return string
+     */
+    public function getNameEn(): string;
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl(): string;
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn(): string;
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameNl(): string;
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameEn(): string;
+
+    /**
+     * @return Logo
+     */
+    public function getLogo(): Logo;
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationNl(): Organization;
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationEn(): Organization;
+
+    /**
+     * @return string
+     */
+    public function getKeywordsNl(): string;
+
+    /**
+     * @return string
+     */
+    public function getKeywordsEn(): string;
+
+    /**
+     * @return X509Certificate[]
+     */
+    public function getCertificates(): array;
+
+    /**
+     * @return string
+     */
+    public function getWorkflowState(): string;
+
+    /**
+     * @return ContactPerson[]
+     */
+    public function getContactPersons(): array;
+
+    /**
+     * @return string
+     */
+    public function getNameIdFormat(): string;
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedNameIdFormats(): array;
+
+    /**
+     * @return Service
+     */
+    public function getSingleLogoutService(): Service;
+
+    /**
+     * @return bool
+     */
+    public function isRequestsMustBeSigned(): bool;
+
+    /**
+     * @return string
+     */
+    public function getResponseProcessingService(): string;
+
+    /**
+     * @return string
+     */
+    public function getManipulation(): string;
+
+    /**
+     * @return Coins
+     */
+    public function getCoins(): Coins;
+
+    /**
+     * @return bool
+     */
+    public function isEnabledInWayf(): bool;
+
+    /**
+     * @return Service[]
+     */
+    public function getSingleSignOnServices(): array;
+
+    /**
+     * @return ConsentSettings
+     */
+    public function getConsentSettings(): ConsentSettings;
+
+    /**
+     * @return ShibMdScope[]
+     */
+    public function getShibMdScopes(): array;
+}

--- a/src/OpenConext/EngineBlock/Entities/ServiceProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Entities/ServiceProviderEntityInterface.php
@@ -1,0 +1,182 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Entities;
+
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\IndexedService;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\RequestedAttribute;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+
+interface ServiceProviderEntityInterface
+{
+
+    /**
+     * @return int
+     */
+    public function getId(): int;
+
+    /**
+     * @return string
+     */
+    public function getEntityId(): string;
+
+    /**
+     * @return string
+     */
+    public function getNameNl(): string;
+
+    /**
+     * @return string
+     */
+    public function getNameEn(): string;
+
+    /**
+     * @return string
+     */
+    public function getDescriptionNl(): string;
+
+    /**
+     * @return string
+     */
+    public function getDescriptionEn(): string;
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameNl(): string;
+
+    /**
+     * @return string
+     */
+    public function getDisplayNameEn(): string;
+
+    /**
+     * @return Logo
+     */
+    public function getLogo(): Logo;
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationNl(): Organization;
+
+    /**
+     * @return Organization
+     */
+    public function getOrganizationEn(): Organization;
+
+    /**
+     * @return string
+     */
+    public function getKeywordsNl(): string;
+
+    /**
+     * @return string
+     */
+    public function getKeywordsEn(): string;
+
+    /**
+     * @return X509Certificate[]
+     */
+    public function getCertificates(): array;
+
+    /**
+     * @return string
+     */
+    public function getWorkflowState(): string;
+
+    /**
+     * @return ContactPerson[]
+     */
+    public function getContactPersons(): array;
+
+    /**
+     * @return string
+     */
+    public function getNameIdFormat(): string;
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedNameIdFormats(): array;
+
+    /**
+     * @return Service
+     */
+    public function getSingleLogoutService(): Service;
+
+    /**
+     * @return bool
+     */
+    public function isRequestsMustBeSigned(): bool;
+
+    /**
+     * @return string
+     */
+    public function getResponseProcessingService(): string;
+
+    /**
+     * @return string
+     */
+    public function getManipulation(): string;
+
+    /**
+     * @return Coins
+     */
+    public function getCoins(): Coins;
+
+    /**
+     * @return AttributeReleasePolicy|null
+     */
+    public function getAttributeReleasePolicy(): ?AttributeReleasePolicy;
+
+    /**
+     * @return IndexedService[]
+     */
+    public function getAssertionConsumerServices(): array;
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedIdpEntityIds(): array;
+
+    /**
+     * @return bool
+     */
+    public function isAllowAll(): bool;
+
+    /**
+     * @return RequestedAttribute[]|null
+     */
+    public function getRequestedAttributes(): ?array;
+
+    /**
+     * @return string|null
+     */
+    public function getSupportUrlEn(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getSupportUrlNl(): ?string;
+}

--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -209,7 +209,7 @@ class Coins
 
     public function signatureMethod()
     {
-        return $this->getValue('signatureMethod', XMLSecurityKey::RSA_SHA1);
+        return $this->getValue('signatureMethod', XMLSecurityKey::RSA_SHA256);
     }
 
     private function getValue($key, $default = null)

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -145,7 +145,7 @@ class IdentityProvider extends AbstractRole
         $publishInEduGainDate = null,
         $publishInEdugain = false,
         $requestsMustBeSigned = false,
-        $signatureMethod = XMLSecurityKey::RSA_SHA1,
+        $signatureMethod = XMLSecurityKey::RSA_SHA256,
         Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         $manipulation = '',

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -163,7 +163,7 @@ class ServiceProvider extends AbstractRole
         $publishInEduGainDate = null,
         $publishInEdugain = false,
         $requestsMustBeSigned = false,
-        $signatureMethod = XMLSecurityKey::RSA_SHA1,
+        $signatureMethod = XMLSecurityKey::RSA_SHA256,
         Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         array $allowedIdpEntityIds = array(),

--- a/src/OpenConext/EngineBlockBundle/Controller/StepupController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/StepupController.php
@@ -23,7 +23,6 @@ use EngineBlock_ApplicationSingleton;
 use EngineBlock_Corto_Adapter;
 use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
-use OpenConext\EngineBlockBundle\Metadata\Service\MetadataService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 

--- a/src/OpenConext/EngineBlockBundle/Controller/StepupController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/StepupController.php
@@ -21,10 +21,9 @@ namespace OpenConext\EngineBlockBundle\Controller;
 
 use EngineBlock_ApplicationSingleton;
 use EngineBlock_Corto_Adapter;
-use EngineBlock_Corto_Exception_ReceivedErrorStatusCode;
-use EngineBlock_Corto_Exception_UserCancelledStepupCallout;
 use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
+use OpenConext\EngineBlockBundle\Metadata\Service\MetadataService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -72,23 +71,6 @@ class StepupController implements AuthenticationLoopThrottlingController
 
         $proxyServer = new EngineBlock_Corto_Adapter();
         $proxyServer->stepupConsumeAssertion();
-
-        return ResponseFactory::fromEngineBlockResponse($this->engineBlockApplicationSingleton->getHttpResponse());
-    }
-
-    /**
-     * @param null|string $keyId
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
-     */
-    public function metadataAction($keyId = null)
-    {
-        $proxyServer = new EngineBlock_Corto_Adapter();
-
-        if ($keyId !== null) {
-            $proxyServer->setKeyId($keyId);
-        }
-
-        $proxyServer->stepupMetadata();
 
         return ResponseFactory::fromEngineBlockResponse($this->engineBlockApplicationSingleton->getHttpResponse());
     }

--- a/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataService.php
+++ b/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataService.php
@@ -50,8 +50,12 @@ class MetadataService
      * @param MetadataRepositoryInterface $metadataRepository
      * @param StepupEndpoint $stepupEndpoint
      */
-    public function __construct(MetadataFactory $factory, MetadataEntityFactory $metadataEntityFactory, MetadataRepositoryInterface $metadataRepository, StepupEndpoint $stepupEndpoint)
-    {
+    public function __construct(
+        MetadataFactory $factory,
+        MetadataEntityFactory $metadataEntityFactory,
+        MetadataRepositoryInterface $metadataRepository,
+        StepupEndpoint $stepupEndpoint
+    ) {
         $this->factory = $factory;
         $this->metadataEntityFactory = $metadataEntityFactory;
         $this->metadataRepository = $metadataRepository;
@@ -97,7 +101,7 @@ class MetadataService
 
     /**
      * Generate XML proxy metadata for the IdP's of an SP
-     * This will be used to generate the WAYF
+     * This can be used to generate the WAYF
      *
      * @param string $entityId
      * @param string $keyId

--- a/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataService.php
+++ b/src/OpenConext/EngineBlockBundle/Metadata/Service/MetadataService.php
@@ -18,9 +18,12 @@
 
 namespace OpenConext\EngineBlockBundle\Metadata\Service;
 
+use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\EngineBlockBundle\Exception\EntityCanNotBeFoundException;
 use OpenConext\EngineBlockBundle\Metadata\MetadataEntityFactory;
 use OpenConext\EngineBlockBundle\Metadata\MetadataFactory;
+use OpenConext\EngineBlockBundle\Stepup\StepupEndpoint;
+use OpenConext\EngineBlockBundle\Stepup\StepupEntityFactory;
 
 class MetadataService
 {
@@ -32,19 +35,31 @@ class MetadataService
      * @var MetadataEntityFactory
      */
     private $metadataEntityFactory;
+    /**
+     * @var MetadataRepositoryInterface
+     */
+    private $metadataRepository;
+    /**
+     * @var StepupEndpoint
+     */
+    private $stepupEndpoint;
 
     /**
      * @param MetadataFactory $factory
      * @param MetadataEntityFactory $metadataEntityFactory
+     * @param MetadataRepositoryInterface $metadataRepository
+     * @param StepupEndpoint $stepupEndpoint
      */
-    public function __construct(MetadataFactory $factory, MetadataEntityFactory $metadataEntityFactory)
+    public function __construct(MetadataFactory $factory, MetadataEntityFactory $metadataEntityFactory, MetadataRepositoryInterface $metadataRepository, StepupEndpoint $stepupEndpoint)
     {
         $this->factory = $factory;
         $this->metadataEntityFactory = $metadataEntityFactory;
+        $this->metadataRepository = $metadataRepository;
+        $this->stepupEndpoint = $stepupEndpoint;
     }
 
     /**
-     * Generate XML metadata for a SP
+     * Generate XML metadata for an SP
      *
      * @param string $entityId
      * @param string $acsLocation
@@ -60,7 +75,6 @@ class MetadataService
         }
         throw new EntityCanNotBeFoundException(sprintf('Unable to find the SP with entity ID "%s".', $entityId));
     }
-
 
     /**
      * Generate XML metadata for an IdP
@@ -78,5 +92,44 @@ class MetadataService
             return $this->factory->fromIdentityProviderEntity($identityProvider, $keyId);
         }
         throw new EntityCanNotBeFoundException(sprintf('Unable to find the SP with entity ID "%s".', $entityId));
+    }
+
+
+    /**
+     * Generate XML proxy metadata for the IdP's of an SP
+     * This will be used to generate the WAYF
+     *
+     * @param string $entityId
+     * @param string $keyId
+     * @param string|null $serviceProviderEntityId
+     * @return string
+     */
+    public function metadataForIdpsOfSp(string $entityId, string $keyId, string $serviceProviderEntityId = null): string
+    {
+        $identityProviders = $this->metadataRepository->findIdentityProviders();
+
+        // Todo: implement sp filter sp-entity-id to list only allowed idps
+        // Todo: hide on coin hidden
+
+        return $this->factory->fromIdentityProviderEntities($identityProviders, $keyId);
+    }
+
+
+    /**
+     * Generate XML metadata for the internal used stepup authentication SP
+     *
+     * @param string $acsLocation
+     * @param string $keyId
+     * @return string
+     * @throws \EngineBlock_Exception
+     */
+    public function metadataForStepup(string $acsLocation, string $keyId): string
+    {
+        $serviceProvider = StepupEntityFactory::spFrom(
+            $this->stepupEndpoint,
+            $acsLocation
+        );
+
+        return $this->factory->fromServiceProviderEntity($serviceProvider, $keyId);
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Metadata/ValueObjects/IdentityProviderMetadataCollection.php
+++ b/src/OpenConext/EngineBlockBundle/Metadata/ValueObjects/IdentityProviderMetadataCollection.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Metadata\ValueObjects;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+class IdentityProviderMetadataCollection implements IteratorAggregate
+{
+    /**
+     * @var IdentityProviderMetadata[]
+     */
+    private $entities = [];
+
+    /**
+     * @param IdentityProviderMetadata $identityProvider
+     */
+    public function add(IdentityProviderMetadata $identityProvider)
+    {
+        $this->entities[] = $identityProvider;
+    }
+
+    /**
+     * @return Traversable
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->entities);
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/metadata.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/metadata.yml
@@ -49,17 +49,17 @@ metadata_all_idps_key:
         keyId: .+
 
 ### Stepup
-metdata_stepup:
-    path:       'authentication/stepup/metadata'
+metadata_stepup:
+    path:       '/authentication/stepup/metadata'
     methods:    [GET]
     defaults:
-        _controller: engineblock.controller.authentication.stepup:metadataAction
+        _controller: engineblock.controller.authentication.metadata:stepupMetadataAction
         keyId: ~
 
-metdata_stepup_key:
+metadata_stepup_key:
     path:       '/authentication/stepup/metadata/key:{keyId}'
     methods:    [GET]
     defaults:
-        _controller: engineblock.controller.authentication.stepup:metadataAction
+        _controller: engineblock.controller.authentication.metadata:stepupMetadataAction
     requirements:
         keyId: .+

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -323,7 +323,7 @@ class PushMetadataAssemblerTest extends PHPUnit_Framework_TestCase
      */
     private function validCoinValuesStringSignatureMethod() {
         return [
-            [null, "http://www.w3.org/2000/09/xmldsig#rsa-sha1"],
+            [null, "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"],
             ["", ""],
             ["string", "string"],
         ];

--- a/theme/material/templates/modules/Authentication/View/Metadata/idps.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/idps.html.twig
@@ -1,0 +1,50 @@
+{% spaceless %}
+<md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                       validUntil="2019-10-05T09:08:44Z" ID="{{ id }}">
+    {% for metadata in metadataCollection %}
+        <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="{{ metadata.entityId }}">
+            <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                <md:Extensions>
+                    <mdui:UIInfo xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
+                        <mdui:DisplayName xml:lang="nl">OpenConext Engine</mdui:DisplayName>
+                        <mdui:DisplayName xml:lang="en">OpenConext Engine</mdui:DisplayName>
+                        <mdui:Description xml:lang="nl">OpenConext SSO Proxy</mdui:Description>
+                        <mdui:Description xml:lang="en">OpenConext SSO Proxy</mdui:Description>
+                        <mdui:Logo height="96" width="96">https://static.vm.openconext.org/media/conext_logo.png</mdui:Logo>
+                        <mdui:Keywords xml:lang="en">openconext engine engineblock proxy sso saml2</mdui:Keywords>
+                        <mdui:Keywords xml:lang="nl">openconext engine engineblock proxy sso saml2</mdui:Keywords>
+                    </mdui:UIInfo>
+                </md:Extensions>
+                {% for key in metadata.publicKeys %}
+                    <md:KeyDescriptor use="signing">
+                        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                            <ds:X509Data>
+                                <ds:X509Certificate>{{ key }}</ds:X509Certificate>
+                            </ds:X509Data>
+                        </ds:KeyInfo>
+                    </md:KeyDescriptor>
+                {% endfor %}
+                <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+                <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+                <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+                <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ metadata.ssoLocation }}"></md:SingleSignOnService>
+            </md:IDPSSODescriptor>
+            <md:ContactPerson contactType="technical">
+                <md:GivenName>Support</md:GivenName>
+                <md:SurName>OpenConext</md:SurName>
+                <md:EmailAddress>help@example.org</md:EmailAddress>
+            </md:ContactPerson>
+            <md:ContactPerson contactType="support">
+                <md:GivenName>Support</md:GivenName>
+                <md:SurName>OpenConext</md:SurName>
+                <md:EmailAddress>help@example.org</md:EmailAddress>
+            </md:ContactPerson>
+            <md:ContactPerson contactType="administrative">
+                <md:GivenName>Support</md:GivenName>
+                <md:SurName>OpenConext</md:SurName>
+                <md:EmailAddress>help@example.org</md:EmailAddress>
+            </md:ContactPerson>
+        </md:EntityDescriptor>
+    {% endfor %}
+</md:EntitiesDescriptor>
+{% endspaceless %}


### PR DESCRIPTION
A uniform entity factory which will return immutable entities is
required to enforce immutable state in entities. This will also prevent
a proliferation of factories to initiate different entities.

https://www.pivotaltracker.com/story/show/168980646