### PR TITLE
Reconfigure LoA settings and verify received LoA

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -164,18 +164,29 @@ pdp.client_id = "EngineBlock"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;; SFO SETTINGS ;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ;; This PCRE regex is used to blacklist incoming AuthnContextClassRef attributes on. If an empty string is used
 ;; the validation is skipped. The validator will throw an exception if the used regex is invalid.
-stepup.authn_context_class_ref_blacklist_regex = "/http:\/\/test\.openconext\.nl\/assurance\/loa[1-3]/"
-;; The loa mapping from the internal used LoA's to the Stepup Gateway LOA's
-stepup.loa.mapping[http://test.openconext.nl/assurance/loa2] = "https://gateway.tld/authentication/loa2"
-stepup.loa.mapping[http://test.openconext.nl/assurance/loa3] = "https://gateway.tld/authentication/loa3"
+stepup.authn_context_class_ref_blacklist_regex = "/https:\/\/.example\.org\/assurance\/loa[1-3]/"
+
+;; The loa mapping from the internal used LoA's to the Stepup Gateway LOA's.
+;; Specification of the mapping: stepup.loa.mapping.[int 1|2|2].[string engineblock|gateway]
+;; The integer after the mapping field indicates the LoA level (1, 2 or 3 are supported).
+;; The engineblock or gateway keys specify the LoAs identifier as will be carried in the AuthnContextClassRef of an assertion.
+stepup.loa.mapping.1.engineblock = "http://example.org/assurance/loa1"
+stepup.loa.mapping.1.gateway = "https://gateway.tld/authentication/loa1"
+stepup.loa.mapping.2.engineblock = "http://example.org/assurance/loa2"
+stepup.loa.mapping.2.gateway = "https://gateway.tld/authentication/loa2"
+stepup.loa.mapping.3.engineblock = "http://example.org/assurance/loa3"
+stepup.loa.mapping.3.gateway = "https://gateway.tld/authentication/loa3"
+
 ;; The fallback LoA to return when the Stepup authentication fails but is not required
 stepup.loa.loa1 = "https://gateway.tld/authentication/loa1"
+
 ;; The EntityId (metadata URL) used in the callout to the SFO endpoint of the configured Stepup Gateway
-stepup.gateway.sfo.entityId = "https://engine.vm.openconext.org/authentication/stepup/metadata"
+stepup.gateway.sfo.entityId = "https://engine.example.org/authentication/stepup/metadata"
 ;; The single sign-on endpoint used for Stepup Gateway SFO callouts
-stepup.gateway.sfo.ssoLocation = "https://engine.vm.openconext.org/functional-testing/gateway/second-factor-only/single-sign-on"
+stepup.gateway.sfo.ssoLocation = "https://engine.example.org/functional-testing/gateway/second-factor-only/single-sign-on"
 ;; The public key from the Stepup Gateway IdP
 stepup.gateway.sfo.keyFile = "/etc/openconext/engineblock.crt"
 

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -352,6 +352,14 @@ class EngineBlock_Application_DiContainer extends Pimple
     }
 
     /**
+     * @return StepupGatewayCallOutHelper
+     */
+    public function getLoaRepository()
+    {
+        return $this->container->get('engineblock.configuration.stepup.loa_repository');
+    }
+
+    /**
      * @return array
      */
     public function getEncryptionKeysConfiguration()

--- a/library/EngineBlock/Corto/Module/Services.php
+++ b/library/EngineBlock/Corto/Module/Services.php
@@ -135,7 +135,8 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
                     $server,
                     $diContainer->getSession(),
                     $diContainer->getProcessingStateHelper(),
-                    $diContainer->getStepupGatewayCallOutHelper()
+                    $diContainer->getStepupGatewayCallOutHelper(),
+                    $diContainer->getLoaRepository()
                 );
             default :
                 return new $className($server, $diContainer->getXmlConverter(), $diContainer->getTwigEnvironment());

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+use OpenConext\EngineBlock\Metadata\Loa;
 use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
@@ -437,7 +438,7 @@ class EngineBlock_Corto_ProxyServer
     public function sendStepupAuthenticationRequest(
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $spRequest,
         IdentityProvider $identityProvider,
-        $authnContextClassRef,
+        Loa $authnContextClassRef,
         NameID $nameId
     ) {
         $ebRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest(
@@ -456,7 +457,7 @@ class EngineBlock_Corto_ProxyServer
         // Add Stepup specific data
         $sspMessage->setRequestedAuthnContext([
             'AuthnContextClassRef' => [
-                $authnContextClassRef
+                $authnContextClassRef->getIdentifier()
             ],
             'Comparison' => 'minimal',
         ]);

--- a/src/OpenConext/EngineBlock/Exception/LoaNotFoundException.php
+++ b/src/OpenConext/EngineBlock/Exception/LoaNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Exception;
+
+use InvalidArgumentException as CoreInvalidArgumentException;
+
+class LoaNotFoundException extends CoreInvalidArgumentException
+{
+}

--- a/src/OpenConext/EngineBlock/Metadata/Loa.php
+++ b/src/OpenConext/EngineBlock/Metadata/Loa.php
@@ -67,14 +67,12 @@ class Loa
     }
 
     /**
-     * @param int $level
+     * @param Loa $loa
      * @return bool
      */
-    public function levelIsHigherOrEqualTo($level)
+    public function levelIsHigherOrEqualTo(Loa $loa)
     {
-        Assertion::integer($level, 'Provide the integer value representing the LoA level');
-        Assertion::greaterThan($level, 0, 'Please provide a positive integer value');
-        $isHigherOrEqualTo = $this->level >= $level;
+        $isHigherOrEqualTo = $this->level >= $loa->getLevel();
         return $isHigherOrEqualTo;
     }
 

--- a/src/OpenConext/EngineBlock/Metadata/Loa.php
+++ b/src/OpenConext/EngineBlock/Metadata/Loa.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use OpenConext\EngineBlock\Assert\Assertion;
+
+/**
+ * Value object representing the different LoAs that can be configured
+ */
+class Loa
+{
+    /**
+     * The different levels
+     */
+    const LOA_1 = 1;
+    const LOA_2 = 2;
+    const LOA_3 = 3;
+
+    /**
+     * @var int
+     */
+    private $level;
+
+    /**
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * @param int $level
+     * @param string $identifier
+     */
+    public static function create($level, $identifier)
+    {
+        $possibleLevels = [self::LOA_1, self::LOA_2, self::LOA_3];
+
+        Assertion::integer($level, 'The LoA level must be an integer value');
+        Assertion::inArray(
+            $level,
+            $possibleLevels,
+            sprintf('Please provide a valid level. Accpetable LoA levels are "%s"', implode(', ', $possibleLevels))
+        );
+        Assertion::nonEmptyString($identifier, 'The LoA identifier must be of type string, and can not be empty');
+
+        $loa = new self;
+
+        $loa->level = $level;
+        $loa->identifier = $identifier;
+
+        return $loa;
+    }
+
+    /**
+     * @param int $level
+     * @return bool
+     */
+    public function levelIsHigherOrEqualTo($level)
+    {
+        Assertion::integer($level, 'Provide the integer value representing the LoA level');
+        Assertion::greaterThan($level, 0, 'Please provide a positive integer value');
+        $isHigherOrEqualTo = $this->level >= $level;
+        return $isHigherOrEqualTo;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    public function __toString()
+    {
+        return $this->identifier;
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/LoaRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/LoaRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use OpenConext\EngineBlock\Assert\Assertion;
+use OpenConext\EngineBlock\Exception\LoaNotFoundException;
+
+/**
+ * Retrieve LoA value objects from the configured LoA mapping
+ */
+class LoaRepository
+{
+    /**
+     * @var array
+     */
+    private $store = [];
+
+    /**
+     * @param array $loaMapping
+     */
+    public function __construct(array $loaMapping)
+    {
+        foreach ($loaMapping as $level => $mapping) {
+            Assertion::integer(
+                $level,
+                'The stepup.loa.mapping should be followed by an integer value, indicating the LoA level. ' .
+                'Example: stepup.loa.mapping.3'
+            );
+            Assertion::keysExist(
+                $mapping,
+                ['engineblock', 'gateway'],
+                'Both the engineblock and gateway keys must be present in every LoA mapping.'
+            );
+            Assertion::string($mapping['engineblock'], 'The EngineBlock LoA must be a string value');
+            Assertion::string($mapping['gateway'], 'The Gateway LoA must be a string value');
+
+            $this->store[$mapping['engineblock']] = Loa::create($level, $mapping['engineblock']);
+            $this->store[$mapping['gateway']] = Loa::create($level, $mapping['gateway']);
+        }
+    }
+
+    /**
+     * @param $identifier
+     * @return Loa
+     * @throws LoaNotFoundException
+     */
+    public function getByIdentifier($identifier)
+    {
+        if (!array_key_exists($identifier, $this->store)) {
+            throw new LoaNotFoundException(sprintf('Unable to find LoA with identifier "%s"', $identifier));
+        }
+        return $this->store[$identifier];
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -21,11 +21,17 @@ services:
             - "%stepup.gateway.sfo.sso_location%"
             - "%stepup.gateway.sfo.key_file%"
 
+    engineblock.configuration.stepup.loa_repository:
+        class: OpenConext\EngineBlock\Metadata\LoaRepository
+        arguments:
+            - "%stepup.loa.mapping%"
+
     engineblock.configuration.stepup.gateway_loa_mapping:
         class: OpenConext\EngineBlockBundle\Stepup\StepupGatewayLoaMapping
         arguments:
             - "%stepup.loa.mapping%"
             - "%stepup.loa.loa1%"
+            - "@engineblock.configuration.stepup.loa_repository"
 
     engineblock.request.request_id_generator:
         public: false

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -63,6 +63,7 @@ services:
         arguments:
             - "@engineblock.configuration.stepup.gateway_loa_mapping"
             - "@engineblock.configuration.stepup.endpoint"
+            - "@engineblock.configuration.stepup.loa_repository"
 
 
     engineblock.service.consent:

--- a/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMapping.php
+++ b/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMapping.php
@@ -51,6 +51,16 @@ class StepupGatewayLoaMapping
 
             $gwLoa = $loaRepository->getByIdentifier($mapping['gateway']);
             $ebLoa = $loaRepository->getByIdentifier($mapping['engineblock']);
+            Assertion::keyNotExists(
+                $this->gatewayToEngine,
+                $gwLoa->getIdentifier(),
+                'Found a duplicate Gateway LoA identifier, this is not allowed.'
+            );
+            Assertion::keyNotExists(
+                $this->engineToGateway,
+                $ebLoa->getIdentifier(),
+                'Found a duplicate EngineBlock LoA identifier, this is not allowed.'
+            );
             $this->gatewayToEngine[$gwLoa->getIdentifier()] = $ebLoa;
             $this->engineToGateway[$ebLoa->getIdentifier()] = $gwLoa;
         }

--- a/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMapping.php
+++ b/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMapping.php
@@ -19,61 +19,60 @@ namespace OpenConext\EngineBlockBundle\Stepup;
 
 use OpenConext\EngineBlock\Assert\Assertion;
 use OpenConext\EngineBlock\Exception\RuntimeException;
+use OpenConext\EngineBlock\Metadata\Loa;
+use OpenConext\EngineBlock\Metadata\LoaRepository;
 
 class StepupGatewayLoaMapping
 {
-    private $mapping = [];
+    private $gatewayToEngine = [];
+    private $engineToGateway = [];
     private $gatewayLoa1 = '';
 
     /**
      * @param array $loaMapping
      * @param string $gatewayLoa1
+     * @param LoaRepository $loaRepository
      * @throws \Assert\AssertionFailedException
      */
-    public function __construct(array $loaMapping, $gatewayLoa1)
+    public function __construct(array $loaMapping, $gatewayLoa1, LoaRepository $loaRepository)
     {
-        foreach ($loaMapping as $from => $to) {
-            Assertion::string($from, 'The stepup.gateway_loa_mapping configuration must be a map, key is not a string');
-            Assertion::string($to, 'The stepup.gateway_loa_mapping configuration must be a map, value is not a string');
+        Assertion::string($gatewayLoa1, 'The stepup.loa.loa1 configuration must be a string');
+        $this->gatewayLoa1 = $loaRepository->findByIdentifier($gatewayLoa1);
 
-            $this->mapping[$from] = $to;
+        foreach ($loaMapping as $level => $mapping) {
+            $gwLoa = $loaRepository->findByIdentifier($mapping['gateway']);
+            $ebLoa = $loaRepository->findByIdentifier($mapping['engineblock']);
+            $this->gatewayToEngine[$gwLoa->getIdentifier()] = $ebLoa;
+            $this->engineToGateway[$ebLoa->getIdentifier()] = $gwLoa;
         }
-
-        Assertion::string($gatewayLoa1, 'The stepup.gateway.loa.loa1 configuration must be a string');
-
-        $this->gatewayLoa1 = $gatewayLoa1;
     }
 
     /**
      * @param $input
-     * @return string
+     * @return Loa
      */
-    public function transformToGatewayLoa($input)
+    public function transformToGatewayLoa(Loa $engineBlockLoa)
     {
-        if (!array_key_exists($input, $this->mapping)) {
+        if (!array_key_exists($engineBlockLoa->getIdentifier(), $this->engineToGateway)) {
             throw new RuntimeException('Unable to find the EngineBlock LoA in the configured stepup LoA mapping');
         }
-
-        return $this->mapping[$input];
+        return $this->engineToGateway[$engineBlockLoa->getIdentifier()];
     }
-
 
     /**
      * @param $input
-     * @return string
+     * @return Loa
      */
-    public function transformToEbLoa($input)
+    public function transformToEbLoa(Loa $gatewayLoa)
     {
-        $loa = array_search($input, $this->mapping);
-        if ($loa === false) {
-            throw new RuntimeException('Unable to find the received stepup LoA in the configured EngineBlock LoA');
+        if (!array_key_exists($gatewayLoa->getIdentifier(), $this->gatewayToEngine)) {
+            throw new RuntimeException('Unable to find the received stepup LoA in the configured EngineBlock LoA mapping');
         }
-
-        return $loa;
+        return $this->gatewayToEngine[$gatewayLoa->getIdentifier()];
     }
 
     /**
-     * @return string
+     * @return Loa
      */
     public function getGatewayLoa1()
     {

--- a/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMapping.php
+++ b/src/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMapping.php
@@ -37,18 +37,27 @@ class StepupGatewayLoaMapping
     public function __construct(array $loaMapping, $gatewayLoa1, LoaRepository $loaRepository)
     {
         Assertion::string($gatewayLoa1, 'The stepup.loa.loa1 configuration must be a string');
-        $this->gatewayLoa1 = $loaRepository->findByIdentifier($gatewayLoa1);
+        $this->gatewayLoa1 = $loaRepository->getByIdentifier($gatewayLoa1);
 
-        foreach ($loaMapping as $level => $mapping) {
-            $gwLoa = $loaRepository->findByIdentifier($mapping['gateway']);
-            $ebLoa = $loaRepository->findByIdentifier($mapping['engineblock']);
+        foreach ($loaMapping as $mapping) {
+            Assertion::nonEmptyString(
+                $mapping['gateway'],
+                sprintf('The gateway LoA must be a non empty string. "%s" given', $mapping['gateway'])
+            );
+            Assertion::nonEmptyString(
+                $mapping['engineblock'],
+                sprintf('The engineblock LoA must be a non empty string. "%s" given', $mapping['engineblock'])
+            );
+
+            $gwLoa = $loaRepository->getByIdentifier($mapping['gateway']);
+            $ebLoa = $loaRepository->getByIdentifier($mapping['engineblock']);
             $this->gatewayToEngine[$gwLoa->getIdentifier()] = $ebLoa;
             $this->engineToGateway[$ebLoa->getIdentifier()] = $gwLoa;
         }
     }
 
     /**
-     * @param $input
+     * @param Loa $engineBlockLoa
      * @return Loa
      */
     public function transformToGatewayLoa(Loa $engineBlockLoa)

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/StepupMockController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/StepupMockController.php
@@ -85,9 +85,13 @@ class StepupMockController extends Controller
      */
     private function getAvailableResponses(Request $request)
     {
-        // Parse success
+        // Parse successfull loa3
         $samlResponse = $this->mockStepupGateway->handleSsoSuccess($request, $this->getFullRequestUri($request));
         $results['success'] = $this->getResponseData($request, $samlResponse);
+
+        // Parse successfull loa2
+        $samlResponse = $this->mockStepupGateway->handleSsoSuccessLoa2($request, $this->getFullRequestUri($request));
+        $results['loa2'] = $this->getResponseData($request, $samlResponse);
 
         // Parse user cancelled
         $samlResponse = $this->mockStepupGateway->handleSsoFailure(

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/StepupContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/StepupContext.php
@@ -72,6 +72,16 @@ class StepupContext extends AbstractSubContext
     }
 
     /**
+     * @Given /^Stepup will successfully verify a user with a LoA 2 token$/
+     */
+    public function stepupWillsSuccessfullyVerifyAUserLoa2()
+    {
+        $mink = $this->getMinkContext();
+
+        $mink->pressButton('Submit-loa2');
+    }
+
+    /**
      * @Given /^I authenticate with Stepup$/
      */
     public function iAuthenticateWithStepup()

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -14,7 +14,7 @@ Feature:
       And a Service Provider named "Proxy-SP"
 
   Scenario: Stepup authentication should be supported if set through SP configuration
-    Given the SP "SSO-SP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2"
+    Given the SP "SSO-SP" requires Stepup LoA "http://example.org/assurance/loa2"
     When I log in at "SSO-SP"
       And I select "SSO-IdP" on the WAYF
       And I pass through EngineBlock
@@ -25,7 +25,7 @@ Feature:
     Then the url should match "/functional-testing/SSO-SP/acs"
 
     Scenario: Stepup authentication should be supported if set trough IdP configuration mapping
-      Given the IdP "SSO-IdP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2" for SP "SSO-SP"
+      Given the IdP "SSO-IdP" requires Stepup LoA "http://example.org/assurance/loa2" for SP "SSO-SP"
       When I log in at "SSO-SP"
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
@@ -36,8 +36,8 @@ Feature:
       Then the url should match "/functional-testing/SSO-SP/acs"
 
     Scenario: Stepup authentication should throw exception if set trough both IdP and SP
-      Given the IdP "SSO-IdP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2" for SP "SSO-SP"
-        And the SP "SSO-SP" requires Stepup LoA "http://test.openconext.nl/assurance/loa3"
+      Given the IdP "SSO-IdP" requires Stepup LoA "http://example.org/assurance/loa2" for SP "SSO-SP"
+        And the SP "SSO-SP" requires Stepup LoA "http://example.org/assurance/loa3"
       When I log in at "SSO-SP"
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
@@ -55,7 +55,7 @@ Feature:
       Then the url should match "/functional-testing/Dummy-SP/acs"
 
     Scenario: Stepup authentication should handle stepup if LoA level is not met but no token is allowed
-      Given the SP "SSO-SP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2"
+      Given the SP "SSO-SP" requires Stepup LoA "http://example.org/assurance/loa2"
         And the SP "SSO-SP" allows no Stepup token
       When I log in at "SSO-SP"
         And I select "SSO-IdP" on the WAYF
@@ -67,7 +67,7 @@ Feature:
       Then the url should match "/functional-testing/SSO-SP/acs"
 
     Scenario: Stepup authentication should show exception when LoA level is not met
-      Given the SP "SSO-SP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2"
+      Given the SP "SSO-SP" requires Stepup LoA "http://example.org/assurance/loa2"
       When I log in at "SSO-SP"
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
@@ -78,7 +78,7 @@ Feature:
         And the response status code should be 400
 
     Scenario: Stepup authentication should show exception when user does cancel
-      Given the SP "SSO-SP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2"
+      Given the SP "SSO-SP" requires Stepup LoA "http://example.org/assurance/loa2"
       When I log in at "SSO-SP"
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
@@ -89,7 +89,7 @@ Feature:
         And the response status code should be 400
 
     Scenario: Stepup authentication should show exception when an unknown status is returned
-      Given the SP "SSO-SP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2"
+      Given the SP "SSO-SP" requires Stepup LoA "http://example.org/assurance/loa2"
       When I log in at "SSO-SP"
         And I select "SSO-IdP" on the WAYF
         And I pass through EngineBlock
@@ -101,7 +101,7 @@ Feature:
 
     # Trusted proxy logic
     Scenario: Step-up authentication should be requested for the proxied SP when using a trusted proxy setup and if configured in the proxied SP
-      Given the SP "SSO-SP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2"
+      Given the SP "SSO-SP" requires Stepup LoA "http://example.org/assurance/loa2"
         And SP "Proxy-SP" is authenticating for SP "SSO-SP"
         And SP "Proxy-SP" is a trusted proxy
         And SP "Proxy-SP" signs its requests
@@ -115,7 +115,7 @@ Feature:
       Then the url should match "/functional-testing/Proxy-SP/acs"
 
     Scenario: Stepup authentication should succeed for the proxied SP when using a trusted prroxy setup, if LoA level is not met but when no token is allowed is configured in the proxied SP
-      Given the SP "SSO-SP" requires Stepup LoA "http://test.openconext.nl/assurance/loa2"
+      Given the SP "SSO-SP" requires Stepup LoA "http://example.org/assurance/loa2"
         And the SP "SSO-SP" allows no Stepup token
         And SP "Proxy-SP" is authenticating for SP "SSO-SP"
         And SP "Proxy-SP" is a trusted proxy

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockStepupGateway.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockStepupGateway.php
@@ -94,6 +94,31 @@ class MockStepupGateway
     /**
      * @param Request $request
      * @param string $fullRequestUri
+     * @return Response
+     */
+    public function handleSsoSuccessLoa2(Request $request, $fullRequestUri)
+    {
+        // parse the authnRequest
+        $authnRequest = $this->parseRequest($request, $fullRequestUri);
+
+        // get parameters from authnRequest
+        $nameId = $authnRequest->getNameId()->value;
+        $destination = $authnRequest->getAssertionConsumerServiceURL();
+        $authnContextClassRef = 'https://gateway.tld/authentication/loa2';
+        $requestId = $authnRequest->getId();
+
+        // handle success
+        return $this->createSecondFactorOnlyResponse(
+            $nameId,
+            $destination,
+            $authnContextClassRef,
+            $requestId
+        );
+    }
+
+    /**
+     * @param Request $request
+     * @param string $fullRequestUri
      * @param string $status
      * @param string $subStatus
      * @param string $message

--- a/tests/unit/OpenConext/EngineBlock/Metadata/LoaRepositoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/LoaRepositoryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Exception\LoaNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class LoaRepositoryTest extends TestCase
+{
+    public function test_build_from_valid_config()
+    {
+        $repository = new LoaRepository($this->getValidConfigAsArray());
+        // No exceptions are raised when creating the repository with a valid config
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function test_build_from_valid_config_empty()
+    {
+        $repository = new LoaRepository([]);
+        // No exceptions are raised when creating the repository with a valid config
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function test_it_can_find_by_loa_identifier()
+    {
+        $repository = new LoaRepository($this->getValidConfigAsArray());
+
+        $existingLoa = 'http://vm.openconext.org/assurance/loa1';
+        $loa = $repository->getByIdentifier($existingLoa);
+
+        $this->assertInstanceOf(Loa::class, $loa);
+    }
+
+    public function test_it_throws_an_exception_when_loa_not_found()
+    {
+        $repository = new LoaRepository($this->getValidConfigAsArray());
+        $nonExistingLoa = 'foobar';
+
+        $this->expectException(LoaNotFoundException::class);
+        $this->expectExceptionMessage('Unable to find LoA with identifier "foobar"');
+        $repository->getByIdentifier($nonExistingLoa);
+
+    }
+
+    /**
+     * @dataProvider provideInvalidConfig
+     */
+    public function test_it_raises_exceptions_when_constructed_with_invalid_configuration(
+        $config,
+        $expectedExceptionMessage
+    ) {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        new LoaRepository($config);
+    }
+
+    private function getValidConfigAsArray()
+    {
+        $validConfig = '{"1":{"engineblock":"http:\/\/vm.openconext.org\/assurance\/loa1","gateway":"https:\/\/gateway.tld\/authentication\/loa1"},"2":{"engineblock":"http:\/\/vm.openconext.org\/assurance\/loa2","gateway":"https:\/\/gateway.tld\/authentication\/loa2"},"3":{"engineblock":"http:\/\/vm.openconext.org\/assurance\/loa3","gateway":"https:\/\/gateway.tld\/authentication\/loa3"}}';
+        return json_decode($validConfig, true);
+    }
+
+    public function provideInvalidConfig()
+    {
+        return [
+            [['loa1' => ['engineblock' => 'loa1', 'gateway' => 'loa1']], 'The stepup.loa.mapping should be followed by an integer value, indicating the LoA level. Example: stepup.loa.mapping.3'],
+            [[1 => ['engineBlock' => 'loa1', 'gateway' => 'loa1']], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
+            [[1 => ['gateway' => 'loa1']], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
+            [[1 => []], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
+            [[2 => ['engineblock' => null, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
+            [[2 => ['engineblock' => 3, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
+            [[2 => ['engineblock' => false, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
+            [[3 => ['engineblock' => 'loa1', 'gateway' => null]], 'The Gateway LoA must be a string value'],
+            [[3 => ['engineblock' => 'loa1', 'gateway' => 4]], 'The Gateway LoA must be a string value'],
+            [[3 => ['engineblock' => 'loa1', 'gateway' => true]], 'The Gateway LoA must be a string value'],
+        ];
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Metadata/LoaTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/LoaTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class LoaTest extends TestCase
+{
+    /**
+     * @dataProvider provideValidLoaParameters
+     */
+    public function test_loa_happy_flow($level, $identifier, $expectationDescription)
+    {
+        $loa = Loa::create($level, $identifier);
+
+        $this->assertEquals($level, $loa->getLevel(), $expectationDescription);
+        $this->assertEquals($identifier, $loa->getIdentifier(), $expectationDescription);
+    }
+
+    /**
+     * @dataProvider provideInvalidLoaParameters
+     */
+    public function test_loa_sad_flow($level, $identifier, $expectedException)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedException);
+        Loa::create($level, $identifier);
+    }
+
+    public function test_loa_can_be_compared_to_other_loa()
+    {
+        $loa1 = Loa::create(1, 'https://vm.openconext.org/assurance/loa1');
+        $loa2 = Loa::create(2, 'https://vm.openconext.org/assurance/loa2');
+        $loa3 = Loa::create(3, 'https://vm.openconext.org/assurance/loa3');
+
+        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa3->getLevel()));
+        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa2->getLevel()));
+        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa1->getLevel()));
+
+        $this->assertTrue($loa2->levelIsHigherOrEqualTo($loa2->getLevel()));
+        $this->assertTrue($loa2->levelIsHigherOrEqualTo($loa1->getLevel()));
+        $this->assertFalse($loa2->levelIsHigherOrEqualTo($loa3->getLevel()));
+
+        $this->assertTrue($loa1->levelIsHigherOrEqualTo($loa1->getLevel()));
+        $this->assertFalse($loa1->levelIsHigherOrEqualTo($loa2->getLevel()));
+        $this->assertFalse($loa1->levelIsHigherOrEqualTo($loa3->getLevel()));
+    }
+
+    /**
+     * @dataProvider provideInvalidComparisonOptions
+     */
+    public function test_loa_comparison_is_to_be_used_correctly($badComparisonOption, $expectedException)
+    {
+        $loa = Loa::create(1, 'https://vm.openconext.org/assurance/loa2');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedException);
+
+        $loa->levelIsHigherOrEqualTo($badComparisonOption);
+    }
+
+    public function provideInvalidComparisonOptions()
+    {
+        return [
+            ['1', 'Provide the integer value representing the LoA level'],
+            [true, 'Provide the integer value representing the LoA level'],
+            [false, 'Provide the integer value representing the LoA level'],
+            [1.5, 'Provide the integer value representing the LoA level'],
+            [9999999999999999999999999999, 'Provide the integer value representing the LoA level'],
+            [-9999999999999999999999999999, 'Provide the integer value representing the LoA level'],
+            [0, 'Please provide a positive integer value'],
+            [-1, 'Please provide a positive integer value'],
+        ];
+    }
+
+    public function provideValidLoaParameters()
+    {
+        return [
+            [1, 'https://vm.openconext.nl/loa1', 'A level 1 LoA'],
+            [2, 'https://vm.openconext.nl/loa2', 'A level 2 LoA'],
+            [3, 'https://vm.openconext.nl/loa3', 'A level 3 LoA'],
+        ];
+    }
+
+    public function provideInvalidLoaParameters()
+    {
+        return [
+            ['1', 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
+            [null, 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
+            [false, 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
+            [1.5, 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
+            [[1], 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
+            [9999999999999999999999999999, 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
+
+            [new \stdClass(), 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
+            [0, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "1, 2, 3"'],
+            [-1, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "1, 2, 3"'],
+            [4, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "1, 2, 3"'],
+
+            [1, '', 'The LoA identifier must be of type string, and can not be empty'],
+            [1, 1, 'The LoA identifier must be of type string, and can not be empty'],
+            [1, -1, 'The LoA identifier must be of type string, and can not be empty'],
+            [1, 1.1, 'The LoA identifier must be of type string, and can not be empty'],
+            [1, false, 'The LoA identifier must be of type string, and can not be empty'],
+            [1, true, 'The LoA identifier must be of type string, and can not be empty'],
+            [1, ['https://vm.openconext.nl/loa1'], 'The LoA identifier must be of type string, and can not be empty'],
+        ];
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Metadata/LoaTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/LoaTest.php
@@ -26,7 +26,7 @@ class LoaTest extends TestCase
     /**
      * @dataProvider provideValidLoaParameters
      */
-    public function test_loa_happy_flow($level, $identifier, $expectationDescription)
+    public function test_loa_happy_flow(int $level, string $identifier, $expectationDescription)
     {
         $loa = Loa::create($level, $identifier);
 
@@ -50,44 +50,17 @@ class LoaTest extends TestCase
         $loa2 = Loa::create(2, 'https://vm.openconext.org/assurance/loa2');
         $loa3 = Loa::create(3, 'https://vm.openconext.org/assurance/loa3');
 
-        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa3->getLevel()));
-        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa2->getLevel()));
-        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa1->getLevel()));
+        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa3));
+        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa2));
+        $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa1));
 
-        $this->assertTrue($loa2->levelIsHigherOrEqualTo($loa2->getLevel()));
-        $this->assertTrue($loa2->levelIsHigherOrEqualTo($loa1->getLevel()));
-        $this->assertFalse($loa2->levelIsHigherOrEqualTo($loa3->getLevel()));
+        $this->assertTrue($loa2->levelIsHigherOrEqualTo($loa2));
+        $this->assertTrue($loa2->levelIsHigherOrEqualTo($loa1));
+        $this->assertFalse($loa2->levelIsHigherOrEqualTo($loa3));
 
-        $this->assertTrue($loa1->levelIsHigherOrEqualTo($loa1->getLevel()));
-        $this->assertFalse($loa1->levelIsHigherOrEqualTo($loa2->getLevel()));
-        $this->assertFalse($loa1->levelIsHigherOrEqualTo($loa3->getLevel()));
-    }
-
-    /**
-     * @dataProvider provideInvalidComparisonOptions
-     */
-    public function test_loa_comparison_is_to_be_used_correctly($badComparisonOption, $expectedException)
-    {
-        $loa = Loa::create(1, 'https://vm.openconext.org/assurance/loa2');
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedException);
-
-        $loa->levelIsHigherOrEqualTo($badComparisonOption);
-    }
-
-    public function provideInvalidComparisonOptions()
-    {
-        return [
-            ['1', 'Provide the integer value representing the LoA level'],
-            [true, 'Provide the integer value representing the LoA level'],
-            [false, 'Provide the integer value representing the LoA level'],
-            [1.5, 'Provide the integer value representing the LoA level'],
-            [9999999999999999999999999999, 'Provide the integer value representing the LoA level'],
-            [-9999999999999999999999999999, 'Provide the integer value representing the LoA level'],
-            [0, 'Please provide a positive integer value'],
-            [-1, 'Please provide a positive integer value'],
-        ];
+        $this->assertTrue($loa1->levelIsHigherOrEqualTo($loa1));
+        $this->assertFalse($loa1->levelIsHigherOrEqualTo($loa2));
+        $this->assertFalse($loa1->levelIsHigherOrEqualTo($loa3));
     }
 
     public function provideValidLoaParameters()

--- a/tests/unit/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMappingTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMappingTest.php
@@ -48,19 +48,19 @@ class StepupGatewayLoaMappingTest extends TestCase
             ],
         ];
 
-        $ebLoa1 = Loa::fromConfig(1, 'ebLoa1');
-        $ebLoa2 = Loa::fromConfig(2, 'ebLoa2');
+        $ebLoa1 = Loa::create(1, 'ebLoa1');
+        $ebLoa2 = Loa::create(2, 'ebLoa2');
 
         $loaRepository = m::mock(LoaRepository::class);
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('gatewayLoa1')
-            ->andReturn(Loa::fromConfig(1, 'gatewayLoa1'));
+            ->andReturn(Loa::create(1, 'gatewayLoa1'));
 
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('gatewayLoa2')
-            ->andReturn(Loa::fromConfig(2, 'gatewayLoa2'));
+            ->andReturn(Loa::create(2, 'gatewayLoa2'));
 
         $loaRepository
             ->shouldReceive('findByIdentifier')
@@ -81,7 +81,7 @@ class StepupGatewayLoaMappingTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to find the EngineBlock LoA in the configured stepup LoA mapping');
 
-        $stepupLoaMapping->transformToGatewayLoa(Loa::fromConfig(2, 'loa2'));
+        $stepupLoaMapping->transformToGatewayLoa(Loa::create(2, 'loa2'));
 
     }
 
@@ -126,14 +126,14 @@ class StepupGatewayLoaMappingTest extends TestCase
             ],
         ];
 
-        $gwLoa2 = Loa::fromConfig(2, 'gatewayLoa2');
-        $gwLoa3 = Loa::fromConfig(3, 'gatewayLoa3');
+        $gwLoa2 = Loa::create(2, 'gatewayLoa2');
+        $gwLoa3 = Loa::create(3, 'gatewayLoa3');
 
         $loaRepository = m::mock(LoaRepository::class);
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('gatewayLoa1')
-            ->andReturn(Loa::fromConfig(1, 'gatewayLoa1'));
+            ->andReturn(Loa::create(1, 'gatewayLoa1'));
 
         $loaRepository
             ->shouldReceive('findByIdentifier')
@@ -148,17 +148,17 @@ class StepupGatewayLoaMappingTest extends TestCase
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('ebLoa1')
-            ->andReturn(Loa::fromConfig(1, 'ebLoa1'));
+            ->andReturn(Loa::create(1, 'ebLoa1'));
 
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('ebLoa2')
-            ->andReturn(Loa::fromConfig(2, 'ebLoa2'));
+            ->andReturn(Loa::create(2, 'ebLoa2'));
 
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('ebLoa3')
-            ->andReturn(Loa::fromConfig(3, 'ebLoa3'));
+            ->andReturn(Loa::create(3, 'ebLoa3'));
 
         $stepupLoaMapping = new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
 
@@ -184,23 +184,23 @@ class StepupGatewayLoaMappingTest extends TestCase
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('gatewayLoa1')
-            ->andReturn(Loa::fromConfig(1, 'gatewayLoa1'));
+            ->andReturn(Loa::create(1, 'gatewayLoa1'));
 
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('gatewayLoa3')
-            ->andReturn(Loa::fromConfig(3, 'gatewayLoa3'));
+            ->andReturn(Loa::create(3, 'gatewayLoa3'));
 
         $loaRepository
             ->shouldReceive('findByIdentifier')
             ->with('ebLoa3')
-            ->andReturn(Loa::fromConfig(3, 'ebLoa3'));
+            ->andReturn(Loa::create(3, 'ebLoa3'));
 
         $stepupLoaMapping = new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to find the received stepup LoA in the configured EngineBlock LoA');
 
-        $stepupLoaMapping->transformToEbLoa(Loa::fromConfig(2, 'loa2'));
+        $stepupLoaMapping->transformToEbLoa(Loa::create(2, 'loa2'));
     }
 }

--- a/tests/unit/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMappingTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMappingTest.php
@@ -53,22 +53,22 @@ class StepupGatewayLoaMappingTest extends TestCase
 
         $loaRepository = m::mock(LoaRepository::class);
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa1')
             ->andReturn(Loa::create(1, 'gatewayLoa1'));
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa2')
             ->andReturn(Loa::create(2, 'gatewayLoa2'));
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('ebLoa1')
             ->andReturn($ebLoa1);
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('ebLoa2')
             ->andReturn($ebLoa2);
 
@@ -131,32 +131,32 @@ class StepupGatewayLoaMappingTest extends TestCase
 
         $loaRepository = m::mock(LoaRepository::class);
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa1')
             ->andReturn(Loa::create(1, 'gatewayLoa1'));
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa2')
             ->andReturn($gwLoa2);
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa3')
             ->andReturn($gwLoa3);
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('ebLoa1')
             ->andReturn(Loa::create(1, 'ebLoa1'));
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('ebLoa2')
             ->andReturn(Loa::create(2, 'ebLoa2'));
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('ebLoa3')
             ->andReturn(Loa::create(3, 'ebLoa3'));
 
@@ -182,17 +182,17 @@ class StepupGatewayLoaMappingTest extends TestCase
         $loaRepository = m::mock(LoaRepository::class);
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa1')
             ->andReturn(Loa::create(1, 'gatewayLoa1'));
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa3')
             ->andReturn(Loa::create(3, 'gatewayLoa3'));
 
         $loaRepository
-            ->shouldReceive('findByIdentifier')
+            ->shouldReceive('getByIdentifier')
             ->with('ebLoa3')
             ->andReturn(Loa::create(3, 'ebLoa3'));
 
@@ -202,5 +202,81 @@ class StepupGatewayLoaMappingTest extends TestCase
         $this->expectExceptionMessage('Unable to find the received stepup LoA in the configured EngineBlock LoA');
 
         $stepupLoaMapping->transformToEbLoa(Loa::create(2, 'loa2'));
+    }
+
+    /**
+     * @test
+     * @group Stepup
+     */
+    public function the_mapping_must_be_valid_no_duplicates_allowed()
+    {
+        $mapping = [
+            1 => [
+                'engineblock' => 'ebLoa1',
+                'gateway' => 'gatewayLoa1',
+            ],
+            2 => [
+                'engineblock' => 'ebLoa1',
+                'gateway' => 'gatewayLoa2',
+            ]
+        ];
+
+        $loaRepository = m::mock(LoaRepository::class);
+        $loaRepository
+            ->shouldReceive('getByIdentifier')
+            ->with('gatewayLoa1')
+            ->andReturn(Loa::create(1, 'gatewayLoa1'));
+        $loaRepository
+            ->shouldReceive('getByIdentifier')
+            ->with('gatewayLoa2')
+            ->andReturn(Loa::create(2, 'gatewayLoa2'));
+        $loaRepository
+            ->shouldReceive('getByIdentifier')
+            ->with('ebLoa1')
+            ->andReturn(Loa::create(1, 'ebLoa1'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Found a duplicate EngineBlock LoA identifier, this is not allowed.');
+        new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
+    }
+
+    /**
+     * @test
+     * @group Stepup
+     */
+    public function the_mapping_must_be_valid_no_duplicates_in_gw_config_allowed()
+    {
+        $mapping = [
+            1 => [
+                'engineblock' => 'ebLoa1',
+                'gateway' => 'gatewayLoa2',
+            ],
+            2 => [
+                'engineblock' => 'ebLoa2',
+                'gateway' => 'gatewayLoa2',
+            ]
+        ];
+
+        $loaRepository = m::mock(LoaRepository::class);
+        $loaRepository
+            ->shouldReceive('getByIdentifier')
+            ->with('gatewayLoa1')
+            ->andReturn(Loa::create(1, 'gatewayLoa1'));
+        $loaRepository
+            ->shouldReceive('getByIdentifier')
+            ->with('gatewayLoa2')
+            ->andReturn(Loa::create(2, 'gatewayLoa2'));
+        $loaRepository
+            ->shouldReceive('getByIdentifier')
+            ->with('ebLoa1')
+            ->andReturn(Loa::create(1, 'ebLoa1'));
+        $loaRepository
+            ->shouldReceive('getByIdentifier')
+            ->with('ebLoa2')
+            ->andReturn(Loa::create(2, 'ebLoa2'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Found a duplicate Gateway LoA identifier, this is not allowed.');
+        new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
     }
 }

--- a/tests/unit/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMappingTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Stepup/StepupGatewayLoaMappingTest.php
@@ -18,9 +18,12 @@
 
 namespace OpenConext\EngineBlockBundle\Tests;
 
+use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Exception\InvalidArgumentException;
 use OpenConext\EngineBlock\Exception\RuntimeException;
+use OpenConext\EngineBlock\Metadata\Loa;
+use OpenConext\EngineBlock\Metadata\LoaRepository;
 use OpenConext\EngineBlockBundle\Stepup\StepupGatewayLoaMapping;
 use PHPUnit\Framework\TestCase;
 
@@ -34,48 +37,52 @@ class StepupGatewayLoaMappingTest extends TestCase
      */
     public function the_stepup_loa_mapping_object_should_be_successful_populated()
     {
-        $stepupLoaMapping = new StepupGatewayLoaMapping([
-            'ebLoa2' => 'gatewayLoa2',
-            'ebLoa3' => 'gatewayLoa3',
-        ],
-            'gatewayLoa1'
-        );
+        $mapping = [
+            1 => [
+                'engineblock' => 'ebLoa1',
+                'gateway' => 'gatewayLoa1',
+            ],
+            2 => [
+                'engineblock' => 'ebLoa2',
+                'gateway' => 'gatewayLoa2',
+            ],
+        ];
 
-        $this->assertSame('gatewayLoa2', $stepupLoaMapping->transformToGatewayLoa('ebLoa2'));
-        $this->assertSame('gatewayLoa2', $stepupLoaMapping->transformToGatewayLoa('ebLoa2'));
-        $this->assertSame('gatewayLoa1', $stepupLoaMapping->getGatewayLoa1());
-    }
+        $ebLoa1 = Loa::fromConfig(1, 'ebLoa1');
+        $ebLoa2 = Loa::fromConfig(2, 'ebLoa2');
 
-    /**
-     * @test
-     * @group Stepup
-     */
-    public function the_stepup_loa_mapping_object_key_should_be_a_string_or_throw_an_exception()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The stepup.gateway_loa_mapping configuration must be a map, key is not a string');
+        $loaRepository = m::mock(LoaRepository::class);
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('gatewayLoa1')
+            ->andReturn(Loa::fromConfig(1, 'gatewayLoa1'));
 
-        $stepupLoaMapping = new StepupGatewayLoaMapping([
-            5 => 'gatewayLoa2',
-        ],
-            'gatewayLoa1'
-        );
-    }
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('gatewayLoa2')
+            ->andReturn(Loa::fromConfig(2, 'gatewayLoa2'));
 
-    /**
-     * @test
-     * @group Stepup
-     */
-    public function the_stepup_loa_mapping_object_value_should_be_a_string_or_throw_an_exception()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The stepup.gateway_loa_mapping configuration must be a map, value is not a string');
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('ebLoa1')
+            ->andReturn($ebLoa1);
 
-        $stepupLoaMapping = new StepupGatewayLoaMapping([
-            'ebLoa2' => 3,
-        ],
-            'gatewayLoa1'
-        );
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('ebLoa2')
+            ->andReturn($ebLoa2);
+
+        $stepupLoaMapping = new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
+
+        $this->assertSame('gatewayLoa1', $stepupLoaMapping->transformToGatewayLoa($ebLoa1)->getIdentifier());
+        $this->assertSame('gatewayLoa2', $stepupLoaMapping->transformToGatewayLoa($ebLoa2)->getIdentifier());
+        $this->assertSame('gatewayLoa1', $stepupLoaMapping->getGatewayLoa1()->getIdentifier());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to find the EngineBlock LoA in the configured stepup LoA mapping');
+
+        $stepupLoaMapping->transformToGatewayLoa(Loa::fromConfig(2, 'loa2'));
+
     }
 
     /**
@@ -84,14 +91,18 @@ class StepupGatewayLoaMappingTest extends TestCase
      */
     public function the_stepup_loa_mapping_loa1_should_be_a_string_or_throw_an_exception()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The stepup.gateway.loa.loa1 configuration must be a string');
+        $loaRepository = m::mock(LoaRepository::class);
 
-        $stepupLoaMapping = new StepupGatewayLoaMapping([
-            'ebLoa2' => 'gatewayLoa2',
-        ],
-            5
-        );
+        $mapping = [
+            2 => [
+                'engineblock' => 'ebLoa2',
+                'gateway' => 'gatewayLoa2',
+            ],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The stepup.loa.loa1 configuration must be a string');
+        new StepupGatewayLoaMapping($mapping, 5, $loaRepository);
     }
 
     /**
@@ -100,15 +111,59 @@ class StepupGatewayLoaMappingTest extends TestCase
      */
     public function the_stepup_loa_mapping_object_should_successful_map_back()
     {
-        $stepupLoaMapping = new StepupGatewayLoaMapping([
-            'ebLoa2' => 'gatewayLoa2',
-            'ebLoa3' => 'gatewayLoa3',
-        ],
-            'gatewayLoa1'
-        );
+        $mapping = [
+            1 => [
+                'engineblock' => 'ebLoa1',
+                'gateway' => 'gatewayLoa1',
+            ],
+            2 => [
+                'engineblock' => 'ebLoa2',
+                'gateway' => 'gatewayLoa2',
+            ],
+            3 => [
+                'engineblock' => 'ebLoa3',
+                'gateway' => 'gatewayLoa3',
+            ],
+        ];
 
-        $this->assertSame('ebLoa2', $stepupLoaMapping->transformToEbLoa('gatewayLoa2'));
-        $this->assertSame('ebLoa3', $stepupLoaMapping->transformToEbLoa('gatewayLoa3'));
+        $gwLoa2 = Loa::fromConfig(2, 'gatewayLoa2');
+        $gwLoa3 = Loa::fromConfig(3, 'gatewayLoa3');
+
+        $loaRepository = m::mock(LoaRepository::class);
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('gatewayLoa1')
+            ->andReturn(Loa::fromConfig(1, 'gatewayLoa1'));
+
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('gatewayLoa2')
+            ->andReturn($gwLoa2);
+
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('gatewayLoa3')
+            ->andReturn($gwLoa3);
+
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('ebLoa1')
+            ->andReturn(Loa::fromConfig(1, 'ebLoa1'));
+
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('ebLoa2')
+            ->andReturn(Loa::fromConfig(2, 'ebLoa2'));
+
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('ebLoa3')
+            ->andReturn(Loa::fromConfig(3, 'ebLoa3'));
+
+        $stepupLoaMapping = new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
+
+        $this->assertSame('ebLoa2', $stepupLoaMapping->transformToEbLoa($gwLoa2)->getIdentifier());
+        $this->assertSame('ebLoa3', $stepupLoaMapping->transformToEbLoa($gwLoa3)->getIdentifier());
     }
 
     /**
@@ -117,15 +172,35 @@ class StepupGatewayLoaMappingTest extends TestCase
      */
     public function the_stepup_loa_mapping_object_should_return_an_exception_when_unable_to_map_back()
     {
+        $mapping = [
+            3 => [
+                'engineblock' => 'ebLoa3',
+                'gateway' => 'gatewayLoa3',
+            ],
+        ];
+
+        $loaRepository = m::mock(LoaRepository::class);
+
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('gatewayLoa1')
+            ->andReturn(Loa::fromConfig(1, 'gatewayLoa1'));
+
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('gatewayLoa3')
+            ->andReturn(Loa::fromConfig(3, 'gatewayLoa3'));
+
+        $loaRepository
+            ->shouldReceive('findByIdentifier')
+            ->with('ebLoa3')
+            ->andReturn(Loa::fromConfig(3, 'ebLoa3'));
+
+        $stepupLoaMapping = new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to find the received stepup LoA in the configured EngineBlock LoA');
 
-        $stepupLoaMapping = new StepupGatewayLoaMapping([
-            'ebLoa2' => 'gatewayLoa2',
-        ],
-            'gatewayLoa1'
-        );
-
-        $stepupLoaMapping->transformToEbLoa('gatewayLoa3');
+        $stepupLoaMapping->transformToEbLoa(Loa::fromConfig(2, 'loa2'));
     }
 }


### PR DESCRIPTION
The first five commits address task 1 and 3 of https://www.pivotaltracker.com/story/show/169392199

Some remarks:
1. A LoaRepository was created, tasked with loading a LoA based on its identifier.
1. The existing Mapping has been kept intact but its API changed slightly as it now returns LoA value objects instead of string identifiers.

The final commit addresses task 2

Here the actual verification is performed. 