### PR TITLE
Separate IdP and EngineBlock decorators

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
@@ -114,7 +114,7 @@ class IdpsMetadataRepository
                 continue;
             }
 
-            $collection->add($this->idpFactory->createEngineBlockEntityFromEntity($idp, $keyId));
+            $collection->add($this->idpFactory->createIdentityProviderEntityFromEntity($idp, $keyId));
         }
         return $collection;
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockIdentityProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockIdentityProviderTest.php
@@ -62,19 +62,17 @@ class EngineblockIdentityProviderTest extends AbstractEntityTest
     {
         $this->adapter = $this->createIdentityProviderAdapter();
 
-        $this->urlProvider->expects($this->exactly(3))
+        $this->urlProvider->expects($this->exactly(2))
             ->method('getUrl')
             ->withConsecutive(
                 // SLO: EngineBlockIdentityProvider::getSingleLogoutService
                 ['authentication_logout', false, null, null],
                 // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
-                ['metadata_idp', false, null, null], // check if entity is EB
-                ['authentication_idp_sso', false, null, 'entity-id']
+                ['authentication_idp_sso', false, null, null]
             ) ->willReturnOnConsecutiveCalls(
                 // SLO
                 'sloLocation',
                 // SSO
-                'entityId',
                 'ssoLocation'
             );
 
@@ -123,47 +121,18 @@ class EngineblockIdentityProviderTest extends AbstractEntityTest
     {
         $this->adapter = $this->createIdentityProviderAdapter();
 
-        $this->urlProvider->expects($this->exactly(2))
+        $this->urlProvider->expects($this->exactly(1))
             ->method('getUrl')
             ->withConsecutive(
                 // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
-                ['metadata_idp', false, null, null], // check if entity is EB
                 ['authentication_idp_sso', false, null, null]  // we would expect the fourth paremeter to be null and not 'entity-id' becasue we are EB
             ) ->willReturnOnConsecutiveCalls(
-            // SLO
                 // SSO
-                'entity-id', // The entity id should be the metadata url to test if EB becasue we are EB
                 'ssoLocation'
             );
-
 
         $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
 
         $this->assertEquals([new Service('ssoLocation', Constants::BINDING_HTTP_REDIRECT)], $decorator->getSingleSignOnServices());
-    }
-
-    public function test_only_add_entity_id_hash_for_sso_service_url_if_not_eb_self()
-    {
-        $this->adapter = $this->createIdentityProviderAdapter([
-            'singleSignOnServices' => null,
-        ]);
-
-        $this->urlProvider->expects($this->exactly(2))
-            ->method('getUrl')
-            ->withConsecutive(
-            // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
-                ['metadata_idp', false, null, null], // check if entity is EB
-                ['authentication_idp_sso', false, null, 'entity-id']  // we would expect the fourth paremeter to be null and not 'entity-id' becasue we are EB
-            ) ->willReturnOnConsecutiveCalls(
-            // SLO
-            // SSO
-                'other-entity-id', // The entity id should be the metadata url to test if EB becasue we are EB
-                'ssoLocation?entityIdHash'
-            );
-
-
-        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
-
-        $this->assertEquals([new Service('ssoLocation?entityIdHash', Constants::BINDING_HTTP_REDIRECT)], $decorator->getSingleSignOnServices());
     }
 }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProviderTest.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata\Factory\Decorator;
+
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\Factory\AbstractEntityTest;
+use OpenConext\EngineBlock\Metadata\Factory\Adapter\IdentityProviderEntity;
+use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
+use OpenConext\EngineBlockBundle\Url\UrlProvider;
+use SAML2\Constants;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class ProxiedIdentityProviderTest extends AbstractEntityTest
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $certificateMock;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $keyPairMock;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $urlProvider;
+    /**
+     * @var IdentityProviderEntity|null
+     */
+    private $adapter;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->adapter = null;
+        $this->certificateMock = $this->createMock(X509Certificate::class);
+        $this->keyPairMock = $this->createMock(X509KeyPair::class);
+        $this->keyPairMock->method('getCertificate')
+            ->willReturn($this->certificateMock);
+
+        $this->urlProvider = $this->createMock(UrlProvider::class);
+    }
+
+    public function test_methods()
+    {
+        $this->adapter = $this->createIdentityProviderAdapter();
+
+        $this->urlProvider->expects($this->exactly(1))
+            ->method('getUrl')
+            ->withConsecutive(
+                // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
+                ['authentication_idp_sso', false, null, 'entity-id']
+            ) ->willReturnOnConsecutiveCalls(
+                // SSO
+                'proxiedSsoLocation'
+            );
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->exactly(1))
+            ->method('trans')
+            ->with('suite_name')
+            ->willReturn('test-suite');
+
+        $configuration = new EngineBlockConfiguration(
+            $translator,
+            'configuredSupportUrl',
+            'configuredSupportMail',
+            'configuredDescription',
+            'configuredLogoUrl',
+            1209,
+            1009
+        );
+
+        $decorator = new ProxiedIdentityProvider(
+            $this->adapter,
+            $configuration,
+            $this->keyPairMock,
+            $this->urlProvider
+        );
+
+        $supportedNameIdFormats = [
+            Constants::NAMEID_PERSISTENT,
+            Constants::NAMEID_TRANSIENT,
+            Constants::NAMEID_UNSPECIFIED,
+        ];
+
+        // Expected contact persons
+        $contactPersons = [
+            ContactPerson::from('support', 'test-suite', 'Support', 'configuredSupportMail'),
+            ContactPerson::from('technical', 'test-suite', 'Support', 'configuredSupportMail'),
+            ContactPerson::from('administrative', 'test-suite', 'Support', 'configuredSupportMail'),
+        ];
+
+        $overrides['certificates'] = [$this->certificateMock];
+        $overrides['supportedNameIdFormats'] = $supportedNameIdFormats;
+        $overrides['singleSignOnServices'] = [new Service('proxiedSsoLocation', Constants::BINDING_HTTP_REDIRECT)];
+        $overrides['singleLogoutService'] = new Service(null, null); // Verify it matches the mocked SLO service
+        $overrides['contactPersons'] = $contactPersons;
+
+        $this->runIdentityProviderAssertions($this->adapter, $decorator, $overrides);
+    }
+}


### PR DESCRIPTION
Created a new decorator: ProxiedIdentityProvider. This decorator is used in the IdPs metadata. As we want to display the specific IdP UIinfo, which in the previous setup was overridden by the EB values.

The new decorator uses the EB config to be able to use the EB certs, contact persons and sso location.

Tests where added and existing tests where modified.

The test_only_add_entity_id_hash_for_sso_service_url_if_not_eb_self was removed from the EBIdentityProviderTest. This test is now available in the ProxiedIdentityProviderTest.

https://www.pivotaltracker.com/story/show/169708158