### PR TITLE
Fix broken ProxiedIdentityProvider test

### DIFF
--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProviderTest.php
@@ -86,6 +86,7 @@ class ProxiedIdentityProviderTest extends AbstractEntityTest
             'configuredSupportMail',
             'configuredDescription',
             'configuredLogoUrl',
+            'logopath',
             1209,
             1009
         );


### PR DESCRIPTION
The test was broken because a feature was merged back while tests
were broken.