### PR TITLE
Show Organization data in IdP(s) metadata

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Factory/Helper/IdentityProviderMetadataHelper.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Helper/IdentityProviderMetadataHelper.php
@@ -74,4 +74,14 @@ class IdentityProviderMetadataHelper extends AbstractIdentityProvider
         }
         return $keys;
     }
+
+    public function hasOrganizationInfo(): bool
+    {
+        $info = [
+            $this->entity->getOrganizationEn(),
+            $this->entity->getOrganizationNl(),
+        ];
+
+        return !empty(array_filter($info));
+    }
 }

--- a/theme/material/templates/modules/Authentication/View/Metadata/idp.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/idp.xml.twig
@@ -20,6 +20,9 @@
         {# Formally we only allow redirect binding on the SSO location #}
         <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ metadata.ssoLocation }}"></md:SingleSignOnService>
     </md:IDPSSODescriptor>
+    {% if metadata.hasOrganizationInfo %}
+        {% include '@theme/Authentication/View/Metadata/partial/organization.xml.twig' %}
+    {% endif %}
     {% if metadata.contactPersons is not empty%}
         {% for contactPerson in metadata.contactPersons %}
             {% include '@theme/Authentication/View/Metadata/partial/contact_person.xml.twig' %}

--- a/theme/material/templates/modules/Authentication/View/Metadata/idps.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/idps.xml.twig
@@ -22,6 +22,9 @@
                 {% endfor %}
                 <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ metadata.ssoLocation }}"></md:SingleSignOnService>
             </md:IDPSSODescriptor>
+            {% if metadata.hasOrganizationInfo %}
+                {% include '@theme/Authentication/View/Metadata/partial/organization.xml.twig' %}
+            {% endif %}
             {% if metadata.contactPersons is not empty%}
                 {% for contactPerson in metadata.contactPersons %}
                     {% include '@theme/Authentication/View/Metadata/partial/contact_person.xml.twig' %}

--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
@@ -1,8 +1,20 @@
 <md:Organization>
+    {% if metadata.organizationNameNl is not empty %}
     <md:OrganizationName xml:lang="nl">{{ metadata.organizationNameNl }}</md:OrganizationName>
+    {% endif %}
+    {% if metadata.organizationNameEn is not empty %}
     <md:OrganizationName xml:lang="en">{{ metadata.organizationNameEn }}</md:OrganizationName>
+    {% endif %}
+    {% if metadata.organizationNameNl is not empty %}
     <md:OrganizationDisplayName xml:lang="nl">{{ metadata.organizationNameNl }}</md:OrganizationDisplayName>
+    {% endif %}
+    {% if metadata.organizationNameEn is not empty %}
     <md:OrganizationDisplayName xml:lang="en">{{ metadata.organizationNameEn }}</md:OrganizationDisplayName>
-    <md:OrganizationURL xml:lang="nl">{{ metadata.supportUrlNl }}</md:OrganizationURL>
-    <md:OrganizationURL xml:lang="en">{{ metadata.supportUrlEn }}</md:OrganizationURL>
+    {% endif %}
+    {% if metadata.organizationUrlNl is not null and metadata.organizationUrlNl is not empty %}
+    <md:OrganizationURL xml:lang="nl">{{ metadata.organizationUrlNl }}</md:OrganizationURL>
+    {% endif %}
+    {% if metadata.organizationUrlEn is not null and metadata.organizationUrlEn is not empty %}
+    <md:OrganizationURL xml:lang="en">{{ metadata.organizationUrlEn }}</md:OrganizationURL>
+    {% endif %}
 </md:Organization>


### PR DESCRIPTION
Initially only SP's where treated with the Organization metadata (consisting of Name, DisplayName and an URL). Now also the IdP and IdPs metadata will display that data.

In addition, empty valued organization data will not be rendered as an empty xml element. But are omitted from the document.

https://www.pivotaltracker.com/story/show/170401380