### PR TITLE
Prevent double schema and hostname on logo

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Factory/ValueObject/EngineBlockConfiguration.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/ValueObject/EngineBlockConfiguration.php
@@ -65,7 +65,8 @@ class EngineBlockConfiguration
         string $supportUrl,
         string $supportMail,
         string $description,
-        string $logoUrl,
+        string $engineHostName,
+        string $logoPath,
         int $logoWidth,
         int $logoHeight
     ) {
@@ -73,7 +74,11 @@ class EngineBlockConfiguration
         $this->supportUrl = $supportUrl;
         $this->supportMail = $supportMail;
         $this->description = $description;
-        // A logo VO is created during construction time
+
+        // A logo VO is created during construction time, the schema for the url is hard coded, we assume engine is
+        // configured with TLS. The host name is read from the `hostname` ini config setting.
+        $logoUrl = 'https://' . $engineHostName . $logoPath;
+
         $this->logo = new Logo($logoUrl);
         $this->logo->width = $logoWidth;
         $this->logo->height = $logoHeight;

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -110,6 +110,7 @@ services:
             - '%openconext_support_url%'
             - '%email_request_access_address%'
             - '%view_default_header%'
+            - '%hostname%'
             - '%view_default_logo%'
             - '%view_default_logo_width%'
             - '%view_default_logo_height%'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
@@ -77,6 +77,7 @@ class MinkContext extends BaseMinkContext
 
         $xpathObj = new DOMXPath($document);
         $xpathObj->registerNamespace('ds', XMLSecurityDSig::XMLDSIGNS);
+        $xpathObj->registerNamespace('mdui', Common::NS);
         $nodeList = $xpathObj->query($xpath);
 
         if ($nodeList && $nodeList->length > 0) {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Metadata.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Metadata.feature
@@ -66,6 +66,8 @@ Feature:
       And the response should match xpath '//md:KeyDescriptor[@use="signing"]//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
       # Verify the used signing key is EB key
       And the response should match xpath '//ds:Signature//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+      # Verify the schema and hostname are not appende twice as was done prior to resolving: https://www.pivotaltracker.com/story/show/169724838
+      And the response should not match xpath '//mdui:Logo[text()="https://engine.vm.openconext.orghttps://engine.vm.openconext.org/images/logo.png"]'
 
   Scenario: A user can request the metadata and does not see invisible IdPs
     Given an Identity Provider named "Known-IdP"

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockIdentityProviderInformationTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockIdentityProviderInformationTest.php
@@ -42,7 +42,8 @@ class EngineblockIdentityProviderInformationTest extends AbstractEntityTest
         'configuredSupportUrl',
         'configuredSupportMail',
         'configuredDescription',
-        'configuredLogoUrl',
+        'example.org',
+        '/configuredLogoUrl',
         1209,
         1009
         );
@@ -50,7 +51,7 @@ class EngineblockIdentityProviderInformationTest extends AbstractEntityTest
         $decorator = new EngineBlockIdentityProviderInformation($adapter, $configuration);
 
         // Logo we would expect
-        $logo = new Logo('configuredLogoUrl');
+        $logo = new Logo('https://example.org/configuredLogoUrl');
         $logo->width = 1209;
         $logo->height = 1009;
 

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockServiceProviderInformationTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockServiceProviderInformationTest.php
@@ -43,7 +43,8 @@ class EngineblockServiceProviderInformationTest extends AbstractEntityTest
             'configuredSupportUrl',
             'configuredSupportMail',
             'configuredDescription',
-            'configuredLogoUrl',
+            'example.org',
+            '/configuredLogoUrl.gif',
             1209,
             1009
         );
@@ -51,7 +52,7 @@ class EngineblockServiceProviderInformationTest extends AbstractEntityTest
         $decorator = new EngineBlockServiceProviderInformation($adapter, $configuration);
 
         // Logo we would expect
-        $logo = new Logo('configuredLogoUrl');
+        $logo = new Logo('https://example.org/configuredLogoUrl.gif');
         $logo->width = 1209;
         $logo->height = 1009;
 

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactoryTest.php
@@ -98,7 +98,8 @@ class IdentityProviderFactoryTest extends AbstractEntityTest
             'configuredSupportUrl',
             'configuredSupportMail',
             'configuredDescription',
-            'configuredLogoUrl',
+            'example.org',
+            '/configuredLogoUrl.gif',
             1209,
             1009
         );
@@ -112,7 +113,7 @@ class IdentityProviderFactoryTest extends AbstractEntityTest
 
 
         // Logo we would expect
-        $logo = new Logo('configuredLogoUrl');
+        $logo = new Logo('https://example.org/configuredLogoUrl.gif');
         $logo->width = 1209;
         $logo->height = 1009;
 

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
@@ -80,7 +80,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $this->translator = $this->createMock(TranslatorInterface::class);
     }
 
-
     public function test_create_engineblock_entity_from()
     {
         $entity = new ServiceProvider('entityId');
@@ -115,7 +114,8 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
             'configuredSupportUrl',
             'configuredSupportMail',
             'configuredDescription',
-            'configuredLogoUrl',
+            'example.org',
+            '/configuredLogoUrl.gif',
             1209,
             1009
         );
@@ -136,7 +136,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $this->attributes->method('getRequestedAttributes')
             ->willReturn($attributes);
 
-
         $this->urlProvider->expects($this->exactly(2))
             ->method('getUrl')
             ->withConsecutive(
@@ -151,16 +150,13 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
                 'proxiedAcsLocation'
             );
 
-
         $this->factory = new ServiceProviderFactory($this->attributes, $this->keyPairFactory, $this->configuration, $this->urlProvider);
 
         $adapter = $this->createServiceProviderAdapter();
         $decorator = $this->factory->createEngineBlockEntityFrom('initial-key-id');
 
-
-
         // Logo we would expect
-        $logo = new Logo('configuredLogoUrl');
+        $logo = new Logo('https://example.org/configuredLogoUrl.gif');
         $logo->width = 1209;
         $logo->height = 1009;
 
@@ -174,16 +170,11 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
             ContactPerson::from('administrative', 'test-suite', 'Support', 'configuredSupportMail'),
         ];
 
-
-
         $supportedNameIdFormats = [
             Constants::NAMEID_PERSISTENT,
             Constants::NAMEID_TRANSIENT,
             Constants::NAMEID_UNSPECIFIED,
         ];
-
-
-
 
         // the actual assertions
         $overrides = [];
@@ -226,9 +217,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $overrides['supportUrlEn'] = null;
         $overrides['supportUrlNl'] = null;
 
-
-
-
         // EngineblockIdentityProviderInformation
         $overrides['nameNl'] = 'test-suite EngineBlock';
         $overrides['nameEn'] = 'test-suite EngineBlock';
@@ -250,7 +238,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $overrides['allowed'] = true;
         $overrides['allowAll'] = true;
 
-
         $this->runServiceProviderAssertions($adapter, $decorator, $overrides);
 
         $this->assertInstanceOf(ServiceProviderEntityInterface::class, $decorator);
@@ -269,6 +256,7 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
             'configuredSupportUrl',
             'configuredSupportMail',
             'configuredDescription',
+            'example.org',
             'configuredLogoUrl',
             1209,
             1009
@@ -304,7 +292,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
                 // ACS
                 'proxiedAcsLocation'
             );
-
 
         $this->factory = new ServiceProviderFactory($this->attributes, $this->keyPairFactory, $this->configuration, $this->urlProvider);
 
@@ -349,7 +336,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $overrides['attributeAggregationRequired'] = false;
         $overrides['requestedAttributes'] = null;
 
-
         // TODO: should the methods below not set trough EBIdPInfo?
         $overrides['supportUrlEn'] = null;
         $overrides['supportUrlNl'] = null;
@@ -369,7 +355,6 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
         $overrides['supportedNameIdFormats'] = [];
         $overrides['assertionConsumerServices'] = [new IndexedService('proxiedAcsLocation', Constants::BINDING_HTTP_POST, 0)];
         $overrides['allowAll'] = false;
-
 
         $this->runServiceProviderAssertions($adapter, $decorator, $overrides);
 

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/ValueObject/EngineBlockConfigurationTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/ValueObject/EngineBlockConfigurationTest.php
@@ -41,7 +41,7 @@ class EngineBlockConfigurationTest extends TestCase
         $url = 'https://www.example.org';
         $mail = 'mail@example.org';
         $description = 'The EngineBlock';
-        $logo = 'images/logo.png';
+        $logo = '/images/logo.png';
         $height = 120;
         $width = 120;
 
@@ -50,6 +50,7 @@ class EngineBlockConfigurationTest extends TestCase
             $url,
             $mail,
             $description,
+            'example.org',
             $logo,
             $width,
             $height
@@ -77,7 +78,7 @@ class EngineBlockConfigurationTest extends TestCase
         $this->assertEquals('administrative', $contactPersons[2]->contactType);
 
         $this->assertInstanceOf(Logo::class, $configuration->getLogo());
-        $this->assertEquals($logo, $configuration->getLogo()->url);
+        $this->assertEquals('https://example.org/images/logo.png', $configuration->getLogo()->url);
         $this->assertEquals($width, $configuration->getLogo()->width);
         $this->assertEquals($height, $configuration->getLogo()->height);
 

--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/ui_info.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/ui_info.xml.twig
@@ -4,6 +4,6 @@
     <mdui:Description xml:lang="nl">{{ metadata.descriptionNl }}</mdui:Description>
     <mdui:Description xml:lang="en">{{ metadata.descriptionEn }}</mdui:Description>
     {% if metadata.logo is not null %}
-    <mdui:Logo height="{{ metadata.logo.height }}" width="{{ metadata.logo.width }}">{{ app.request.getSchemeAndHttpHost() ~ metadata.logo.url }}</mdui:Logo>
+    <mdui:Logo height="{{ metadata.logo.height }}" width="{{ metadata.logo.width }}">{{ metadata.logo.url }}</mdui:Logo>
     {% endif %}
 </mdui:UIInfo>


### PR DESCRIPTION
When the IdPs metadata is rendered, Manage configured IdP logo URLs are used. Which are URIs, in contrary to the configured EB logo which is a relative path to the locally sourced logo.

To get both situations to render the logo URI correctly, the EB config object was updated. It now uses the EB hostname to create a logo URI the schema is set to HTTPS as we can assume TLS is used for Engine.

Finally the ui_info.xml.twig was updated to no longer prepend the schema and hostname.

A IdPs Metadata.feature scenario is used to verify that the logos are rendered without double hostnames.

https://www.pivotaltracker.com/story/show/169724838