### PR TITLE
Add missing trusted proxy to stepup callout

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -136,6 +136,12 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
             $receivedResponse
         );
 
+        // When dealing with an SP that acts as a trusted proxy, we should use the proxying SP and not the proxy itself.
+        if ($sp->getCoins()->isTrustedProxy()) {
+            // Overwrite the trusted proxy SP instance with that of the SP that uses the trusted proxy.
+            $sp = $this->_server->findOriginalServiceProvider($receivedRequest, $log);
+        }
+
         // Goto consent if no Stepup authentication is needed
         if (!$this->_stepupGatewayCallOutHelper->shouldUseStepup($idp, $sp)) {
             $this->_server->sendConsentAuthenticationRequest($receivedResponse, $receivedRequest, $currentProcessStep->getRole(), $this->getAuthenticationState());

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -45,7 +45,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         // proxy itself.
         if ($sp->getCoins()->isTrustedProxy()) {
             // Overwrite the trusted proxy SP instance with that of the SP that uses the trusted proxy.
-            $sp = $this->findOriginalServiceProvider($request, $log);
+            $sp = $this->_server->findOriginalServiceProvider($request, $log);
         }
 
         // Exposing entityId to be used when tracking the start of an authentication procedure
@@ -370,7 +370,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
         $currentLocale = $container->getLocaleProvider()->getLocale();
 
         $cookies = $container->getSymfonyRequest()->cookies->all();
-        $serviceProvider = $this->findOriginalServiceProvider($request, $application->getLogInstance());
+        $serviceProvider = $this->_server->findOriginalServiceProvider($request, $application->getLogInstance());
         $idpList = $this->_transformIdpsForWAYF($candidateIdpEntityIds, $request->isDebugRequest(), $currentLocale);
         $rememberChoiceFeature = $container->getRememberChoice();
 
@@ -392,37 +392,6 @@ class EngineBlock_Corto_Module_Service_SingleSignOn extends EngineBlock_Corto_Mo
             ]
         );
         $this->_server->sendOutput($output);
-    }
-
-    /**
-     * Find a ServiceProvider instance based on the received AuthnRequest.
-     *
-     * @param EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request
-     * @param LoggerInterface $logger
-     * @return ServiceProvider
-     */
-    private function findOriginalServiceProvider(
-        EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request,
-        LoggerInterface $logger
-    ) {
-
-        $issuingServiceProvider = $this->_server->getRepository()->fetchServiceProviderByEntityId($request->getIssuer());
-
-        // Find the original requester SP
-        $originalRequesterServiceProvider = EngineBlock_SamlHelper::findRequesterServiceProvider(
-            $issuingServiceProvider,
-            $request,
-            $this->_server->getRepository(),
-            $logger
-        );
-
-        // If the SamlHelper found us the correct SP, return it
-        if ($originalRequesterServiceProvider) {
-            return $originalRequesterServiceProvider;
-        }
-
-        // Return the SP based on the Issuer.
-        return $issuingServiceProvider;
     }
 
     protected function _transformIdpsForWayf(array $idpEntityIds, $isDebugRequest, $currentLocale)

--- a/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
@@ -167,6 +167,12 @@ class EngineBlock_Corto_Module_Service_StepupAssertionConsumer implements Engine
                 $idp = $this->_server->getRepository()->fetchIdentityProviderByEntityId($originalReceivedResponse->getIssuer());
                 $sp = $this->_server->getRepository()->fetchServiceProviderByEntityId($originalReceivedRequest->getIssuer());
 
+                // When dealing with an SP that acts as a trusted proxy, we should use the proxying SP and not the proxy itself.
+                if ($sp->getCoins()->isTrustedProxy()) {
+                    // Overwrite the trusted proxy SP instance with that of the SP that uses the trusted proxy.
+                    $sp = $this->_server->findOriginalServiceProvider($receivedRequest, $log);
+                }
+
                 if ($this->_stepupGatewayCallOutHelper->allowNoToken($idp, $sp)) {
 
                     $log->warning('Allow no token allowed from sp/idp configuration, continuing', array('key_id' => $receivedRequest->getId(), 'result' => $e->getFeedbackInfo()));

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -1211,6 +1211,37 @@ class EngineBlock_Corto_ProxyServer
         return $privateKey;
     }
 
+    /**
+     * Find a ServiceProvider instance based on the received AuthnRequest.
+     *
+     * @param EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request
+     * @param LoggerInterface $logger
+     * @return ServiceProvider
+     */
+    public function findOriginalServiceProvider(
+        EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request,
+        LoggerInterface $logger
+    ) {
+
+        $issuingServiceProvider = $this->getRepository()->fetchServiceProviderByEntityId($request->getIssuer());
+
+        // Find the original requester SP
+        $originalRequesterServiceProvider = EngineBlock_SamlHelper::findRequesterServiceProvider(
+            $issuingServiceProvider,
+            $request,
+            $this->getRepository(),
+            $logger
+        );
+
+        // If the SamlHelper found us the correct SP, return it
+        if ($originalRequesterServiceProvider) {
+            return $originalRequesterServiceProvider;
+        }
+
+        // Return the SP based on the Issuer.
+        return $issuingServiceProvider;
+    }
+
     public function setLogger(LoggerInterface $logger)
     {
         $this->_logger = $logger;


### PR DESCRIPTION
When configuring stepup functionality the trusted proxy wasn't taken into account. So only the configuration of the trusted proxy was used and not the configuration of the proxied SP.

This need to be cherrypicked to release 5.13 and included in release 6.1

https://www.pivotaltracker.com/story/show/169033643