### PR TITLE
Stop disasembling the Edugain publication settings

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
@@ -133,16 +133,6 @@ class CortoDisassembler
     {
         $cortoEntity['EntityID'] = $entity->entityId;
 
-        /**
-         * @deprecated: The coins below are no longer used in EngineBlock and will be removed in release 6.2
-         */
-        if ($entity->publishInEdugain) {
-            $cortoEntity['PublishInEdugain'] = true;
-        }
-        if ($entity->publishInEduGainDate) {
-            $cortoEntity['PublishInEdugainDate'] = $entity->publishInEduGainDate->format(DateTime::W3C);
-        }
-
         if ($entity->getCoins()->disableScoping()) {
             $cortoEntity['DisableScoping'] = true;
         }

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
@@ -27,10 +27,8 @@ use OpenConext\EngineBlock\Metadata\Factory\Decorator\ServiceProviderProxy;
 use OpenConext\EngineBlock\Metadata\Factory\Decorator\ServiceProviderStepup;
 use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration;
-use OpenConext\EngineBlock\Metadata\IndexedService;
 use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
 use OpenConext\EngineBlockBundle\Url\UrlProvider;
-use SAML2\Constants;
 
 /**
  * This factory is used for instantiating an entity with the required adapters and/or decorators set.


### PR DESCRIPTION
This was first tagged to be removed in release 6.2, but we can rid ourselves of this dependency in 6.1. As EB should stop depending on these coins in 6.1

See: https://www.pivotaltracker.com/story/show/164925138