### PR TITLE
Metadata UI Info optimalisation

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProvider.php
@@ -98,4 +98,35 @@ class ProxiedIdentityProvider extends AbstractIdentityProvider
         $ssoLocation = $this->urlProvider->getUrl('authentication_idp_sso', false, null, $this->getEntityId());
         return [new Service($ssoLocation, Constants::BINDING_HTTP_REDIRECT)];
     }
+
+    /**
+     * Best effort to show a Dutch display name.
+     *
+     * Buisiness rule:
+     * displayname:nl, name:nl, name:en
+     */
+    public function getDisplayNameNl(): string
+    {
+        if (empty($this->entity->getDisplayNameNl())) {
+            if (!empty($this->entity->getNameNl())) {
+                return $this->entity->getNameNl();
+            }
+            return $this->entity->getNameEn();
+        }
+        return $this->entity->getDisplayNameNl();
+    }
+
+    /**
+     * Best effort to show an English display name.
+     *
+     * Buisiness rule:
+     * displayname:en, name:en
+     */
+    public function getDisplayNameEn(): string
+    {
+        if (empty($this->entity->getDisplayNameEn())) {
+            return $this->entity->getNameEn();
+        }
+        return $this->entity->getDisplayNameEn();
+    }
 }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProviderTest.php
@@ -64,32 +64,9 @@ class ProxiedIdentityProviderTest extends AbstractEntityTest
     {
         $this->adapter = $this->createIdentityProviderAdapter();
 
-        $this->urlProvider->expects($this->exactly(1))
-            ->method('getUrl')
-            ->withConsecutive(
-                // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
-                ['authentication_idp_sso', false, null, 'entity-id']
-            ) ->willReturnOnConsecutiveCalls(
-                // SSO
-                'proxiedSsoLocation'
-            );
+        $this->configureUrlProvider();
 
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects($this->exactly(1))
-            ->method('trans')
-            ->with('suite_name')
-            ->willReturn('test-suite');
-
-        $configuration = new EngineBlockConfiguration(
-            $translator,
-            'configuredSupportUrl',
-            'configuredSupportMail',
-            'configuredDescription',
-            'configuredLogoUrl',
-            'logopath',
-            1209,
-            1009
-        );
+        $configuration = $this->createConfiguration();
 
         $decorator = new ProxiedIdentityProvider(
             $this->adapter,
@@ -118,5 +95,86 @@ class ProxiedIdentityProviderTest extends AbstractEntityTest
         $overrides['contactPersons'] = $contactPersons;
 
         $this->runIdentityProviderAssertions($this->adapter, $decorator, $overrides);
+    }
+
+    /**
+     * Verification test for display name related requirements stated in:
+     * https://www.pivotaltracker.com/story/show/170401452
+     */
+    public function test_name_fallback()
+    {
+        // If Display Name EN is not set, the decorator will fall back on the Name EN
+        $this->adapter = $this->createIdentityProviderAdapter(['displayNameEn' => '']);
+        $configuration = $this->createConfiguration();
+        $decorator = new ProxiedIdentityProvider(
+            $this->adapter,
+            $configuration,
+            $this->keyPairMock,
+            $this->urlProvider
+        );
+        // Falls back on the name EN when display name is not set (empty)
+        $this->assertEquals($decorator->getNameEn(), $decorator->getDisplayNameEn());
+
+        // If Display Name NL is not set, the decorator will fall back on the Name NL
+        $this->adapter = $this->createIdentityProviderAdapter(['displayNameNl' => '']);
+        $configuration = $this->createConfiguration();
+        $decorator = new ProxiedIdentityProvider(
+            $this->adapter,
+            $configuration,
+            $this->keyPairMock,
+            $this->urlProvider
+        );
+        // Falls back on the name NL when display name is not set (empty)
+        $this->assertEquals($decorator->getNameNl(), $decorator->getDisplayNameNl());
+
+        // If Display Name NL is not set, the decorator will fall back on the Name NL
+        $this->adapter = $this->createIdentityProviderAdapter([
+            'displayNameNl' => '',
+            'nameNl' => '',
+        ]);
+        $configuration = $this->createConfiguration();
+        $decorator = new ProxiedIdentityProvider(
+            $this->adapter,
+            $configuration,
+            $this->keyPairMock,
+            $this->urlProvider
+        );
+        // Falls back on the name EN when display name and name NL are not set (empty)
+        $this->assertEquals($decorator->getNameEn(), $decorator->getDisplayNameNl());
+    }
+
+    private function createConfiguration(): EngineBlockConfiguration
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->exactly(1))
+            ->method('trans')
+            ->with('suite_name')
+            ->willReturn('test-suite');
+
+        $configuration = new EngineBlockConfiguration(
+            $translator,
+            'configuredSupportUrl',
+            'configuredSupportMail',
+            'configuredDescription',
+            'configuredLogoUrl',
+            'logopath',
+            1209,
+            1009
+        );
+
+        return $configuration;
+    }
+
+    private function configureUrlProvider(): void
+    {
+        $this->urlProvider->expects($this->exactly(1))
+            ->method('getUrl')
+            ->withConsecutive(
+            // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
+                ['authentication_idp_sso', false, null, 'entity-id']
+            )->willReturnOnConsecutiveCalls(
+            // SSO
+                'proxiedSsoLocation'
+            );
     }
 }

--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/ui_info.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/ui_info.xml.twig
@@ -1,8 +1,12 @@
 <mdui:UIInfo xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
     <mdui:DisplayName xml:lang="nl">{{ metadata.displayNameNl }}</mdui:DisplayName>
     <mdui:DisplayName xml:lang="en">{{ metadata.displayNameEn }}</mdui:DisplayName>
+    {% if metadata.descriptionNl is not empty %}
     <mdui:Description xml:lang="nl">{{ metadata.descriptionNl }}</mdui:Description>
+    {% endif %}
+    {% if metadata.descriptionEn is not empty %}
     <mdui:Description xml:lang="en">{{ metadata.descriptionEn }}</mdui:Description>
+    {% endif %}
     {% if metadata.logo is not null %}
     <mdui:Logo height="{{ metadata.logo.height }}" width="{{ metadata.logo.width }}">{{ metadata.logo.url }}</mdui:Logo>
     {% endif %}


### PR DESCRIPTION
The displayname can always be set because name:en is a required field. Use this preference for the value:

* For EN: displayname:en, name:en
* For NL: displayname:nl, name:nl, name:en

Empty descriptions need not be displayed in the metadata.

Previously an empty tag was rendered, now the tag is omitted in its entirety. It was not a trivial task to verify this change in a functional test, but given the low complexity of this change it is a 'risk' I feel we can take.

https://www.pivotaltracker.com/story/show/170401452