### PR TITLE
Add missing documentation to EntityFactory

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -31,14 +31,13 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Constants;
 
 /**
- * Class IdentityProvider
  * @package OpenConext\EngineBlock\Metadata\Entity
  * @ORM\Entity
  * @SuppressWarnings(PHPMD.CamelCasePropertyName)
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
  *
- *
- * PLEASE DON'T USE THIS ENTITY DIRECTLY BUT USE `\OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory`
+ * WARNING: Please don't use this entity directly but use the dedicated factory instead.
+ * @see \OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory
  */
 class IdentityProvider extends AbstractRole
 {
@@ -86,7 +85,8 @@ class IdentityProvider extends AbstractRole
     public $shibMdScopes = array();
 
     /**
-     * PLEASE DON'T USE THIS ENTITY DIRECTLY BUT USE `\OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory`
+     * WARNING: Please don't use this entity directly but use the dedicated factory instead.
+     * @see \OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory
      *
      * @param string $entityId
      * @param Organization $organizationEn

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -36,6 +36,9 @@ use SAML2\Constants;
  * @ORM\Entity
  * @SuppressWarnings(PHPMD.CamelCasePropertyName)
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ *
+ *
+ * PLEASE DON'T USE THIS ENTITY DIRECTLY BUT USE `\OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory`
  */
 class IdentityProvider extends AbstractRole
 {
@@ -83,6 +86,8 @@ class IdentityProvider extends AbstractRole
     public $shibMdScopes = array();
 
     /**
+     * PLEASE DON'T USE THIS ENTITY DIRECTLY BUT USE `\OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory`
+     *
      * @param string $entityId
      * @param Organization $organizationEn
      * @param Organization $organizationNl

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -31,7 +31,6 @@ use SAML2\Constants;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Class ServiceProvider
  * @package OpenConext\EngineBlock\Metadata\Entity
  * @ORM\Entity
  * @SuppressWarnings(PHPMD.TooManyMethods)
@@ -39,8 +38,8 @@ use Doctrine\ORM\Mapping as ORM;
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  *
- *
- * PLEASE DON'T USE THIS ENTITY DIRECTLY BUT USE `\OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory`
+ * WARNING: Please don't use this entity directly but use the dedicated factory instead.
+ * @see \OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory
  */
 class ServiceProvider extends AbstractRole
 {
@@ -94,7 +93,8 @@ class ServiceProvider extends AbstractRole
     public $supportUrlNl;
 
     /**
-     * PLEASE DON'T USE THIS ENTITY DIRECTLY BUT USE `\OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory`
+     * WARNING: Please don't use this entity directly but use the dedicated factory instead.
+     * @see \OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory
      *
      * @param string $entityId
      * @param Organization $organizationEn

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -38,6 +38,9 @@ use Doctrine\ORM\Mapping as ORM;
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ *
+ *
+ * PLEASE DON'T USE THIS ENTITY DIRECTLY BUT USE `\OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory`
  */
 class ServiceProvider extends AbstractRole
 {
@@ -91,6 +94,8 @@ class ServiceProvider extends AbstractRole
     public $supportUrlNl;
 
     /**
+     * PLEASE DON'T USE THIS ENTITY DIRECTLY BUT USE `\OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory`
+     *
      * @param string $entityId
      * @param Organization $organizationEn
      * @param Organization $organizationNl

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
@@ -29,6 +29,10 @@ use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\ShibMdScope;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 
+/**
+ * This Entity is the immutable counterpart of the legacy Entity
+ * This adapter is used to support the old legacy entity so it would be easier to remove the legacy entity ultimately
+ */
 class IdentityProviderEntity implements IdentityProviderEntityInterface
 {
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
@@ -17,7 +17,6 @@
 
 namespace OpenConext\EngineBlock\Metadata\Factory\Adapter;
 
-use DateTime;
 use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
@@ -30,8 +29,10 @@ use OpenConext\EngineBlock\Metadata\ShibMdScope;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 
 /**
- * This Entity is the immutable counterpart of the legacy Entity
- * This adapter is used to support the old legacy entity so it would be easier to remove the legacy entity ultimately
+ * This IdentityProviderEntity is an immutable counterpart of the IdentityProvider Doctrine ORM Entity.
+ *
+ * This adapter is used to support the ORM entity by encapsulating it. This will make it easier to replace the ORM
+ * entity ultimately.
  */
 class IdentityProviderEntity implements IdentityProviderEntityInterface
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
@@ -29,6 +29,10 @@ use OpenConext\EngineBlock\Metadata\RequestedAttribute;
 use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 
+/**
+ * This Entity is the immutable counterpart of the legacy Entity
+ * This adapter is used to support the old legacy entity so it would be easier to remove the legacy entity ultimately
+ */
 class ServiceProviderEntity implements ServiceProviderEntityInterface
 {
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
@@ -30,8 +30,10 @@ use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 
 /**
- * This Entity is the immutable counterpart of the legacy Entity
- * This adapter is used to support the old legacy entity so it would be easier to remove the legacy entity ultimately
+ * This ServiceProviderEntity is an immutable counterpart of the ServiceProvider Doctrine ORM Entity.
+ *
+ * This adapter is used to support the ORM entity by encapsulating it. This will make it easier to replace the ORM
+ * entity ultimately.
  */
 class ServiceProviderEntity implements ServiceProviderEntityInterface
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
@@ -27,6 +27,10 @@ use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\ShibMdScope;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 
+/**
+ * This Abstract class is used to circumvent the implementation of all methods of the EntityInterface
+ * so only the wanted methods could be implemented if this abstract class is extended
+ */
 class AbstractIdentityProvider implements IdentityProviderEntityInterface
 {
 

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
@@ -28,8 +28,9 @@ use OpenConext\EngineBlock\Metadata\ShibMdScope;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 
 /**
- * This Abstract class is used to circumvent the implementation of all methods of the EntityInterface
- * so only the wanted methods could be implemented if this abstract class is extended
+ * This abstract class is used to circumvent the implementation of all methods of the IdentityProviderEntityInterface.
+ * So only the methods required for the specific implementation have to be created on the decorated Entity that is
+ * extended from this abstract IdP entity.
  */
 class AbstractIdentityProvider implements IdentityProviderEntityInterface
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
@@ -29,8 +29,9 @@ use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 
 /**
- * This Abstract class is used to circumvent the implementation of all methods of the EntityInterface
- * so only the wanted methods could be implemented if this abstract class is extended
+ * This abstract class is used to circumvent the implementation of all methods of the ServiceProviderEntityInterface.
+ * So only the methods required for the specific implementation have to be created on the decorated Entity that is
+ * extended from this abstract SP entity.
  */
 class AbstractServiceProvider implements ServiceProviderEntityInterface
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
@@ -28,6 +28,10 @@ use OpenConext\EngineBlock\Metadata\RequestedAttribute;
 use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 
+/**
+ * This Abstract class is used to circumvent the implementation of all methods of the EntityInterface
+ * so only the wanted methods could be implemented if this abstract class is extended
+ */
 class AbstractServiceProvider implements ServiceProviderEntityInterface
 {
 

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxy.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxy.php
@@ -21,6 +21,10 @@ use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
+/**
+ * This decorator is used for using an entity when EB is used as authentication proxy
+ * It will make sure all required parameters to support EB are set
+ */
 class IdentityProviderProxy extends AbstractIdentityProvider
 {
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxy.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxy.php
@@ -22,8 +22,8 @@ use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
 /**
- * This decorator is used for using an entity when EB is used as authentication proxy
- * It will make sure all required parameters to support EB are set
+ * This decoration is used to represent EngineBlock in it's IdP role when EngineBlock is used as authentication
+ * proxy. It will make sure all required parameters to support EB are set.
  */
 class IdentityProviderProxy extends AbstractIdentityProvider
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderStepup.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderStepup.php
@@ -18,8 +18,8 @@
 namespace OpenConext\EngineBlock\Metadata\Factory\Decorator;
 
 /**
- * This decorator is used for using an entity when EB is doing a stepup callout during authentication
- * It will make sure all required parameters to support EB are set
+ * This decoration is used to represent EngineBlock in it's step-up authentication IdP role. It will make sure all
+ * required parameters to support EB are set.
  */
 class IdentityProviderStepup extends AbstractIdentityProvider
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderStepup.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderStepup.php
@@ -17,6 +17,10 @@
 
 namespace OpenConext\EngineBlock\Metadata\Factory\Decorator;
 
+/**
+ * This decorator is used for using an entity when EB is doing a stepup callout during authentication
+ * It will make sure all required parameters to support EB are set
+ */
 class IdentityProviderStepup extends AbstractIdentityProvider
 {
     public function getSsoLocation(): string

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderProxy.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderProxy.php
@@ -25,8 +25,8 @@ use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
 /**
- * This decorator is used for using an entity when EB is used as authentication proxy
- * It will make sure all required parameters to support EB are set
+ * This decoration is used to represent EngineBlock in it's SP role when EngineBlock is used as authentication
+ * proxy. It will make sure all required parameters to support EB are set.
  */
 class ServiceProviderProxy extends AbstractServiceProvider
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderProxy.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderProxy.php
@@ -24,6 +24,10 @@ use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
+/**
+ * This decorator is used for using an entity when EB is used as authentication proxy
+ * It will make sure all required parameters to support EB are set
+ */
 class ServiceProviderProxy extends AbstractServiceProvider
 {
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderStepup.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderStepup.php
@@ -17,6 +17,10 @@
 
 namespace OpenConext\EngineBlock\Metadata\Factory\Decorator;
 
+/**
+ * This decorator is used for using an entity when EB is doing a stepup callout during authentication
+ * It will make sure all required parameters to support EB are set
+ */
 class ServiceProviderStepup extends AbstractServiceProvider
 {
     public function getAcsLocation(): string

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderStepup.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderStepup.php
@@ -18,8 +18,8 @@
 namespace OpenConext\EngineBlock\Metadata\Factory\Decorator;
 
 /**
- * This decorator is used for using an entity when EB is doing a stepup callout during authentication
- * It will make sure all required parameters to support EB are set
+ * This decoration is used to represent EngineBlock in it's step-up authentication SP role. It will make sure all
+ * required parameters to support EB are set.
  */
 class ServiceProviderStepup extends AbstractServiceProvider
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
@@ -27,6 +27,10 @@ use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
+/**
+ * This factory is used for instantiating an entity with the required adapters and/or decorators set
+ * It also makes sure that static entities could be generated without the use of the database
+ */
 class IdentityProviderFactory
 {
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
@@ -28,8 +28,8 @@ use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
 /**
- * This factory is used for instantiating an entity with the required adapters and/or decorators set
- * It also makes sure that static entities could be generated without the use of the database
+ * This factory is used for instantiating an entity with the required adapters and/or decorators set.
+ * It also makes sure that static, internally used, entities can be generated without the use of the database.
  */
 class IdentityProviderFactory
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
@@ -29,8 +29,8 @@ use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
 /**
- * This factory is used for instantiating an entity with the required adapters and/or decorators set
- * It also makes sure that static entities could be generated without the use of the database
+ * This factory is used for instantiating an entity with the required adapters and/or decorators set.
+ * It also makes sure that static, internally used, entities can be generated without the use of the database.
  */
 class ServiceProviderFactory
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
@@ -28,6 +28,10 @@ use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
+/**
+ * This factory is used for instantiating an entity with the required adapters and/or decorators set
+ * It also makes sure that static entities could be generated without the use of the database
+ */
 class ServiceProviderFactory
 {
     /**


### PR DESCRIPTION
The EntityFactory architecture was created during a POC but
was lacking documentation. This is added to improve the
inline documentation of the architecture.

This is to address:
https://github.com/OpenConext/OpenConext-engineblock/pull/773#issuecomment-539434966

https://www.pivotaltracker.com/story/show/168980646