### PR TITLE
Prevent invalid assertion when stepup LoA is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,9 @@ script:
 branches:
   only:
     - master
-    - /^feature\/metadata(.*)$/
+    - /^feature\/(.*)$/
+    - /^hotfix\/(.*)$/
+    - /^bugfix\/(.*)$/
 
 after_failure:
   - sudo tail -500 /var/log/apache2/error.log

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -52,3 +52,6 @@ doctrine:
                 port:     "%database.test.port%"
                 user:     "%database.test.user%"
                 password: "%database.test.password%"
+
+twig:
+    strict_variables: true

--- a/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
@@ -16,11 +16,12 @@
  */
 
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider as ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Loa;
 use OpenConext\EngineBlock\Metadata\LoaRepository;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
-use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
 use OpenConext\EngineBlock\Stepup\StepupDecision;
 use OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper;
+use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -228,10 +229,10 @@ class EngineBlock_Corto_Module_Service_StepupAssertionConsumer implements Engine
      * @param string $loa
      * @throws EngineBlock_Corto_Module_Services_SessionLostException
      */
-    private function updateProcessingStateLoa(EngineBlock_Saml2_AuthnRequestAnnotationDecorator $receivedRequest, EngineBlock_Saml2_ResponseAnnotationDecorator $receivedResponse, $loa)
+    private function updateProcessingStateLoa(EngineBlock_Saml2_AuthnRequestAnnotationDecorator $receivedRequest, EngineBlock_Saml2_ResponseAnnotationDecorator $receivedResponse, Loa $loa)
     {
         $processStep = $this->_processingStateHelper->getStepByRequestId($receivedRequest->getId(), ProcessingStateHelperInterface::STEP_STEPUP);
-        $processStep->getResponse()->getAssertion()->setAuthnContextClassRef($loa);
+        $processStep->getResponse()->getAssertion()->setAuthnContextClassRef($loa->getIdentifier());
         $this->_processingStateHelper->updateStepResponseByRequestId($receivedRequest->getId(), ProcessingStateHelperInterface::STEP_STEPUP, $processStep->getResponse());
     }
 

--- a/src/OpenConext/EngineBlock/Metadata/Loa.php
+++ b/src/OpenConext/EngineBlock/Metadata/Loa.php
@@ -91,9 +91,4 @@ class Loa
     {
         return $this->identifier;
     }
-
-    public function __toString()
-    {
-        return $this->identifier;
-    }
 }


### PR DESCRIPTION
When setting a Loa on a Saml2 Assertion, the LOA VO was set on the AuthnContextClassRef.  In certain distro's this resulted in a false positive when asserting the `is_string` method. Because the VO had a `__toString` method.

The method is now removed and explicitly a string is given as parameter while maintaining the VO in Corto itself.

Some additional boyscouting was done:
 * Travis branch regex fixed
 * Enabled `strict_variables` on test to prevent a silent failure and thus removed magic

https://www.pivotaltracker.com/story/show/169976060

**This needs also to be cherrypicked to 6.0**