### PR TITLE
Update text and remove stray closing div tag

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Index/index.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Index/index.html.twig
@@ -8,129 +8,131 @@
 {% endspaceless %}{% endblock %}
 
 {% block content %}
-<div id="engine-main-page" class="box">
-  <div class="mod-content">
-    <header>
-      <img class="logo" src="{{ defaultLogo }}" alt=""/>
-      <h1>{{ 'suite_name'|trans }} EngineBlock</h1>
-    </header>
+    <div id="engine-main-page" class="box">
+        <div class="mod-content">
+            <header>
+                <img class="logo" src="{{ defaultLogo }}" alt=""/>
+                <h1>{{ 'suite_name'|trans }} EngineBlock</h1>
+            </header>
 
-    <div class="main">
+            <div class="main">
 
-        <h1>{{ subHeader }}</h1>
-        <dl class="metadata-certificates-list">
-            <dt>
-                The Public SAML Signing certificate of the {{ 'suite_name'|trans }} IdP
-            </dt>
-            <dd>
-                <ul>
-                    <li><a href="/authentication/idp/certificate">Open link</a></li>
-                    {% for keyId in keyPairIds %}
-                    <li><a href="/authentication/idp/certificate/key:{{ keyId }}">Open link</a></li>
-                    {% endfor %}
-                </ul>
-            </dd>
-            <dt>
-                The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} IdP Proxy
-            </dt>
-            <dd>
-                <ul>
-                    <li><a href="/authentication/idp/metadata">Open link</a></li>
-                    {% for keyId in keyPairIds %}
-                    <li><a href="/authentication/idp/metadata/key:{{ keyId }}">Open link</a></li>
-                    {% endfor %}
-                </ul>
-            </dd>
-            <dt>
-                The Public SAML metadata (the entities descriptor) for all the {{ 'suite_name'|trans }} IdPs
-            </dt>
-            <dd>
-                <ul>
-                    <li><a href="/authentication/proxy/idps-metadata">Open link</a></li>
-                    {% for keyId in keyPairIds %}
-                    <li><a href="/authentication/proxy/idps-metadata/key:{{ keyId }}">Open link</a></li>
-                    {% endfor %}
-                </ul>
-            </dd>
-            <dt>
-                <p class="strong">Metadata below is only relevant for key rollover or in
-                    case you want a custom WAYF for your SP</p>
-            </dt>
-            <dt>
-                The Public SAML metadata (the entities descriptor) of the {{ 'suite_name'|trans }} IdPs which allow
-                access to SP with entityID "urn:example.org". Please replace "urn:example.org" with
-                the entityID of your own SP before testing. The resulting metadata will include all
-                {{ 'suite_name'|trans }} IdPs that allow access to the service, as well as the SP metadata, if
-                configured for {{ 'suite_name'|trans }}. Please note this information is generated dynamically, so
-                the number of available IdPs may change over time.
-            </dt>
-            <dd>
-                <ul>
-                    <li><a href="/authentication/proxy/idps-metadata?sp-entity-id=urn:example.org">Open link</a></li>
-                    {% for keyId in keyPairIds %}
-                    <li><a href="/authentication/proxy/idps-metadata/key:{{ keyId }}?sp-entity-id=urn:example.org">Open link</a></li>
-                    {% endfor %}
-                </ul>
+                <h1>{{ subHeader }}</h1>
+                <dl class="metadata-certificates-list">
+                    <dt>
+                        The Public SAML Signing certificate of the {{ 'suite_name'|trans }} IdP
+                    </dt>
+                    <dd>
+                        <ul>
+                            <li><a href="/authentication/idp/certificate">Open link</a></li>
+                            {% for keyId in keyPairIds %}
+                                <li><a href="/authentication/idp/certificate/key:{{ keyId }}">Open link</a></li>
+                            {% endfor %}
+                        </ul>
+                    </dd>
+                    <dt>
+                        The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} IdP Proxy
+                    </dt>
+                    <dd>
+                        <ul>
+                            <li><a href="/authentication/idp/metadata">Open link</a></li>
+                            {% for keyId in keyPairIds %}
+                                <li><a href="/authentication/idp/metadata/key:{{ keyId }}">Open link</a></li>
+                            {% endfor %}
+                        </ul>
+                    </dd>
+                    <dt>
+                        The Public SAML metadata (the entities descriptor) for all the {{ 'suite_name'|trans }} IdPs
+                    </dt>
+                    <dd>
+                        <ul>
+                            <li><a href="/authentication/proxy/idps-metadata">Open link</a></li>
+                            {% for keyId in keyPairIds %}
+                                <li><a href="/authentication/proxy/idps-metadata/key:{{ keyId }}">Open link</a></li>
+                            {% endfor %}
+                        </ul>
+                    </dd>
+                    <dt>
+                        <p class="strong">Metadata below is only relevant for key rollover or in
+                            case you want a custom WAYF for your SP</p>
+                    </dt>
+                    <dt>
+                        The Public SAML metadata (the entities descriptor) of the {{ 'suite_name'|trans }} IdPs which
+                        allow
+                        access to SP with entityID "urn:example.org". Please replace "urn:example.org" with
+                        the entityID of your own SP before testing. The resulting metadata will include all
+                        {{ 'suite_name'|trans }} IdPs that allow access to the service. Please note this information is
+                        generated dynamically, so the number of available IdPs may change over time.
+                    </dt>
+                    <dd>
+                        <ul>
+                            <li><a href="/authentication/proxy/idps-metadata?sp-entity-id=urn:example.org">Open link</a>
+                            </li>
+                            {% for keyId in keyPairIds %}
+                                <li>
+                                    <a href="/authentication/proxy/idps-metadata/key:{{ keyId }}?sp-entity-id=urn:example.org">Open
+                                        link</a></li>
+                            {% endfor %}
+                        </ul>
 
-            </dd>
-        </dl>
+                    </dd>
+                </dl>
+            </div>
+
+            <div class="main">
+                <h1>SP Certificate and Metadata</h1>
+                <dl class="metadata-certificates-list">
+                    <dt>
+                        Test authentication with an identity provider.
+                    </dt>
+                    <dd>
+                        <ul>
+                            <li><a href="/authentication/sp/debug">Open link</a></li>
+                        </ul>
+                    </dd>
+                    <dt>
+                        The Public SAML Signing certificate of the {{ 'suite_name'|trans }} SP
+                    </dt>
+                    <dd>
+                        <ul>
+                            <li><a href="/authentication/sp/certificate">Open link</a></li>
+                            {% for keyId in keyPairIds %}
+                                <li><a href="/authentication/sp/certificate/key:{{ keyId }}">Open link</a></li>
+                            {% endfor %}
+                        </ul>
+                    </dd>
+                    <dt>
+                        The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} SP Proxy
+                    </dt>
+                    <dd>
+                        <ul>
+                            <li><a href="/authentication/sp/metadata">Open link</a></li>
+                            {% for keyId in keyPairIds %}
+                                <li><a href="/authentication/sp/metadata/key:{{ keyId }}">Open link</a></li>
+                            {% endfor %}
+                        </ul>
+                    </dd>
+                </dl>
+            </div>
+
+            <div class="main">
+                <h2>Step-up authentication Certificate and Metadata</h2>
+                <dl class="metadata-certificates-list">
+                    <dt>
+                        The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} step-up
+                        authentication Proxy
+                    </dt>
+                    <dd>
+                        <ul>
+                            <li><a href="/authentication/stepup/metadata">Open link</a></li>
+                            {% for keyId in keyPairIds %}
+                                <li><a href="/authentication/stepup/metadata/key:{{ keyId }}">Open link</a></li>
+                            {% endfor %}
+                        </ul>
+                    </dd>
+                </dl>
+
+            </div>
+        </div>
     </div>
-
-      <div class="main">
-          <h1>SP Certificate and Metadata</h1>
-          <dl class="metadata-certificates-list">
-              <dt>
-                  Test authentication with an identity provider.
-              </dt>
-              <dd>
-                  <ul>
-                      <li><a href="/authentication/sp/debug">Open link</a></li>
-                  </ul>
-              </dd>
-              <dt>
-                  The Public SAML Signing certificate of the {{ 'suite_name'|trans }} SP
-              </dt>
-              <dd>
-                  <ul>
-                      <li><a href="/authentication/sp/certificate">Open link</a></li>
-                      {% for keyId in keyPairIds %}
-                      <li><a href="/authentication/sp/certificate/key:{{ keyId }}">Open link</a></li>
-                      {% endfor %}
-                  </ul>
-              </dd>
-              <dt>
-                  The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} SP Proxy
-              </dt>
-              <dd>
-                  <ul>
-                      <li><a href="/authentication/sp/metadata">Open link</a></li>
-                      {% for keyId in keyPairIds %}
-                      <li><a href="/authentication/sp/metadata/key:{{ keyId }}">Open link</a></li>
-                      {% endfor %}
-                  </ul>
-              </dd>
-          </dl>
-      </div>
-
-
-      <div class="main">
-          <h2>Step-up authentication Certificate and Metadata</h2>
-          <dl class="metadata-certificates-list">
-              <dt>
-                  The Public SAML metadata (the entity descriptor) of the {{ 'suite_name'|trans }} step-up authentication Proxy
-              </dt>
-              <dd>
-                  <ul>
-                      <li><a href="/authentication/stepup/metadata">Open link</a></li>
-                      {% for keyId in keyPairIds %}
-                          <li><a href="/authentication/stepup/metadata/key:{{ keyId }}">Open link</a></li>
-                      {% endfor %}
-                  </ul>
-              </dd>
-          </dl>
-      </div>
-
-    </div>
-  </div>
-</div>
 {% endblock %}


### PR DESCRIPTION
1. The text for the  `idps-metadata` was not fully correct. A part of the descriptive sentence was removed.
2. An excessive closing div element was removed.
3. The HTML has been reformatted.

See: https://www.pivotaltracker.com/story/show/170357520