### PR TITLE
Add metadata stepup signing

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProviderMetadata.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProviderMetadata.php
@@ -20,7 +20,6 @@ namespace OpenConext\EngineBlock\Metadata\Factory\Decorator;
 
 use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\IndexedService;
-use OpenConext\EngineBlock\Service\TimeProvider\TimeProvider;
 
 class EngineBlockServiceProviderMetadata extends AbstractServiceProvider
 {
@@ -58,5 +57,27 @@ class EngineBlockServiceProviderMetadata extends AbstractServiceProvider
             $keys[$pem] = $pem;
         }
         return $keys;
+    }
+
+    public function hasUiInfo(): bool
+    {
+        $info = [
+            $this->getDisplayNameEn(),
+            $this->getDisplayNameNl(),
+            $this->getOrganizationEn(),
+            $this->getOrganizationNl(),
+        ];
+
+        return !empty(array_filter($info));
+    }
+
+    public function hasOrganizationInfo(): bool
+    {
+        $info = [
+            $this->getOrganizationEn(),
+            $this->getOrganizationNl(),
+        ];
+
+        return !empty(array_filter($info));
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderStepup.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderStepup.php
@@ -24,29 +24,23 @@ use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use SAML2\Constants;
 
 /**
- * This decoration is used to represent EngineBlock in it's SP role when EngineBlock is used as authentication
- * proxy. It will make sure all required parameters to support EB are set.
+ * This decoration is used to represent EngineBlock in it's Stepup role when EngineBlock is doing a stepup callout
+ * It will make sure the right acs location is used to consume the response back to EB.
  */
-class ServiceProviderProxy extends AbstractServiceProvider
+class ServiceProviderStepup extends AbstractServiceProvider
 {
     /**
      * @var X509KeyPair
      */
     private $keyPair;
-    /**
-     * @var AttributesMetadata
-     */
-    private $attributes;
 
     public function __construct(
         ServiceProviderEntityInterface $entity,
-        X509KeyPair $keyPair,
-        AttributesMetadata $attributes
+        X509KeyPair $keyPair
     ) {
         parent::__construct($entity);
 
         $this->keyPair = $keyPair;
-        $this->attributes = $attributes;
     }
 
 
@@ -57,23 +51,6 @@ class ServiceProviderProxy extends AbstractServiceProvider
 
     public function getSupportedNameIdFormats(): array
     {
-        return [
-            Constants::NAMEID_PERSISTENT,
-            Constants::NAMEID_TRANSIENT,
-            Constants::NAMEID_UNSPECIFIED,
-        ];
-    }
-
-    /**
-     * @return RequestedAttribute[]|null
-     */
-    public function getRequestedAttributes(): ?array
-    {
-        return $this->attributes->getRequestedAttributes();
-    }
-
-    public function isAllowAll(): bool
-    {
-        return true;
+        return [];
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
@@ -102,7 +102,7 @@ class IdentityProviderFactory
      */
     private function buildEngineBlockEntityFromEntity(IdentityProvider $entity, string $keyId): IdentityProviderEntityInterface
     {
-        return new EngineBlockIdentityProviderMetadata(
+        return new EngineBlockIdentityProviderMetadata( // Add metadata helper functions for presenting data
             new IdentityProviderProxy(  // Add EB proxy data
                 new EngineBlockIdentityProviderInformation( // Add EB specific information
                     new IdentityProviderEntity($entity),

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
@@ -24,6 +24,7 @@ use OpenConext\EngineBlock\Metadata\Factory\Adapter\ServiceProviderEntity;
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockServiceProviderInformation;
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockServiceProviderMetadata;
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\ServiceProviderProxy;
+use OpenConext\EngineBlock\Metadata\Factory\Decorator\ServiceProviderStepup;
 use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration;
 use OpenConext\EngineBlock\Metadata\IndexedService;
@@ -68,7 +69,7 @@ class ServiceProviderFactory
     ): ServiceProviderEntityInterface {
         $entity = $this->buildServiceProviderOrmEntity($entityId, $acsLocation, $keyId);
 
-        return new EngineBlockServiceProviderMetadata(
+        return new EngineBlockServiceProviderMetadata( // Add metadata helper functions for presenting data
             new ServiceProviderProxy( // Add EB proxy data
                 new EngineBlockServiceProviderInformation(  // Add EB specific information
                     new ServiceProviderEntity($entity),
@@ -87,8 +88,11 @@ class ServiceProviderFactory
     ): ServiceProviderEntityInterface {
         $entity = $this->buildServiceProviderOrmEntity($entityId, $acsLocation, $keyId);
 
-        return new EngineBlockServiceProviderMetadata(
-            new ServiceProviderEntity($entity)
+        return new EngineBlockServiceProviderMetadata( // Add metadata helper functions for presenting data
+            new ServiceProviderStepup( // Add stepup data
+                new ServiceProviderEntity($entity),
+                $this->keyPairFactory->buildFromIdentifier($keyId)
+            )
         );
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Metadata.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Metadata.feature
@@ -30,6 +30,15 @@ Feature:
       # Verify SSO location and binding is set correctly
       And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" and @Location="https://engine.vm.openconext.org/authentication/idp/single-sign-on"]'
 
+  Scenario: A user can request the EngineBlock stepup metadata
+    When I go to Engineblock URL "/authentication/stepup/metadata"
+    # Verify the entity id is correctly set in the metadata
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/authentication/stepup/metadata"]'
+    # Verify the signature method is set to sha256
+    And the response should match xpath '//ds:SignatureMethod[@Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"]'
+    # Verify the ACS location and binding
+    And the response should match xpath '//md:AssertionConsumerService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" and @Location="https://engine.vm.openconext.org/authentication/stepup/consume-assertion"]'
+
 #  Scenario: A user can request the metadata of all known and visible IdPs
 #      Given an Identity Provider named "Known-IdP"
 #      And an Identity Provider named "Second-IdP"

--- a/theme/material/templates/modules/Authentication/View/Metadata/sp.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/sp.xml.twig
@@ -1,8 +1,10 @@
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="{{ id }}" entityID="{{ metadata.entityId }}" validUntil="{{ validUntil }}">
     <md:SPSSODescriptor WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        {% if metadata.hasUiInfo %}
         <md:Extensions>
             {% include '@theme/Authentication/View/Metadata/partial/ui_info.xml.twig' %}
         </md:Extensions>
+        {% endif %}
         {% for key in metadata.publicKeys %}
         <md:KeyDescriptor use="signing">
             <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
@@ -15,20 +17,25 @@
         <md:AssertionConsumerService Binding="{{ metadata.assertionConsumerService.binding }}"
                                      Location="{{ metadata.assertionConsumerService.location }}"
                                      index="0"></md:AssertionConsumerService>
-        <md:AttributeConsumingService index="0">
-            <md:ServiceName xml:lang="nl">{{ metadata.nameNl }}</md:ServiceName>
-            <md:ServiceName xml:lang="en">{{ metadata.nameEn }}</md:ServiceName>
-            <md:ServiceDescription xml:lang="nl">{{ metadata.descriptionNl }}</md:ServiceDescription>
-            <md:ServiceDescription xml:lang="en">{{ metadata.descriptionEn }}</md:ServiceDescription>
-            {# Requested attributes are hardcoded into this template, override the template if you require other values #}
-            <md:RequestedAttribute Name="urn:mace:dir:attribute-def:displayName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="false"></md:RequestedAttribute>
-            <md:RequestedAttribute Name="urn:mace:dir:attribute-def:mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="false"></md:RequestedAttribute>
-            <md:RequestedAttribute Name="urn:mace:dir:attribute-def:uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"></md:RequestedAttribute>
-            <md:RequestedAttribute Name="urn:mace:terena.org:attribute-def:schacHomeOrganization" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"></md:RequestedAttribute>
-        </md:AttributeConsumingService>
+        {% if metadata.requestedAttributes is not empty%}
+            <md:AttributeConsumingService index="0">
+                <md:ServiceName xml:lang="nl">{{ metadata.nameNl }}</md:ServiceName>
+                <md:ServiceName xml:lang="en">{{ metadata.nameEn }}</md:ServiceName>
+                <md:ServiceDescription xml:lang="nl">{{ metadata.descriptionNl }}</md:ServiceDescription>
+                <md:ServiceDescription xml:lang="en">{{ metadata.descriptionEn }}</md:ServiceDescription>
+                {% for attribute in metadata.requestedAttributes %}
+                    <md:RequestedAttribute Name="{{ attribute.name }}" NameFormat="{{ attribute.nameFormat }}" isRequired="{{ attribute.required ? 'true' : 'false' }}"></md:RequestedAttribute>
+                {% endfor %}
+            </md:AttributeConsumingService>
+        {%  endif %}
+
     </md:SPSSODescriptor>
+    {% if metadata.hasOrganizationInfo %}
     {% include '@theme/Authentication/View/Metadata/partial/organization.xml.twig' %}
-    {% for contactPerson in metadata.contactPersons %}
-        {% include '@theme/Authentication/View/Metadata/partial/contact_person.xml.twig' %}
-    {% endfor %}
+    {% endif %}
+    {% if metadata.contactPersons is not empty%}
+        {% for contactPerson in metadata.contactPersons %}
+            {% include '@theme/Authentication/View/Metadata/partial/contact_person.xml.twig' %}
+        {% endfor %}
+    {% endif %}
 </md:EntityDescriptor>


### PR DESCRIPTION
The metadta stepup signing needed to be implmented. To make sure
the metadata xml stays the same some adjustments were needed
to support the stepup metadata because not all fields should be shown.

The fields shouldn't be shown because in case of stepup only the ACS
location and the enityId is relevant. So requested attributes, UiInfo and
organization information isn't relevant and should therefore be omitted.