### PR TITLE
Adjust decorator naming to reflect purpose

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockIdentityProvider.php
@@ -27,7 +27,7 @@ use SAML2\Constants;
  * This decoration is used to represent Idp's EngineBlock in it's IdP role when EngineBlock is used as authentication
  * proxy. It will make sure all required parameters to support EB are set.
  */
-class IdentityProviderProxy extends AbstractIdentityProvider
+class EngineBlockIdentityProvider extends AbstractIdentityProvider
 {
     /**
      * @var X509KeyPair

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockIdentityProviderInformation.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockIdentityProviderInformation.php
@@ -24,6 +24,9 @@ use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\Organization;
 
+/**
+ * This decoration is used to add non functional and strictly informational data to an entity
+ */
 class EngineBlockIdentityProviderInformation extends AbstractIdentityProvider
 {
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProvider.php
@@ -21,7 +21,6 @@ use EngineBlock_Attributes_Metadata as AttributesMetadata;
 use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\IndexedService;
 use OpenConext\EngineBlock\Metadata\RequestedAttribute;
-use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use OpenConext\EngineBlockBundle\Url\UrlProvider;
 use SAML2\Constants;
@@ -30,7 +29,7 @@ use SAML2\Constants;
  * This decoration is used to represent EngineBlock in it's SP role when EngineBlock is used as authentication
  * proxy. It will make sure all required parameters to support EB are set.
  */
-class ServiceProviderProxy extends AbstractServiceProvider
+class EngineBlockServiceProvider extends AbstractServiceProvider
 {
     /**
      * @var X509KeyPair

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProviderInformation.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProviderInformation.php
@@ -24,6 +24,9 @@ use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\Organization;
 
+/**
+ * This decoration is used to add non functional and strictly informational data to an entity
+ */
 class EngineBlockServiceProviderInformation extends AbstractServiceProvider
 {
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
@@ -19,15 +19,12 @@ namespace OpenConext\EngineBlock\Metadata\Factory\Factory;
 
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\IdentityProviderEntity;
+use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockIdentityProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockIdentityProviderInformation;
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockIdentityProviderMetadata;
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\IdentityProviderProxy;
 use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration;
-use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
 use OpenConext\EngineBlockBundle\Url\UrlProvider;
-use SAML2\Constants;
 
 /**
  * This factory is used for instantiating an entity with the required adapters and/or decorators set.
@@ -58,7 +55,7 @@ class IdentityProviderFactory
     }
 
     /**
-     * Use this method to create an entity which could act as proxy
+     * Use this method to create a bare Engineblock IdP entity
      */
     public function createEngineBlockEntityFrom(string $keyId): IdentityProviderEntityInterface
     {
@@ -89,13 +86,13 @@ class IdentityProviderFactory
      *
      * - IdentityProviderEntity: The adapter to convert the ORM entity to support the immutable IdentityProviderEntityInterface interface
      * - EngineBlockIdentityProviderInformation: Information used to add EB contact and UI info
-     * - IdentityProviderProxy: Set the functional fields to act as proxy:
+     * - EngineBlockIdentityProvider: Set the functional fields to act as proxy:
      *   (signing certificate, supported nameid formats, sso/slo services, response processing service)
      */
     private function buildEngineBlockEntityFromEntity(IdentityProvider $entity, string $keyId): IdentityProviderEntityInterface
     {
-        return new IdentityProviderProxy(  // Add EB proxy data
-            new EngineBlockIdentityProviderInformation( // Add EB specific information
+        return new EngineBlockIdentityProvider(  // Set EngineBlock specific functional properties so EB could act as proxy
+            new EngineBlockIdentityProviderInformation( // Set EngineBlock specific presentation properties
                 new IdentityProviderEntity($entity),
                 $this->engineBlockConfiguration
             ),

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
@@ -21,9 +21,8 @@ namespace OpenConext\EngineBlock\Metadata\Factory\Factory;
 use EngineBlock_Attributes_Metadata as AttributesMetadata;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\ServiceProviderEntity;
+use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockServiceProviderInformation;
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockServiceProviderMetadata;
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\ServiceProviderProxy;
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\ServiceProviderStepup;
 use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration;
@@ -73,8 +72,8 @@ class ServiceProviderFactory
 
         $entity = $this->buildServiceProviderOrmEntity($entityId);
 
-        return new ServiceProviderProxy( // Add EB proxy data
-            new EngineBlockServiceProviderInformation(  // Add EB specific information
+        return new EngineBlockServiceProvider( // Set EngineBlock specific functional properties so EB could act as proxy
+            new EngineBlockServiceProviderInformation(  // Set EngineBlock specific presentation properties
                 new ServiceProviderEntity($entity),
                 $this->engineBlockConfiguration
             ),

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Helper/IdentityProviderMetadataHelper.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Helper/IdentityProviderMetadataHelper.php
@@ -18,10 +18,10 @@
 
 namespace OpenConext\EngineBlock\Metadata\Factory\Helper;
 
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\AbstractServiceProvider;
-use OpenConext\EngineBlock\Metadata\IndexedService;
+use OpenConext\EngineBlock\Metadata\Factory\Decorator\AbstractIdentityProvider;
+use OpenConext\EngineBlock\Metadata\Service;
 
-class EngineBlockServiceProviderMetadata extends AbstractServiceProvider
+class IdentityProviderMetadataHelper extends AbstractIdentityProvider
 {
     public function getOrganizationNameEn() : string
     {
@@ -55,9 +55,11 @@ class EngineBlockServiceProviderMetadata extends AbstractServiceProvider
         return $this->entity->getOrganizationNl()->url;
     }
 
-    public function getAssertionConsumerService() : IndexedService
+    public function getSsoLocation() : string
     {
-        return reset($this->entity->getAssertionConsumerServices());
+        /** @var Service $service */
+        $service = reset($this->entity->getSingleSignOnServices());
+        return $service->location;
     }
 
     /**
@@ -71,27 +73,5 @@ class EngineBlockServiceProviderMetadata extends AbstractServiceProvider
             $keys[$pem] = $pem;
         }
         return $keys;
-    }
-
-    public function hasUiInfo(): bool
-    {
-        $info = [
-            $this->entity->getDisplayNameEn(),
-            $this->entity->getDisplayNameNl(),
-            $this->entity->getOrganizationEn(),
-            $this->entity->getOrganizationNl(),
-        ];
-
-        return !empty(array_filter($info));
-    }
-
-    public function hasOrganizationInfo(): bool
-    {
-        $info = [
-            $this->entity->getOrganizationEn(),
-            $this->entity->getOrganizationNl(),
-        ];
-
-        return !empty(array_filter($info));
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Helper/ServiceProviderMetadataHelper.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Helper/ServiceProviderMetadataHelper.php
@@ -18,10 +18,10 @@
 
 namespace OpenConext\EngineBlock\Metadata\Factory\Helper;
 
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\AbstractIdentityProvider;
-use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\Factory\Decorator\AbstractServiceProvider;
+use OpenConext\EngineBlock\Metadata\IndexedService;
 
-class EngineBlockIdentityProviderMetadata extends AbstractIdentityProvider
+class ServiceProviderMetadataHelper extends AbstractServiceProvider
 {
     public function getOrganizationNameEn() : string
     {
@@ -55,11 +55,9 @@ class EngineBlockIdentityProviderMetadata extends AbstractIdentityProvider
         return $this->entity->getOrganizationNl()->url;
     }
 
-    public function getSsoLocation() : string
+    public function getAssertionConsumerService() : IndexedService
     {
-        /** @var Service $service */
-        $service = reset($this->entity->getSingleSignOnServices());
-        return $service->location;
+        return reset($this->entity->getAssertionConsumerServices());
     }
 
     /**
@@ -73,5 +71,27 @@ class EngineBlockIdentityProviderMetadata extends AbstractIdentityProvider
             $keys[$pem] = $pem;
         }
         return $keys;
+    }
+
+    public function hasUiInfo(): bool
+    {
+        $info = [
+            $this->entity->getDisplayNameEn(),
+            $this->entity->getDisplayNameNl(),
+            $this->entity->getOrganizationEn(),
+            $this->entity->getOrganizationNl(),
+        ];
+
+        return !empty(array_filter($info));
+    }
+
+    public function hasOrganizationInfo(): bool
+    {
+        $info = [
+            $this->entity->getOrganizationEn(),
+            $this->entity->getOrganizationNl(),
+        ];
+
+        return !empty(array_filter($info));
     }
 }

--- a/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
+++ b/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
@@ -20,8 +20,8 @@ namespace OpenConext\EngineBlock\Xml;
 
 use EngineBlock_Saml2_IdGenerator;
 use OpenConext\EngineBlock\Metadata\Factory\Collection\IdentityProviderEntityCollection;
-use OpenConext\EngineBlock\Metadata\Factory\Helper\EngineBlockIdentityProviderMetadata;
-use OpenConext\EngineBlock\Metadata\Factory\Helper\EngineBlockServiceProviderMetadata;
+use OpenConext\EngineBlock\Metadata\Factory\Helper\IdentityProviderMetadataHelper;
+use OpenConext\EngineBlock\Metadata\Factory\Helper\ServiceProviderMetadataHelper;
 use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
@@ -124,7 +124,7 @@ class MetadataRenderer
 
     private function renderMetadataXmlServiceProvider(ServiceProviderEntityInterface $sp, string $template) : string
     {
-        $metadata = new EngineBlockServiceProviderMetadata($sp);
+        $metadata = new ServiceProviderMetadataHelper($sp);
 
         $params = [
             'id' => $this->samlIdGenerator->generate(self::ID_PREFIX, EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_METADATA),
@@ -138,7 +138,7 @@ class MetadataRenderer
 
     private function renderMetadataXmlIdentityProvider(IdentityProviderEntityInterface $idp, string $template) : string
     {
-        $metadata = new EngineBlockIdentityProviderMetadata($idp);
+        $metadata = new IdentityProviderMetadataHelper($idp);
 
         $params = [
             'id' => $this->samlIdGenerator->generate(self::ID_PREFIX, EngineBlock_Saml2_IdGenerator::ID_USAGE_SAML2_METADATA),
@@ -154,7 +154,7 @@ class MetadataRenderer
     {
         $metadataCollection = new IdentityProviderEntityCollection();
         foreach ($idpCollection as $idp) {
-            $metadataCollection->add(new EngineBlockIdentityProviderMetadata($idp));
+            $metadataCollection->add(new IdentityProviderMetadataHelper($idp));
         }
 
         $params = [

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockServiceProviderTest.php
@@ -26,7 +26,7 @@ use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use OpenConext\EngineBlockBundle\Url\UrlProvider;
 use SAML2\Constants;
 
-class ServiceProviderProxyTest extends AbstractEntityTest
+class EngineBlockServiceProviderTest extends AbstractEntityTest
 {
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|UrlProvider
@@ -48,7 +48,7 @@ class ServiceProviderProxyTest extends AbstractEntityTest
         $this->urlProvider->expects($this->exactly(1))
             ->method('getUrl')
             ->withConsecutive(
-                // ACS: ServiceProviderProxy::getAssertionConsumerServices
+                // ACS: EngineBlockServiceProvider::getAssertionConsumerServices
                 ['authentication_sp_consume_assertion', false, null, null]
             ) ->willReturnOnConsecutiveCalls(
                 // ACS
@@ -69,7 +69,7 @@ class ServiceProviderProxyTest extends AbstractEntityTest
         $attributesMock->method('getRequestedAttributes')
             ->willReturn($attributes);
 
-        $decorator = new ServiceProviderProxy($adapter, $keyPairMock, $attributesMock, $this->urlProvider);
+        $decorator = new EngineBlockServiceProvider($adapter, $keyPairMock, $attributesMock, $this->urlProvider);
 
         $supportedNameIdFormats = [
             Constants::NAMEID_PERSISTENT,

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockIdentityProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockIdentityProviderTest.php
@@ -25,7 +25,7 @@ use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use OpenConext\EngineBlockBundle\Url\UrlProvider;
 use SAML2\Constants;
 
-class IdentityProviderProxyTest extends AbstractEntityTest
+class EngineblockIdentityProviderTest extends AbstractEntityTest
 {
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject
@@ -65,9 +65,9 @@ class IdentityProviderProxyTest extends AbstractEntityTest
         $this->urlProvider->expects($this->exactly(3))
             ->method('getUrl')
             ->withConsecutive(
-                // SLO: IdentityProviderProxy::getSingleLogoutService
+                // SLO: EngineBlockIdentityProvider::getSingleLogoutService
                 ['authentication_logout', false, null, null],
-                // SSO: IdentityProviderProxy::getSingleSignOnServices
+                // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
                 ['metadata_idp', false, null, null], // check if entity is EB
                 ['authentication_idp_sso', false, null, 'entity-id']
             ) ->willReturnOnConsecutiveCalls(
@@ -78,7 +78,7 @@ class IdentityProviderProxyTest extends AbstractEntityTest
                 'ssoLocation'
             );
 
-        $decorator = new IdentityProviderProxy($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
 
         $supportedNameIdFormats = [
             Constants::NAMEID_PERSISTENT,
@@ -103,7 +103,7 @@ class IdentityProviderProxyTest extends AbstractEntityTest
             ->with('authentication_logout', false, null, null)
             ->willReturn('sloLocation');
 
-        $decorator = new IdentityProviderProxy($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
 
         $this->assertEquals($decorator->getSingleLogoutService(), new Service('sloLocation', Constants::BINDING_HTTP_REDIRECT));
     }
@@ -114,7 +114,7 @@ class IdentityProviderProxyTest extends AbstractEntityTest
             'singleLogoutService' => null,
         ]);
 
-        $decorator = new IdentityProviderProxy($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
 
         $this->assertEquals($decorator->getSingleLogoutService(), null);
     }
@@ -126,7 +126,7 @@ class IdentityProviderProxyTest extends AbstractEntityTest
         $this->urlProvider->expects($this->exactly(2))
             ->method('getUrl')
             ->withConsecutive(
-                // SSO: IdentityProviderProxy::getSingleSignOnServices
+                // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
                 ['metadata_idp', false, null, null], // check if entity is EB
                 ['authentication_idp_sso', false, null, null]  // we would expect the fourth paremeter to be null and not 'entity-id' becasue we are EB
             ) ->willReturnOnConsecutiveCalls(
@@ -137,7 +137,7 @@ class IdentityProviderProxyTest extends AbstractEntityTest
             );
 
 
-        $decorator = new IdentityProviderProxy($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
 
         $this->assertEquals([new Service('ssoLocation', Constants::BINDING_HTTP_REDIRECT)], $decorator->getSingleSignOnServices());
     }
@@ -151,7 +151,7 @@ class IdentityProviderProxyTest extends AbstractEntityTest
         $this->urlProvider->expects($this->exactly(2))
             ->method('getUrl')
             ->withConsecutive(
-            // SSO: IdentityProviderProxy::getSingleSignOnServices
+            // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
                 ['metadata_idp', false, null, null], // check if entity is EB
                 ['authentication_idp_sso', false, null, 'entity-id']  // we would expect the fourth paremeter to be null and not 'entity-id' becasue we are EB
             ) ->willReturnOnConsecutiveCalls(
@@ -162,7 +162,7 @@ class IdentityProviderProxyTest extends AbstractEntityTest
             );
 
 
-        $decorator = new IdentityProviderProxy($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
 
         $this->assertEquals([new Service('ssoLocation?entityIdHash', Constants::BINDING_HTTP_REDIRECT)], $decorator->getSingleSignOnServices());
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactoryTest.php
@@ -21,7 +21,7 @@ use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Factory\AbstractEntityTest;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\IdentityProviderEntity;
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\IdentityProviderProxy;
+use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockIdentityProvider;
 use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration;
 use OpenConext\EngineBlock\Metadata\Logo;
@@ -130,9 +130,9 @@ class IdentityProviderFactoryTest extends AbstractEntityTest
         $this->urlProvider->expects($this->exactly(3))
             ->method('getUrl')
             ->withConsecutive(
-            // SLO: IdentityProviderProxy::getSingleLogoutService
+            // SLO: EngineBlockIdentityProvider::getSingleLogoutService
                 ['authentication_logout', false, null, null],
-                // SSO: IdentityProviderProxy::getSingleSignOnServices
+                // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
                 ['metadata_idp', false, null, null], // check if entity is EB
                 ['authentication_idp_sso', false, null, 'entity-id']
             ) ->willReturnOnConsecutiveCalls(
@@ -165,7 +165,7 @@ class IdentityProviderFactoryTest extends AbstractEntityTest
         $overrides['organizationEn'] = $organization;
         $overrides['contactPersons'] = $contactPersons;
 
-        // IdentityProviderProxy
+        // EngineBlockIdentityProvider
         $overrides['certificates'] = [$this->certificateMock];
         $overrides['supportedNameIdFormats'] = $supportedNameIdFormats;
         $overrides['singleSignOnServices'] = [new Service('ssoLocation', Constants::BINDING_HTTP_REDIRECT)];

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
@@ -24,7 +24,7 @@ use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\AbstractEntityTest;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\IdentityProviderEntity;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\ServiceProviderEntity;
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\ServiceProviderProxy;
+use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration;
 use OpenConext\EngineBlock\Metadata\IndexedService;
@@ -140,9 +140,9 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $this->urlProvider->expects($this->exactly(2))
             ->method('getUrl')
             ->withConsecutive(
-                // EntityId: ServiceProviderProxy::getEntityId
+                // EntityId: EngineBlockServiceProvider::getEntityId
                 ['metadata_sp', false, null, null],
-                // ACS: ServiceProviderProxy::getAssertionConsumerService
+                // ACS: EngineBlockServiceProvider::getAssertionConsumerService
                 ['authentication_sp_consume_assertion', false, null, null]
             ) ->willReturnOnConsecutiveCalls(
                 // EntityId
@@ -241,7 +241,7 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $overrides['organizationEn'] = $organization;
         $overrides['contactPersons'] = $contactPersons;
 
-        // ServiceProviderProxy
+        // EngineBlockServiceProvider
         $overrides['entityId'] = 'EbEntityId';
         $overrides['certificates'] = [$certificateMock];
         $overrides['supportedNameIdFormats'] = $supportedNameIdFormats;

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockIdentityProviderMetadataTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockIdentityProviderMetadataTest.php
@@ -32,7 +32,7 @@ class EngineBlockIdentityProviderMetadataTest extends AbstractEntityTest
     {
         $adapter = $this->createIdentityProviderAdapter();
 
-        $decorator = new EngineBlockIdentityProviderMetadata($adapter);
+        $decorator = new IdentityProviderMetadataHelper($adapter);
 
         $this->runIdentityProviderAssertions($adapter, $decorator);
     }
@@ -65,7 +65,7 @@ class EngineBlockIdentityProviderMetadataTest extends AbstractEntityTest
             $cert1, $cert2,
         ]);
 
-        $decorator = new EngineBlockIdentityProviderMetadata($adapter);
+        $decorator = new IdentityProviderMetadataHelper($adapter);
 
         $this->assertEquals('metadata-organization-name-en', $decorator->getOrganizationNameEn());
         $this->assertEquals('metadata-organization-name-nl', $decorator->getOrganizationNameNl());

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockServiceProviderMetadataTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockServiceProviderMetadataTest.php
@@ -32,7 +32,7 @@ class EngineBlockServiceProviderMetadataTest extends AbstractEntityTest
     {
         $adapter = $this->createServiceProviderAdapter();
 
-        $decorator = new EngineBlockServiceProviderMetadata($adapter);
+        $decorator = new ServiceProviderMetadataHelper($adapter);
 
         $this->runServiceProviderAssertions($adapter, $decorator);
     }
@@ -66,7 +66,7 @@ class EngineBlockServiceProviderMetadataTest extends AbstractEntityTest
             $cert1, $cert2,
         ]);
 
-        $decorator = new EngineBlockServiceProviderMetadata($adapter);
+        $decorator = new ServiceProviderMetadataHelper($adapter);
 
         $this->assertEquals('metadata-organization-name-en', $decorator->getOrganizationNameEn());
         $this->assertEquals('metadata-organization-name-nl', $decorator->getOrganizationNameNl());

--- a/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
@@ -25,7 +25,7 @@ use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\IdentityProviderEntity;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\ServiceProviderEntity;
 use OpenConext\EngineBlock\Metadata\Factory\Collection\IdentityProviderEntityCollection;
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\IdentityProviderProxy;
+use OpenConext\EngineBlock\Metadata\Factory\Decorator\EngineBlockIdentityProvider;
 use OpenConext\EngineBlock\Metadata\IndexedService;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\Organization;
@@ -187,7 +187,7 @@ class MetadataRendererTest extends TestCase
         $logo->width = 100;
         $logo->height = 100;
 
-        $idp1 = m::mock(IdentityProviderProxy::class);
+        $idp1 = m::mock(EngineBlockIdentityProvider::class);
         $idp1
             ->shouldReceive('getEntityId')
             ->andReturn('idp1')
@@ -200,7 +200,7 @@ class MetadataRendererTest extends TestCase
         ;
         $idp1->shouldIgnoreMissing();
 
-        $idp2 = m::mock(IdentityProviderProxy::class);
+        $idp2 = m::mock(EngineBlockIdentityProvider::class);
         $idp2
             ->shouldReceive('getEntityId')
             ->andReturn('idp2')


### PR DESCRIPTION
Some decorators and helpers naming didn't reflect the purpose of
the class properly.

https://www.pivotaltracker.com/story/show/169257771