### PR TITLE
Display keywords when present

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/ui_info.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/ui_info.xml.twig
@@ -6,4 +6,10 @@
     {% if metadata.logo is not null %}
     <mdui:Logo height="{{ metadata.logo.height }}" width="{{ metadata.logo.width }}">{{ metadata.logo.url }}</mdui:Logo>
     {% endif %}
+    {% if metadata.keywordsNl is not empty %}
+        <mdui:Keywords xml:lang="nl">{{ metadata.keywordsNl }}</mdui:Keywords>
+    {% endif %}
+    {% if metadata.keywordsEn is not empty %}
+    <mdui:Keywords xml:lang="en">{{ metadata.keywordsEn }}</mdui:Keywords>
+    {% endif %}
 </mdui:UIInfo>


### PR DESCRIPTION
When keywords are present they are appended to the UI Info. Adding a functional test for this feature was no trivial task. Given the low complexity, this is something we can get away with. But @pablothedude you'll be the judge.

https://www.pivotaltracker.com/story/show/170401406