### PR TITLE
debug page: move icons to first column of table.

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -269,6 +269,7 @@ Your %organisationNoun% has denied you access to this service. You will have to 
 
     'attributes' => 'Attributes',
     'validation' => 'Validation',
+    'remarks' => 'Remarks',
     'idp_debugging_mail_explain' => 'When requested by %suiteName%,
                                         use the "Mail to %suiteName%" button below
                                         to mail the information in this screen.',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -272,6 +272,7 @@ Je %organisationNoun% heeft je de toegang geweigerd tot deze dienst. Je zult dus
 
     'attributes' => 'Attributen',
     'validation' => 'Validatie',
+    'remarks' => 'Opmerkingen',
     'idp_debugging_mail_explain' => 'Indien gevraagd door %suiteName%,
                                         gebruik de "Mail naar %suiteName%" knop hieronder
                                         om de informatie op dit scherm naar %suiteName% beheer te e-mailen.',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -265,6 +265,7 @@ A sua %organisationNoun% negou-lhe acesso a este serviço. Terá de entrar em co
     'retry'                           => 'Tente novamente',
     'attributes' => 'Atributos',
     'validation' => 'Validação',
+    'remarks' => 'Observações',
     'idp_debugging_mail_explain' => 'Quando solicitado por %suiteName%,
                                         utilize o botão "Enviar Email a %suiteName%" em baixo
                                         para enviar o email com a informação deste ecrã.',

--- a/theme/material/templates/modules/Authentication/View/Proxy/debug-idp-response.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/debug-idp-response.html.twig
@@ -125,7 +125,7 @@
                             {{ 'value'|trans }}
                         </th>
                         <th>
-                            {{ 'validation'|trans }}
+                            {{ 'remarks'|trans }}
                         </th>
                     </tr>
                     </thead>

--- a/theme/material/templates/modules/Authentication/View/Proxy/debug-idp-response.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/debug-idp-response.html.twig
@@ -113,6 +113,9 @@
                     <thead>
                     <tr>
                         <th>
+                            {{ 'validation'|trans }}
+                        </th>
+                        <th>
                             {{ 'suite_name'|trans }} Display Name
                         </th>
                         <th>
@@ -129,6 +132,20 @@
                     <tbody>
                     {% for attributeName, attributeValues in attributes %}
                         <tr>
+                            <td>
+                                {% if validationResult.isValid(attributeName) %}
+                                    <i class="c-icon c-icon-checkmark fa-check" alt="&#9989;"></i>
+                                {% else %}
+                                    {% if validationResult.errors(attributeName).length > 0 %}
+                                        <p class="error">
+                                            <i class="c-icon c-icon-error fa-exclamation"></i>
+                                        </p>
+                                    {% else %}
+                                        <p class="warning"><i class="c-icon c-icon-warning fa-exclamation"></i>
+                                        </p>
+                                    {% endif %}
+                                {% endif %}
+                            </td>
                             <td>
                                 {{ attributeName(attributeName, 'en') }}
                             </td>
@@ -147,23 +164,19 @@
                                 {% endif %}
                             </td>
                             <td>
-                                {% if validationResult.isValid(attributeName) %}
-                                    <i class="c-icon c-icon-checkmark fa-check" alt="&#9989;"></i>
-                                {% else %}
+                                {% if not validationResult.isValid(attributeName) %}
+                                <em>
                                     {% for error in validationResult.errors(attributeName) %}
-                                        <p class="error">
-                                            <i class="c-icon c-icon-error fa-exclamation"></i>
                                             {{ error[0]|trans({'%arg1%': error[1], '%arg2%': error[2], '%arg3%': error[3]}) }}
-                                        </p>
                                     {% endfor %}
                                     {% for warning in validationResult.warnings(attributeName) %}
-                                        <p class="warning"><i class="c-icon c-icon-warning fa-exclamation"></i>
                                            {{ warning[0]|trans({'%arg1%': warning[1], '%arg2%': warning[2], '%arg3%': warning[3]}) }}
-                                        </p>
                                     {% endfor %}
+                                 </em>
                                 {% endif %}
                             </td>
                         </tr>
+
                     {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
They tend to easily get overlooked when all the way at the end of a
line. This will draw attention to the line, so the user can scroll
to the right if needed to get the "why" information.