### PR TITLE
Address issue PR 787 788

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
@@ -105,6 +105,13 @@ class IdpsMetadataRepository
         $collection = new IdentityProviderEntityCollection();
 
         foreach ($idps as $idp) {
+            // Don't add ourselves
+            // TODO: remove after the 'magic' entities are removed
+            // @see: https://www.pivotaltracker.com/story/show/168249058
+            if ($idp->entityId === $this->urlProvider->getUrl('metadata_idp', false, null, null)) {
+                continue;
+            }
+
             // Do not reveal hidden IdP's
             if ($idp->getCoins()->hidden()) {
                 continue;

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Metadata.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Metadata.feature
@@ -39,17 +39,17 @@ Feature:
     # Verify the ACS location and binding
     And the response should match xpath '//md:AssertionConsumerService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" and @Location="https://engine.vm.openconext.org/authentication/stepup/consume-assertion"]'
 
-#  Scenario: A user can request the metadata of all known and visible IdPs
-#      Given an Identity Provider named "Known-IdP"
-#      And an Identity Provider named "Second-IdP"
-#      And an Identity Provider named "Regular-IdP"
-#      When I go to Engineblock URL "/authentication/proxy/idps-metadata"
-#      # Verify the three IdPs are present in the list
-#      Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Known-IdP/metadata"]'
-#      And the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Second-IdP/metadata"]'
-#      And the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Regular-IdP/metadata"]'
-#      # And Engine IdP is not listed
-#      And the response should not match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/authentication/idp/metadata"]'
+  Scenario: A user can request the metadata of all known and visible IdPs
+      Given an Identity Provider named "Known-IdP"
+      And an Identity Provider named "Second-IdP"
+      And an Identity Provider named "Regular-IdP"
+      When I go to Engineblock URL "/authentication/proxy/idps-metadata"
+      # Verify the three IdPs are present in the list
+      Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Known-IdP/metadata"]'
+      And the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Second-IdP/metadata"]'
+      And the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Regular-IdP/metadata"]'
+      # And Engine IdP is not listed
+      And the response should not match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/authentication/idp/metadata"]'
 
   Scenario: A user can request the metadata and does not see invisible IdPs
       Given an Identity Provider named "Known-IdP"

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
@@ -102,9 +102,9 @@ abstract class AbstractEntityTest extends TestCase
 
         foreach ($assertions as $name => $assertion) {
             if (array_key_exists($name, $overrides)) {
-                $this->assertEquals($overrides[$name], $assertion($decorator), 'Invalid override ' . $name);
+                $this->assertEquals($overrides[$name], $assertion($decorator), sprintf("Invalid expectancy in method override for property '%s'", $name));
             } else {
-                $this->assertSame($assertion($adapter), $assertion($decorator), 'Invalid abstract ' . $name);
+                $this->assertSame($assertion($adapter), $assertion($decorator), sprintf("Invalid expectancy in abstract method for property '%s'", $name));
             }
         }
     }
@@ -160,9 +160,9 @@ abstract class AbstractEntityTest extends TestCase
 
         foreach ($assertions as $name => $assertion) {
             if (array_key_exists($name, $overrides)) {
-                $this->assertEquals($overrides[$name], $assertion($decorator), 'Invalid override ' . $name);
+                $this->assertEquals($overrides[$name], $assertion($decorator), sprintf("Invalid expectancy in method override for property '%s'", $name));
             } else {
-                $this->assertSame($assertion($adapter), $assertion($decorator), 'Invalid abstract ' . $name);
+                $this->assertSame($assertion($adapter), $assertion($decorator), sprintf("Invalid expectancy in abstract method for property '%s'", $name));
             }
         }
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxyTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxyTest.php
@@ -37,18 +37,18 @@ class IdentityProviderProxyTest extends AbstractEntityTest
 
         $urlProvider = $this->createMock(UrlProvider::class);
 
-        $urlProvider->expects($this->exactly(5))
+        $urlProvider->expects($this->exactly(3))
             ->method('getUrl')
             ->withConsecutive(
-                ['authentication_idp_sso', false, null, null], // check if entity is EB (SLO)
+                // SLO: IdentityProviderProxy::getSingleLogoutService
                 ['authentication_logout', false, null, null],
-                ['authentication_idp_sso', false, null, null], // check if entity is EB (RPS)
-                ['authentication_idp_sso', false, null, null], // check if entity is EB (SSO)
-                ['authentication_idp_sso', false, null, null]
+                // SSO: IdentityProviderProxy::getSingleSignOnServices
+                ['metadata_idp', false, null, null], // check if entity is EB
+                ['authentication_idp_sso', false, null, 'entity-id']
             ) ->willReturnOnConsecutiveCalls(
-                'ssoLocation',
+                // SLO
                 'sloLocation',
-                'ssoLocation',
+                // SSO
                 'ssoLocation',
                 'ssoLocation'
             );

--- a/theme/material/templates/modules/Authentication/View/Metadata/idp.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/idp.xml.twig
@@ -13,15 +13,17 @@
                 </ds:KeyInfo>
             </md:KeyDescriptor>
         {% endfor %}
-        {# The supported NameIdFormats for the EngineBlock IdP are hard coded into this template. #}
-        <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+        {% for nameId in metadata.supportedNameIdFormats  %}
+            <md:NameIDFormat>{{ nameId }}</md:NameIDFormat>
+        {% endfor %}
         {# Formally we only allow redirect binding on the SSO location #}
         <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ metadata.ssoLocation }}"></md:SingleSignOnService>
     </md:IDPSSODescriptor>
-    {% for contactPerson in metadata.contactPersons %}
-        {% include '@theme/Authentication/View/Metadata/partial/contact_person.xml.twig' %}
-    {% endfor %}
+    {% if metadata.contactPersons is not empty%}
+        {% for contactPerson in metadata.contactPersons %}
+            {% include '@theme/Authentication/View/Metadata/partial/contact_person.xml.twig' %}
+        {% endfor %}
+    {% endif %}
+
 </md:EntityDescriptor>
 {% endspaceless %}

--- a/theme/material/templates/modules/Authentication/View/Metadata/idps.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/idps.xml.twig
@@ -17,13 +17,15 @@
                     </md:KeyDescriptor>
                 {% endfor %}
                 {% for nameIdFormat in metadata.supportedNameIdFormats %}
-                <md:NameIDFormat>{{ nameIdFormat }}</md:NameIDFormat>
+                    <md:NameIDFormat>{{ nameIdFormat }}</md:NameIDFormat>
                 {% endfor %}
                 <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ metadata.ssoLocation }}"></md:SingleSignOnService>
             </md:IDPSSODescriptor>
-            {% for contactPerson in metadata.contactPersons %}
-                {% include '@theme/Authentication/View/Metadata/partial/contact_person.xml.twig' %}
-            {% endfor %}
+            {% if metadata.contactPersons is not empty%}
+                {% for contactPerson in metadata.contactPersons %}
+                    {% include '@theme/Authentication/View/Metadata/partial/contact_person.xml.twig' %}
+                {% endfor %}
+            {% endif %}
         </md:EntityDescriptor>
     {% endfor %}
 </md:EntitiesDescriptor>


### PR DESCRIPTION
There were some considerations raised during the review of the
refactoring of the ServiceReplacer. #786 

See: https://github.com/OpenConext/OpenConext-engineblock/pull/786

- slo service shouldn't be replaced when empty
- sso check was invalid
- repository EB check should be addressed later on after refactor
- re-enabled metadata feature test
- improved decorator test message

#788
Also the twig templates were unified for idp and idps so they would
become the same as the sp template.


The npm audit test is still failing but this should be addressed later on as it couldn't be fixed by running just `npm audit fix`.