### PR TITLE
Use correct language value in organization metadata

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderStepup.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ServiceProviderStepup.php
@@ -17,10 +17,8 @@
 
 namespace OpenConext\EngineBlock\Metadata\Factory\Decorator;
 
-use EngineBlock_Attributes_Metadata as AttributesMetadata;
 use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\IndexedService;
-use OpenConext\EngineBlock\Metadata\RequestedAttribute;
 use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use OpenConext\EngineBlockBundle\Url\UrlProvider;
 use SAML2\Constants;
@@ -50,7 +48,6 @@ class ServiceProviderStepup extends AbstractServiceProvider
         $this->keyPair = $keyPair;
         $this->urlProvider = $urlProvider;
     }
-
 
     public function getCertificates(): array
     {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockIdentityProviderMetadata.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockIdentityProviderMetadata.php
@@ -19,12 +19,11 @@
 namespace OpenConext\EngineBlock\Metadata\Factory\Helper;
 
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\AbstractIdentityProvider;
-use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Service;
 
 class EngineBlockIdentityProviderMetadata extends AbstractIdentityProvider
 {
-    public function getOrganization() : string
+    public function getOrganizationNameEn() : string
     {
         if (!$this->entity->getOrganizationEn()) {
             return '';
@@ -32,12 +31,28 @@ class EngineBlockIdentityProviderMetadata extends AbstractIdentityProvider
         return $this->entity->getOrganizationEn()->name;
     }
 
-    public function getOrganizationSupportUrl() : string
+    public function getOrganizationNameNl() : string
+    {
+        if (!$this->entity->getOrganizationNl()) {
+            return '';
+        }
+        return $this->entity->getOrganizationNl()->name;
+    }
+
+    public function getOrganizationUrlEn() : string
     {
         if (!$this->entity->getOrganizationEn()) {
             return '';
         }
         return $this->entity->getOrganizationEn()->url;
+    }
+
+    public function getOrganizationUrlNl() : string
+    {
+        if (!$this->entity->getOrganizationNl()) {
+            return '';
+        }
+        return $this->entity->getOrganizationNl()->url;
     }
 
     public function getSsoLocation() : string

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockServiceProviderMetadata.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockServiceProviderMetadata.php
@@ -19,14 +19,11 @@
 namespace OpenConext\EngineBlock\Metadata\Factory\Helper;
 
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\AbstractServiceProvider;
-use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\IndexedService;
-use OpenConext\EngineBlock\Metadata\Logo;
-use OpenConext\EngineBlock\Metadata\RequestedAttribute;
 
 class EngineBlockServiceProviderMetadata extends AbstractServiceProvider
 {
-    public function getOrganization() : string
+    public function getOrganizationNameEn() : string
     {
         if (!$this->entity->getOrganizationEn()) {
             return '';
@@ -34,12 +31,28 @@ class EngineBlockServiceProviderMetadata extends AbstractServiceProvider
         return $this->entity->getOrganizationEn()->name;
     }
 
-    public function getOrganizationSupportUrl() : string
+    public function getOrganizationNameNl() : string
+    {
+        if (!$this->entity->getOrganizationNl()) {
+            return '';
+        }
+        return $this->entity->getOrganizationNl()->name;
+    }
+
+    public function getOrganizationUrlEn() : string
     {
         if (!$this->entity->getOrganizationEn()) {
             return '';
         }
         return $this->entity->getOrganizationEn()->url;
+    }
+
+    public function getOrganizationUrlNl() : string
+    {
+        if (!$this->entity->getOrganizationNl()) {
+            return '';
+        }
+        return $this->entity->getOrganizationNl()->url;
     }
 
     public function getAssertionConsumerService() : IndexedService

--- a/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
+++ b/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
@@ -67,19 +67,24 @@ class MetadataRenderer
      * @var string
      */
     private $termsOfUse;
+    /**
+     * @var TimeProvider
+     */
+    private $timeProvider;
 
     public function __construct(
         Environment $twig,
         EngineBlock_Saml2_IdGenerator $samlIdGenerator,
         KeyPairFactory $keyPairFactory,
         DocumentSigner $documentSigner,
+        TimeProvider $timeProvider,
         string $termsOfUse
     ) {
         $this->twig = $twig;
         $this->samlIdGenerator = $samlIdGenerator;
         $this->keyPairFactory = $keyPairFactory;
         $this->documentSigner = $documentSigner;
-        $this->timeProvider = new TimeProvider();
+        $this->timeProvider = $timeProvider;
         $this->termsOfUse = $termsOfUse;
     }
 

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -120,6 +120,7 @@ services:
             - "@engineblock.compat.saml2_id_generator"
             - "@OpenConext\\EngineBlock\\Metadata\\X509\\KeyPairFactory"
             - "@OpenConext\\EngineBlock\\Xml\\DocumentSigner"
+            - "@engineblock.service.time_provider"
             - "%openconext_terms_of_use_url%"
 
     OpenConext\EngineBlock\Xml\MetadataProvider:

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockIdentityProviderMetadataTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockIdentityProviderMetadataTest.php
@@ -67,8 +67,10 @@ class EngineBlockIdentityProviderMetadataTest extends AbstractEntityTest
 
         $decorator = new EngineBlockIdentityProviderMetadata($adapter);
 
-        $this->assertEquals('metadata-organization-name-en', $decorator->getOrganization());
-        $this->assertEquals('metadata-organization-url-en', $decorator->getOrganizationSupportUrl());
+        $this->assertEquals('metadata-organization-name-en', $decorator->getOrganizationNameEn());
+        $this->assertEquals('metadata-organization-name-nl', $decorator->getOrganizationNameNl());
+        $this->assertEquals('metadata-organization-url-en', $decorator->getOrganizationUrlEn());
+        $this->assertEquals('metadata-organization-url-nl', $decorator->getOrganizationUrlNl());
         $this->assertEquals('location1', $decorator->getSsoLocation());
         $this->assertEquals(['pem1-abc' => 'pem1-abc', 'pem2-abc' => 'pem2-abc'], $decorator->getPublicKeys());
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockServiceProviderMetadataTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockServiceProviderMetadataTest.php
@@ -68,8 +68,10 @@ class EngineBlockServiceProviderMetadataTest extends AbstractEntityTest
 
         $decorator = new EngineBlockServiceProviderMetadata($adapter);
 
-        $this->assertEquals('metadata-organization-name-en', $decorator->getOrganization());
-        $this->assertEquals('metadata-organization-url-en', $decorator->getOrganizationSupportUrl());
+        $this->assertEquals('metadata-organization-name-en', $decorator->getOrganizationNameEn());
+        $this->assertEquals('metadata-organization-name-nl', $decorator->getOrganizationNameNl());
+        $this->assertEquals('metadata-organization-url-en', $decorator->getOrganizationUrlEn());
+        $this->assertEquals('metadata-organization-url-nl', $decorator->getOrganizationUrlNl());
         $this->assertEquals( new IndexedService('location1','binding1', 0), $decorator->getAssertionConsumerService());
         $this->assertEquals(true, $decorator->hasUiInfo());
         $this->assertEquals(true, $decorator->hasOrganizationInfo());

--- a/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
@@ -25,8 +25,6 @@ use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\IdentityProviderEntity;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\ServiceProviderEntity;
 use OpenConext\EngineBlock\Metadata\Factory\Collection\IdentityProviderEntityCollection;
-use OpenConext\EngineBlock\Metadata\Factory\Helper\EngineBlockIdentityProviderMetadata;
-use OpenConext\EngineBlock\Metadata\Factory\Helper\EngineBlockServiceProviderMetadata;
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\IdentityProviderProxy;
 use OpenConext\EngineBlock\Metadata\IndexedService;
 use OpenConext\EngineBlock\Metadata\Logo;
@@ -37,6 +35,7 @@ use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use OpenConext\EngineBlock\Metadata\X509\X509PrivateKey;
+use OpenConext\EngineBlock\Service\TimeProvider\TimeProvider;
 use PHPUnit\Framework\TestCase;
 use RobRichards\XMLSecLibs\XMLSecEnc;
 use RobRichards\XMLSecLibs\XMLSecurityDSig;
@@ -83,6 +82,7 @@ class MetadataRendererTest extends TestCase
             $samlIdGenerator,
             $keyPairFactory,
             $documentSigner,
+            new TimeProvider(),
             'terms-of-use'
         );
 

--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
@@ -1,8 +1,8 @@
 <md:Organization>
-    <md:OrganizationName xml:lang="nl">{{ metadata.organization }}</md:OrganizationName>
-    <md:OrganizationName xml:lang="en">{{ metadata.organization }}</md:OrganizationName>
-    <md:OrganizationDisplayName xml:lang="nl">{{ metadata.organization }}</md:OrganizationDisplayName>
-    <md:OrganizationDisplayName xml:lang="en">{{ metadata.organization }}</md:OrganizationDisplayName>
-    <md:OrganizationURL xml:lang="nl">{{ metadata.organizationSupportUrl }}</md:OrganizationURL>
-    <md:OrganizationURL xml:lang="en">{{ metadata.organizationSupportUrl }}</md:OrganizationURL>
+    <md:OrganizationName xml:lang="nl">{{ metadata.organizationNameNl }}</md:OrganizationName>
+    <md:OrganizationName xml:lang="en">{{ metadata.organizationNameEn }}</md:OrganizationName>
+    <md:OrganizationDisplayName xml:lang="nl">{{ metadata.organizationNameNl }}</md:OrganizationDisplayName>
+    <md:OrganizationDisplayName xml:lang="en">{{ metadata.organizationNameEn }}</md:OrganizationDisplayName>
+    <md:OrganizationURL xml:lang="nl">{{ metadata.supportUrlNl }}</md:OrganizationURL>
+    <md:OrganizationURL xml:lang="en">{{ metadata.supportUrlEn }}</md:OrganizationURL>
 </md:Organization>


### PR DESCRIPTION
The translations weren't working for the organization block and
only english translations were used. This is fixed.

https://www.pivotaltracker.com/story/show/169257771