### PR TITLE
Repair ChromeDriver issue and resolve NodeSass issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,4 +100,3 @@ addons:
   hosts:
     - engine.vm.openconext.org
   mariadb: '10.2'
-  chrome: stable

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -4843,9 +4843,9 @@
       "dev": true
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
+      "integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
@@ -7486,9 +7486,9 @@
       }
     },
     "node-sass": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -7498,7 +7498,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -7543,6 +7543,12 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "supports-color": {

--- a/theme/package.json
+++ b/theme/package.json
@@ -38,7 +38,7 @@
     "jest": "^24.7.1",
     "jest-image-snapshot": "^2.8.1",
     "jshint": "^2.10.2",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.13.1",
     "postcss-cli": "^6.1.2",
     "puppeteer-core": "^1.14.0",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
We no longer use Chrome:stable on Travis xenial. This resolves the incompatibility between Chrome and the driver.

Finally Node SASS was updated. Even though the 'fix' mentioned above. It was still considered a production dependency by other packages..