### PR TITLE
Remove ResponseProcessingService

### DIFF
--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -499,11 +499,7 @@ class EngineBlock_Corto_Adapter
             $idpEntityId,
             $spEntityId,
             $keyPair,
-            EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getAttributeMetadata(),
-            new Service(
-                '/authentication/idp/provide-consent',
-                'INTERNAL'
-            )
+            EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getAttributeMetadata()
         );
 
         $this->getMetadataRepository()->appendVisitor($visitor);

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -472,8 +472,8 @@ class EngineBlock_Corto_ProxyServer
         // Change the destiny of the received response
         $inResponseTo = $receivedResponse->getInResponseTo();
         $newResponse->setInResponseTo($inResponseTo);
-        $newResponse->setDestination($serviceProvider->responseProcessingService->location);
-        $newResponse->setDeliverByBinding($serviceProvider->responseProcessingService->binding);
+        $newResponse->setDestination('/authentication/idp/provide-consent');
+        $newResponse->setDeliverByBinding('INTERNAL');
         $newResponse->setReturn($this->_server->getUrl('processedAssertionConsumerService'));
 
         $idp = $this->_server->getRepository()->fetchIdentityProviderByEntityId($receivedResponse->getIssuer());

--- a/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRole.php
@@ -238,13 +238,6 @@ abstract class AbstractRole
     public $requestsMustBeSigned = false;
 
     /**
-     * This seems to be used only to inject a ConsentService when initiating consent...
-     *
-     * @var Service
-     */
-    public $responseProcessingService;
-
-    /**
      * @var string
      *
      * @ORM\Column(name="manipulation", type="text")
@@ -279,7 +272,6 @@ abstract class AbstractRole
      * @param null $publishInEduGainDate
      * @param bool $publishInEdugain
      * @param bool $requestsMustBeSigned
-     * @param Service $responseProcessingService
      * @param string $workflowState
      * @param string $manipulation
      */
@@ -307,7 +299,6 @@ abstract class AbstractRole
         $publishInEduGainDate = null,
         $publishInEdugain = false,
         $requestsMustBeSigned = false,
-        Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         $manipulation = ''
     ) {
@@ -330,7 +321,6 @@ abstract class AbstractRole
         $this->publishInEduGainDate = $publishInEduGainDate;
         $this->publishInEdugain = $publishInEdugain;
         $this->requestsMustBeSigned = $requestsMustBeSigned;
-        $this->responseProcessingService = $responseProcessingService;
         $this->singleLogoutService = $singleLogoutService;
         $this->workflowState = $workflowState;
         $this->manipulation = $manipulation;

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -111,7 +111,6 @@ class IdentityProvider extends AbstractRole
      * @param bool $publishInEdugain
      * @param bool $requestsMustBeSigned
      * @param string $signatureMethod
-     * @param Service $responseProcessingService
      * @param string $workflowState
      * @param string $manipulation
      * @param bool $enabledInWayf
@@ -150,7 +149,6 @@ class IdentityProvider extends AbstractRole
         $publishInEdugain = false,
         $requestsMustBeSigned = false,
         $signatureMethod = XMLSecurityKey::RSA_SHA256,
-        Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         $manipulation = '',
         $enabledInWayf = true,
@@ -186,7 +184,6 @@ class IdentityProvider extends AbstractRole
             $publishInEduGainDate,
             $publishInEdugain,
             $requestsMustBeSigned,
-            $responseProcessingService,
             $workflowState,
             $manipulation
         );

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -119,7 +119,6 @@ class ServiceProvider extends AbstractRole
      * @param bool $publishInEdugain
      * @param bool $requestsMustBeSigned
      * @param string $signatureMethod
-     * @param Service $responseProcessingService
      * @param string $workflowState
      * @param array $allowedIdpEntityIds
      * @param bool $allowAll
@@ -169,7 +168,6 @@ class ServiceProvider extends AbstractRole
         $publishInEdugain = false,
         $requestsMustBeSigned = false,
         $signatureMethod = XMLSecurityKey::RSA_SHA256,
-        Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         array $allowedIdpEntityIds = array(),
         $allowAll = false,
@@ -215,7 +213,6 @@ class ServiceProvider extends AbstractRole
             $publishInEduGainDate,
             $publishInEdugain,
             $requestsMustBeSigned,
-            $responseProcessingService,
             $workflowState,
             $manipulation
         );

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
@@ -207,14 +207,6 @@ class IdentityProviderEntity implements IdentityProviderEntityInterface
     }
 
     /**
-     * @return Service
-     */
-    public function getResponseProcessingService(): Service
-    {
-        return $this->entity->responseProcessingService;
-    }
-
-    /**
      * @return string
      */
     public function getManipulation(): string

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
@@ -208,14 +208,6 @@ class ServiceProviderEntity implements ServiceProviderEntityInterface
     }
 
     /**
-     * @return null|Service
-     */
-    public function getResponseProcessingService(): ?Service
-    {
-        return $this->entity->responseProcessingService;
-    }
-
-    /**
      * @return string
      */
     public function getManipulation(): string

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
@@ -209,14 +209,6 @@ abstract class AbstractIdentityProvider implements IdentityProviderEntityInterfa
     }
 
     /**
-     * @return Service
-     */
-    public function getResponseProcessingService(): Service
-    {
-        return $this->entity->getResponseProcessingService();
-    }
-
-    /**
      * @return string
      */
     public function getManipulation(): string

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
@@ -210,14 +210,6 @@ abstract class AbstractServiceProvider implements ServiceProviderEntityInterface
     }
 
     /**
-     * @return null|Service
-     */
-    public function getResponseProcessingService(): ?Service
-    {
-        return $this->entity->getResponseProcessingService();
-    }
-
-    /**
      * @return string
      */
     public function getManipulation(): string

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxy.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxy.php
@@ -75,14 +75,6 @@ class IdentityProviderProxy extends AbstractIdentityProvider
         return new Service($sloLocation, Constants::BINDING_HTTP_REDIRECT);
     }
 
-    public function getResponseProcessingService(): Service
-    {
-        // TODO:  test if this works or could be removed
-        // @see https://www.pivotaltracker.com/story/show/169204880
-
-        return new Service('/authentication/idp/provide-consent', 'INTERNAL');
-    }
-
     /**
      * When the service is requested for an entity other then EB we should replace service locations and bindings with those of EB
      * - if the entity is not EB we should add the entityId so EB could determine the IdP we are acting for.

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockServiceProviderMetadata.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Helper/EngineBlockServiceProviderMetadata.php
@@ -19,10 +19,7 @@
 namespace OpenConext\EngineBlock\Metadata\Factory\Helper;
 
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\AbstractServiceProvider;
-use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\IndexedService;
-use OpenConext\EngineBlock\Metadata\Logo;
-use OpenConext\EngineBlock\Metadata\RequestedAttribute;
 
 class EngineBlockServiceProviderMetadata extends AbstractServiceProvider
 {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/IdentityProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/IdentityProviderEntityInterface.php
@@ -131,11 +131,6 @@ interface IdentityProviderEntityInterface
     public function isRequestsMustBeSigned(): bool;
 
     /**
-     * @return Service
-     */
-    public function getResponseProcessingService(): Service;
-
-    /**
      * @return string
      */
     public function getManipulation(): string;

--- a/src/OpenConext/EngineBlock/Metadata/Factory/ServiceProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/ServiceProviderEntityInterface.php
@@ -131,11 +131,6 @@ interface ServiceProviderEntityInterface
     public function isRequestsMustBeSigned(): bool;
 
     /**
-     * @return null|Service
-     */
-    public function getResponseProcessingService(): ?Service;
-
-    /**
      * @return string
      */
     public function getManipulation(): string;

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/Visitor/EngineBlockMetadataVisitor.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/Visitor/EngineBlockMetadataVisitor.php
@@ -18,13 +18,11 @@
 
 namespace OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor;
 
-use EngineBlock_X509_KeyPair as KeyPair;
 use EngineBlock_Attributes_Metadata as AttributesMetadata;
+use EngineBlock_X509_KeyPair as KeyPair;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
-use OpenConext\EngineBlock\Metadata\RequestedAttribute;
-use OpenConext\EngineBlock\Metadata\Service;
 use SAML2\Constants;
 
 /**
@@ -53,29 +51,21 @@ class EngineBlockMetadataVisitor implements VisitorInterface
     private $attributes;
 
     /**
-     * @var Service
-     */
-    private $consentService;
-
-    /**
      * @param string $idpEntityId
      * @param string $spEntityId
      * @param KeyPair $keyPair
      * @param AttributesMetadata $attributes
-     * @param Service $consentService
      */
     public function __construct(
         $idpEntityId,
         $spEntityId,
         KeyPair $keyPair,
-        AttributesMetadata $attributes,
-        Service $consentService
+        AttributesMetadata $attributes
     ) {
         $this->idpEntityId = $idpEntityId;
         $this->spEntityId = $spEntityId;
         $this->keyPair = $keyPair;
         $this->attributes = $attributes;
-        $this->consentService = $consentService;
     }
 
     /**
@@ -90,6 +80,8 @@ class EngineBlockMetadataVisitor implements VisitorInterface
     }
 
     /**
+     * The allowAll was needed for the dynamically set ConsentService but it's unclear if the 'allow all entity ids' is still required.
+     *
      * {@inheritdoc}
      */
     public function visitServiceProvider(ServiceProvider $entity)
@@ -97,8 +89,9 @@ class EngineBlockMetadataVisitor implements VisitorInterface
         if ($entity->entityId === $this->spEntityId) {
             $this->setCertificate($entity);
             $this->setNameIdFormats($entity);
-            $this->setConsentService($entity);
             $this->setRequestedAttributes($entity);
+
+            $entity->allowAll = true;
         }
     }
 
@@ -151,24 +144,5 @@ class EngineBlockMetadataVisitor implements VisitorInterface
     private function setRequestedAttributes(ServiceProvider $entity)
     {
         $entity->requestedAttributes = $this->attributes->getRequestedAttributes();
-    }
-
-    /**
-     * Configure the consent service.
-     *
-     * The consent service is implemented using a so-called 'internal
-     * binding'. This can be considered an implementation detail, and can not
-     * and should not be configured in service registry / manage. This method
-     * overrides the metadata so the internal consent service is used.
-     *
-     * It's unclear if the 'allow all entity ids' is still required for the
-     * consent service to function.
-     *
-     * @param ServiceProvider $entity
-     */
-    private function setConsentService(ServiceProvider $entity)
-    {
-        $entity->responseProcessingService = $this->consentService;
-        $entity->allowAll = true;
     }
 }

--- a/src/OpenConext/EngineBlock/Stepup/StepupEntityFactory.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupEntityFactory.php
@@ -38,10 +38,6 @@ class StepupEntityFactory
     {
         $publicKeyFactory = new EngineBlock_X509_CertificateFactory();
         $certificates[] = $publicKeyFactory->fromFile($stepupEndpoint->getKeyFile());
-        $responseProcessingService = new Service(
-            $acsLocation,
-            Constants::BINDING_HTTP_REDIRECT
-        );
         $singleSignOnServices[] = new Service($stepupEndpoint->getSsoLocation(), Constants::BINDING_HTTP_REDIRECT);
 
         $entity = new IdentityProvider(
@@ -71,7 +67,6 @@ class StepupEntityFactory
             false,
             true,
             XMLSecurityKey::RSA_SHA256,
-            $responseProcessingService,
             IdentityProvider::WORKFLOW_STATE_DEFAULT,
             '',
             false,
@@ -131,7 +126,6 @@ class StepupEntityFactory
             false,
             true,
             XMLSecurityKey::RSA_SHA256,
-            null,
             IdentityProvider::WORKFLOW_STATE_DEFAULT,
             [],
             false,

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
@@ -88,7 +88,6 @@ abstract class AbstractEntityTest extends TestCase
             'supportedNameIdFormats' => function(IdentityProviderEntityInterface $entity) { return  $entity->getSupportedNameIdFormats(); },
             'singleLogoutService' => function(IdentityProviderEntityInterface $entity) { return  $entity->getSingleLogoutService(); },
             'requestsMustBeSigned' => function(IdentityProviderEntityInterface $entity) { return  $entity->isRequestsMustBeSigned(); },
-            'responseProcessingService' => function(IdentityProviderEntityInterface $entity) { return  $entity->getResponseProcessingService(); },
             'manipulation' => function(IdentityProviderEntityInterface $entity) { return  $entity->getManipulation(); },
             'coins' => function(IdentityProviderEntityInterface $entity) { return  $entity->getCoins(); },
             'enabledInWayf' => function(IdentityProviderEntityInterface $entity) { return  $entity->isEnabledInWayf(); },
@@ -99,7 +98,7 @@ abstract class AbstractEntityTest extends TestCase
 
         $missing = array_diff_key($implemented, $assertions);
         $this->assertCount(0, $missing, 'missing tests for: '. json_encode($missing));
-        $this->assertCount(27, $implemented);
+        $this->assertCount(26, $implemented);
         $this->assertCount(count($implemented), $assertions);
 
         foreach ($assertions as $name => $assertion) {
@@ -139,7 +138,6 @@ abstract class AbstractEntityTest extends TestCase
             'supportedNameIdFormats' => function(ServiceProviderEntityInterface $decorator) { return $decorator->getSupportedNameIdFormats(); },
             'singleLogoutService' => function(ServiceProviderEntityInterface $decorator) { return $decorator->getSingleLogoutService(); },
             'requestsMustBeSigned' => function(ServiceProviderEntityInterface $decorator) { return $decorator->isRequestsMustBeSigned(); },
-            'responseProcessingService' => function(ServiceProviderEntityInterface $decorator) { return $decorator->getResponseProcessingService(); },
             'manipulation' => function(ServiceProviderEntityInterface $decorator) { return $decorator->getManipulation(); },
             'coins' => function(ServiceProviderEntityInterface $decorator) { return $decorator->getCoins(); },
             'attributeReleasePolicy' => function(ServiceProviderEntityInterface $decorator) { return $decorator->getAttributeReleasePolicy(); },
@@ -157,7 +155,7 @@ abstract class AbstractEntityTest extends TestCase
 
         $missing = array_diff_key($implemented, $assertions);
         $this->assertCount(0, $missing, 'missing tests for: ' . json_encode($missing));
-        $this->assertCount(33, $implemented);
+        $this->assertCount(32, $implemented);
         $this->assertCount(count($implemented), $assertions);
 
         foreach ($assertions as $name => $assertion) {
@@ -306,7 +304,6 @@ abstract class AbstractEntityTest extends TestCase
             ],
             'singleLogoutService' => $this->createMock(Service::class),
             'requestsMustBeSigned' => true,
-            'responseProcessingService' => $this->createMock(Service::class),
             'manipulation' => 'manipulation',
             'coins' => $this->createMock(Coins::class),
             'enabledInWayf' => true,
@@ -363,7 +360,6 @@ abstract class AbstractEntityTest extends TestCase
             ],
             'singleLogoutService' => $this->createMock(Service::class),
             'requestsMustBeSigned' => true,
-            'responseProcessingService' => $this->createMock(Service::class),
             'manipulation' => 'manipulation',
             'coins' => $this->createMock(Coins::class),
             'attributeReleasePolicy' => $attributeReleasePolicy,

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntityTest.php
@@ -52,7 +52,6 @@ class IdentityProviderEntityTest extends AbstractEntityTest
             'supportedNameIdFormats' => $ormEntity->supportedNameIdFormats,
             'singleLogoutService' => $ormEntity->singleLogoutService,
             'requestsMustBeSigned' => $ormEntity->requestsMustBeSigned,
-            'responseProcessingService' => $ormEntity->responseProcessingService,
             'manipulation' => $ormEntity->manipulation,
             'coins' => $ormEntity->getCoins(),
             'enabledInWayf' => $ormEntity->enabledInWayf,

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntityTest.php
@@ -52,7 +52,6 @@ class ServiceProviderEntityTest extends AbstractEntityTest
             'supportedNameIdFormats' => $ormEntity->supportedNameIdFormats,
             'singleLogoutService' => $ormEntity->singleLogoutService,
             'requestsMustBeSigned' => $ormEntity->requestsMustBeSigned,
-            'responseProcessingService' => $ormEntity->responseProcessingService,
             'manipulation' => $ormEntity->manipulation,
             'coins' => $ormEntity->getCoins(),
 

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxyTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/IdentityProviderProxyTest.php
@@ -90,7 +90,6 @@ class IdentityProviderProxyTest extends AbstractEntityTest
         $overrides['supportedNameIdFormats'] = $supportedNameIdFormats;
         $overrides['singleSignOnServices'] = [new Service('ssoLocation', Constants::BINDING_HTTP_REDIRECT)];
         $overrides['singleLogoutService'] = new Service('sloLocation', Constants::BINDING_HTTP_REDIRECT);
-        $overrides['responseProcessingService'] = new Service('/authentication/idp/provide-consent', 'INTERNAL');
 
         $this->runIdentityProviderAssertions($this->adapter, $decorator, $overrides);
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactoryTest.php
@@ -170,8 +170,6 @@ class IdentityProviderFactoryTest extends AbstractEntityTest
         $overrides['supportedNameIdFormats'] = $supportedNameIdFormats;
         $overrides['singleSignOnServices'] = [new Service('ssoLocation', Constants::BINDING_HTTP_REDIRECT)];
         $overrides['singleLogoutService'] = new Service('sloLocation', Constants::BINDING_HTTP_REDIRECT);
-        $overrides['responseProcessingService'] = new Service('/authentication/idp/provide-consent', 'INTERNAL');
-
 
         $this->runIdentityProviderAssertions($adapter, $decorator, $overrides);
 

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
@@ -198,7 +198,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $overrides['nameIdFormat'] = null;
         $overrides['singleLogoutService'] = null;
         $overrides['requestsMustBeSigned'] = false;
-        $overrides['responseProcessingService'] = null;
         $overrides['manipulation'] = null;
         $overrides['coins'] = Coins::createForServiceProvider(
             true,
@@ -326,7 +325,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $overrides['nameIdFormat'] = null;
         $overrides['singleLogoutService'] = null;
         $overrides['requestsMustBeSigned'] = false;
-        $overrides['responseProcessingService'] = null;
         $overrides['manipulation'] = null;
         $overrides['coins'] = Coins::createForServiceProvider(
             true,


### PR DESCRIPTION
Remove ResponseProcessingService logic from ORM entities and move this
to the ProxyServer class so legacy code only exists in the legacy
namespace as this is only used there to temporarily inject the
ConsentService used for internal binding.

https://www.pivotaltracker.com/story/show/169204880