### PR TITLE
Added IDPentityID to the Attribute Aggregation request

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/AttributeAggregator.php
+++ b/library/EngineBlock/Corto/Filter/Command/AttributeAggregator.php
@@ -113,6 +113,7 @@ class EngineBlock_Corto_Filter_Command_AttributeAggregator extends EngineBlock_C
         // The AA request contains all response attributes.
         $request = Request::from(
             $serviceProvider->entityId,
+            $this->_identityProvider->entityId,
             $this->_collabPersonId,
             (array) $this->_responseAttributes,
             $rules

--- a/src/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/Request.php
+++ b/src/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/Request.php
@@ -31,6 +31,11 @@ final class Request implements JsonSerializable
     /**
      * @var string
      */
+    public $idpEntityId;
+
+    /**
+     * @var string
+     */
     public $subjectId;
 
     /**
@@ -52,9 +57,10 @@ final class Request implements JsonSerializable
      * @param AttributeRule[] $rules
      * @return Request $request
      */
-    public static function from($spEntityId, $subjectId, array $attributes, array $rules)
+    public static function from($spEntityId, $idpEntityId, $subjectId, array $attributes, array $rules)
     {
         Assertion::string($spEntityId, 'The SP entity ID must be a string, received "%s" (%s)');
+        Assertion::string($idpEntityId, 'The IDP entity ID must be a string, received "%s" (%s)');
         Assertion::string($subjectId, 'The SubjectId must be a string, received "%s" (%s)');
         Assertion::allIsInstanceOf($rules, AttributeRule::class, 'All attributes must be of type AttributeRule');
 
@@ -63,6 +69,7 @@ final class Request implements JsonSerializable
 
         $request = new self;
         $request->spEntityId = $spEntityId;
+        $request->idpEntityId = $idpEntityId;
         $request->subjectId = $subjectId;
         $request->attributes = $attributes;
         $request->rules = $rules;
@@ -94,6 +101,10 @@ final class Request implements JsonSerializable
                     [
                         'name' => 'SPentityID',
                         'values' => [$this->spEntityId],
+                    ],
+                    [
+                        'name' => 'IDPentityID',
+                        'values' => [$this->idpEntityId],
                     ]
                 ],
                 array_map(

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/AttributeAggregatorTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/AttributeAggregatorTest.php
@@ -20,6 +20,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\EngineBlockBundle\AttributeAggregation\AttributeAggregationClientInterface;
@@ -53,6 +54,11 @@ class EngineBlock_Test_Corto_Filter_Command_AttributeAggregatorTest extends Test
     private $sp;
 
     /**
+     * @var IdentityProvider
+     */
+    private $idp;
+
+    /**
      * @var MetadataRepositoryInterface
      */
     private $repository;
@@ -73,6 +79,7 @@ class EngineBlock_Test_Corto_Filter_Command_AttributeAggregatorTest extends Test
         $this->logger  = new Logger('Test', array($this->handler));
 
         $this->sp = new ServiceProvider('SP');
+        $this->idp = new IdentityProvider('IdP');
 
         $this->repository = Mockery::mock(MetadataRepositoryInterface::class);
         $this->repository->shouldReceive('findServiceProviderByEntityId')
@@ -163,7 +170,7 @@ class EngineBlock_Test_Corto_Filter_Command_AttributeAggregatorTest extends Test
         $command->setRequest($this->request);
         $command->setResponse($this->response);
         $command->setServiceProvider($this->sp);
-
+        $command->setIdentityProvider($this->idp);
         $command->execute();
     }
 
@@ -192,6 +199,7 @@ class EngineBlock_Test_Corto_Filter_Command_AttributeAggregatorTest extends Test
         $command->setRequest($this->request);
         $command->setResponse($this->response);
         $command->setServiceProvider($this->sp);
+        $command->setIdentityProvider($this->idp);
 
         $command->execute();
 
@@ -236,6 +244,7 @@ class EngineBlock_Test_Corto_Filter_Command_AttributeAggregatorTest extends Test
           'name' => ['non-aggregated-value'],
         ]);
         $command->setServiceProvider($this->sp);
+        $command->setIdentityProvider($this->idp);
 
         $command->execute();
 
@@ -285,6 +294,7 @@ class EngineBlock_Test_Corto_Filter_Command_AttributeAggregatorTest extends Test
         ]);
 
         $command->setServiceProvider($this->sp);
+        $command->setIdentityProvider($this->idp);
 
         $command->execute();
 
@@ -321,6 +331,7 @@ class EngineBlock_Test_Corto_Filter_Command_AttributeAggregatorTest extends Test
         $command->setRequest($this->request);
         $command->setResponse($this->response);
         $command->setServiceProvider($this->sp);
+        $command->setIdentityProvider($this->idp);
 
         $command->execute();
     }
@@ -348,6 +359,7 @@ class EngineBlock_Test_Corto_Filter_Command_AttributeAggregatorTest extends Test
         $command->setRequest($this->request);
         $command->setResponse($this->response);
         $command->setServiceProvider($this->sp);
+        $command->setIdentityProvider($this->idp);
 
         $command->execute();
 

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/AttributeAggregationClientTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/AttributeAggregationClientTest.php
@@ -43,6 +43,7 @@ class AttributeAggregationClientTest extends TestCase
     {
         $request = Request::from(
             'sp-entity-id',
+            'idp-entity-id',
             'subject',
             [],
             [

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/RequestTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/RequestTest.php
@@ -38,6 +38,7 @@ class RequestTest extends TestCase
     {
         $request = Request::from(
             'sp-entity-id',
+            'idp-entity-id',
             'subject',
             [
                 'attr' => ['1', '2', '3'],
@@ -92,6 +93,7 @@ class RequestTest extends TestCase
     {
         $request = Request::from(
             'sp-entity-id',
+            'idp-entity-id',
             'subject',
             [
                 'attr' => ['1', ['foo' => 'bar'], '3'],
@@ -150,7 +152,16 @@ class RequestTest extends TestCase
     public function request_sp_entity_id_must_be_set()
     {
         $this->expectException(InvalidArgumentException::class);
-        Request::from(NULL,'subject-id', [], []);
+        Request::from(NULL, 'idp-entity-id', 'subject-id', [], []);
+    }
+
+    /**
+     * @test
+     */
+    public function request_idp_entity_id_must_be_set()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Request::from('sp-entity-id', 'idp-entity-id', NULL, 'subject-id', [], []);
     }
 
     /**
@@ -159,6 +170,6 @@ class RequestTest extends TestCase
     public function request_attributes_must_be_of_type_dto()
     {
         $this->expectException(InvalidArgumentException::class);
-        Request::from('sp-entity-id', 'subject', [], [['invalid']]);
+        Request::from('sp-entity-id', 'idp-entity-id', 'subject', [], [['invalid']]);
     }
 }

--- a/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/RequestTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/AttributeAggregation/Dto/RequestTest.php
@@ -61,6 +61,10 @@ class RequestTest extends TestCase
                         'values' => ['sp-entity-id'],
                     ],
                     [
+                        'name' => 'IDPentityID',
+                        'values' => ['idp-entity-id'],
+                    ],
+                    [
                         'name' => 'attr',
                         'values' => ['1', '2', '3'],
                     ],
@@ -115,6 +119,10 @@ class RequestTest extends TestCase
                         'name' => 'SPentityID',
                         'values' => ['sp-entity-id'],
                     ],
+                    [
+                        'name' => 'IDPentityID',
+                        'values' => ['idp-entity-id'],
+                    ]
                 ],
                 'arpAttributes' => [
                     'name' => [
@@ -143,7 +151,7 @@ class RequestTest extends TestCase
     public function request_subject_must_be_set()
     {
         $this->expectException(InvalidArgumentException::class);
-        Request::from('sp-entity-id', NULL, [], []);
+        Request::from('sp-entity-id', 'idp-entity-id',NULL, [], []);
     }
 
     /**
@@ -161,7 +169,7 @@ class RequestTest extends TestCase
     public function request_idp_entity_id_must_be_set()
     {
         $this->expectException(InvalidArgumentException::class);
-        Request::from('sp-entity-id', 'idp-entity-id', NULL, 'subject-id', [], []);
+        Request::from('sp-entity-id', NULL, 'subject-id', [], []);
     }
 
     /**


### PR DESCRIPTION
The new Manage / SURF CRM attribute aggregator requires the IdP entityID for the query to Manage. Added it to `OpenConext\EngineBlockBundle\AttributeAggregation\Dto\Request` including test assertions.