### PR TITLE
Show service info if no attributes are set (twig)

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockIdentityProviderInformation.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockIdentityProviderInformation.php
@@ -47,6 +47,16 @@ class EngineBlockIdentityProviderInformation extends AbstractIdentityProvider
         return $this->engineBlockConfiguration->getName();
     }
 
+    public function getDisplayNameNl(): string
+    {
+        return $this->engineBlockConfiguration->getName();
+    }
+
+    public function getDisplayNameEn(): string
+    {
+        return $this->engineBlockConfiguration->getName();
+    }
+
     public function getDescriptionNl(): string
     {
         return $this->engineBlockConfiguration->getDescription();

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProviderInformation.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProviderInformation.php
@@ -47,6 +47,16 @@ class EngineBlockServiceProviderInformation extends AbstractServiceProvider
         return $this->engineBlockConfiguration->getName();
     }
 
+    public function getDisplayNameNl(): string
+    {
+        return $this->engineBlockConfiguration->getName();
+    }
+
+    public function getDisplayNameEn(): string
+    {
+        return $this->engineBlockConfiguration->getName();
+    }
+
     public function getDescriptionNl(): string
     {
         return $this->engineBlockConfiguration->getDescription();

--- a/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
@@ -136,7 +136,7 @@ class MetadataRendererTest extends TestCase
                 'entityId' => 'sp',
                 'assertionConsumerServices' => $assertionConsumerServices,
                 'logo' => new Logo('/images/logo.gif'),
-                'organizationEn' => new Organization('Org', 'Organization', 'https://example.org')
+                'organizationEn' => new Organization('Org', 'Organization', 'https://example.org'),
             ]
         );
 

--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/ui_info.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/ui_info.xml.twig
@@ -1,6 +1,6 @@
 <mdui:UIInfo xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
-    <mdui:DisplayName xml:lang="nl">{{ metadata.nameNl }}</mdui:DisplayName>
-    <mdui:DisplayName xml:lang="en">{{ metadata.nameEn }}</mdui:DisplayName>
+    <mdui:DisplayName xml:lang="nl">{{ metadata.displayNameNl }}</mdui:DisplayName>
+    <mdui:DisplayName xml:lang="en">{{ metadata.displayNameEn }}</mdui:DisplayName>
     <mdui:Description xml:lang="nl">{{ metadata.descriptionNl }}</mdui:Description>
     <mdui:Description xml:lang="en">{{ metadata.descriptionEn }}</mdui:Description>
     {% if metadata.logo is not null %}

--- a/theme/material/templates/modules/Authentication/View/Metadata/sp.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/sp.xml.twig
@@ -17,7 +17,7 @@
         <md:AssertionConsumerService Binding="{{ metadata.assertionConsumerService.binding }}"
                                      Location="{{ metadata.assertionConsumerService.location }}"
                                      index="0"></md:AssertionConsumerService>
-        {% if metadata.requestedAttributes is not empty%}
+        {% if metadata.requestedAttributes is not empty %}
             <md:AttributeConsumingService index="0">
                 <md:ServiceName xml:lang="nl">{{ metadata.nameNl }}</md:ServiceName>
                 <md:ServiceName xml:lang="en">{{ metadata.nameEn }}</md:ServiceName>


### PR DESCRIPTION
The sp metadata service name and description values were not shown
if no attributes were set in the sp metadata twig template. This is changed now.

Requested in:
https://github.com/OpenConext/OpenConext-engineblock/pull/788#discussion_r337923991