### PR TITLE
Fix typos for stepup no token

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -256,7 +256,7 @@ Your %organisationNoun% has denied you access to this service. You will have to 
     'error_stepup_callout_unknown_title' => 'Error - Unknown strong authentication failure',
     'error_stepup_callout_unknown_desc' => 'Logging in with strong authentication has failed and we don\'t know exactly why . Please try again first by going back to the service and logging in again . If this doesn\'t work, please contact the help desk of your %organisationNoun%.',
     'error_stepup_callout_unmet_loa_title' => 'Error - No suitable token found',
-    'error_stepup_callout_unmet_loa_desc' => 'To continue to this service, a registered token with a certain level of assurance is required. Currently, you either haven\'t registered a token at all, or the level of assurance of token you did register is too low . See the link below for more information about the registration process.',
+    'error_stepup_callout_unmet_loa_desc' => 'To continue to this service, a registered token with a certain level of assurance is required. Currently, you either haven\'t registered a token at all, or the level of assurance of the token you did register is too low. See the link below for more information about the registration process.<br/><br/><a target="_blank" href="https://support.surfconext.nl/stepup-noauthncontext-en">Read more about the registration process.</a>',
     'error_stepup_callout_user_cancelled_title' => 'Error - Logging in cancelled',
     'error_stepup_callout_user_cancelled_desc' => 'You have aborted the login process. Go back to the service if you want to try again.',
     'attributes_validation_succeeded' => 'Authentication success',


### PR DESCRIPTION
Some typos were on the no token feedback page. The typos are fixed and the missing link to the registration support page is also added.

https://www.pivotaltracker.com/n/projects/1425900/stories/169087364