### PR TITLE
Add explicit reference to metadata xml signature.

### DIFF
--- a/src/OpenConext/EngineBlock/Xml/DocumentSigner.php
+++ b/src/OpenConext/EngineBlock/Xml/DocumentSigner.php
@@ -32,13 +32,18 @@ class DocumentSigner
         $doc = new DOMDocument();
         $doc->loadXML($source);
 
+        // Find root element to sign. The firstChild is the TOS comment,
+        // so need to skip over that.
+        $rootNode = $doc->childNodes[1];
+
         // Create sign object
         $objDSig = new XMLSecurityDSig();
         $objDSig->setCanonicalMethod(XMLSecurityDSig::EXC_C14N);
         $objDSig->addReference(
-            $doc,
+            $rootNode,
             self::SIGN_ALGORITHM,
-            array('http://www.w3.org/2000/09/xmldsig#enveloped-signature')
+            ['http://www.w3.org/2000/09/xmldsig#enveloped-signature'],
+            ['id_name' => 'ID', 'overwrite' => false]
         );
 
         // Load private key

--- a/src/OpenConext/EngineBlock/Xml/DocumentSigner.php
+++ b/src/OpenConext/EngineBlock/Xml/DocumentSigner.php
@@ -19,6 +19,8 @@
 namespace OpenConext\EngineBlock\Xml;
 
 use DOMDocument;
+use DOMElement;
+use OpenConext\EngineBlock\Exception\RuntimeException;
 use OpenConext\EngineBlock\Metadata\X509\X509KeyPair;
 use RobRichards\XMLSecLibs\XMLSecurityDSig;
 
@@ -34,6 +36,9 @@ class DocumentSigner
 
         // Find root element to sign. The firstChild is the TOS comment,
         // so need to skip over that.
+        if (!isset($doc->childNodes[1]) || !$doc->childNodes[1] instanceof DOMElement) {
+            throw new RuntimeException("Could not locate root element to sign");
+        }
         $rootNode = $doc->childNodes[1];
 
         // Create sign object

--- a/tests/unit/OpenConext/EngineBlock/Xml/DocumentSignerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/DocumentSignerTest.php
@@ -31,7 +31,8 @@ class DocumentSignerTest extends TestCase
         $signer = new DocumentSigner();
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2019-10-16T12:41:12Z" cacheDuration="PT604800S" entityID="Test Entity">
+<!-- https://support.example.org/terms-en -->
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="EB12345" validUntil="2019-10-16T12:41:12Z" cacheDuration="PT604800S" entityID="Test Entity">
    <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
       <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
       <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/acs" index="1" />
@@ -46,20 +47,21 @@ XML;
 
         $expextedOutput = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2019-10-16T12:41:12Z" cacheDuration="PT604800S" entityID="Test Entity">
+<!-- https://support.example.org/terms-en -->
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="EB12345" validUntil="2019-10-16T12:41:12Z" cacheDuration="PT604800S" entityID="Test Entity">
    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
       <ds:SignedInfo>
          <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
          <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
-         <ds:Reference>
+         <ds:Reference URI="#EB12345">
             <ds:Transforms>
                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
             </ds:Transforms>
             <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
-            <ds:DigestValue>UeuCX/0rS+ZFeJT5KQEQ3fB5QrKmygggPFIKkbXLCkE=</ds:DigestValue>
+            <ds:DigestValue>nM+i0lfnpkNm/iH9c4XsvqUL3PaH+4OPethgW0fzI/Y=</ds:DigestValue>
          </ds:Reference>
       </ds:SignedInfo>
-      <ds:SignatureValue>qANWi8HspdG+jJd5lPKKHQBV46GXf8R7PH6htq4Tq4ZkWkzq87YVbIeCBhs8ayEZquiLS9KdCsV980FgtiahU9iFsSd7oJEAbT/7zFQWd4vf5NkGF2hb+PVVnQI+ysP02slsm8PSCpQHIliDDW5FS2GVgXb+q1InMfWWWBNbyUw8/bUJ2B4xyGvT9ytvSedOY4qceldtNzNz4kDrEP1Qv/iiInU3t59POeq+WFKwXNsdk5Df/koNWdW++Nqm+HOy+SgCNfkGvV4lb6suQyH7yXOKcC7M6/fpruTvg4xNYpd99YNKF+uawx/7JDNLP4P7dxgzHjTl3K8csVvoiwI1cA==</ds:SignatureValue>
+      <ds:SignatureValue>NbMqns50Fr0qpW5jnEdliAS8+jXv//AH5kAvBKvxWt2PS8Xeo8qZnJoR6cxriaeytB0JgRsmPEyZw59e+OAvz/Dox/6gEgrMPiPDSvTRaEPR4a9BVCw71i3aam4bEc6TfdRC9RZ44LETlLqTwYvmVlVF5iWx1E5yR4WV0/esnwDHiUXqXddgDS0zqih8YiDjRrqJFxb0PvothVkwGkyN5fLgl2fNqTbA0VzY5YtTVOEsbVWBpE0Xl9kJMIctnT8P57uWcleRRLMHUqroUc8zzjO3wq2kB7JPNFU1tQVgnoYMPVPaUNQS8ARfQp2nuGmCxNcsprz1o6xXeu9jpNcgKw==</ds:SignatureValue>
       <ds:KeyInfo>
          <ds:X509Data>
             <ds:X509Certificate>MIIDXzCCAkegAwIBAgIJAM4CwNsdIhJ3MA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMMBkVuZ2luZTERMA8GA1UECwwIU2VydmljZXMxEzARBgNVBAoMCk9wZW5Db25leHQxCzAJBgNVBAYTAk5MMB4XDTE0MDUxMjEzMjIxNloXDTI0MDUxMTEzMjIxNlowRjEPMA0GA1UEAwwGRW5naW5lMREwDwYDVQQLDAhTZXJ2aWNlczETMBEGA1UECgwKT3BlbkNvbmV4dDELMAkGA1UEBhMCTkwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2aQ9OYsAASWR/aN5NB2mQqFsBc13uN0nSbjkk1Um8VouGo7OmSM0eiur5my8UvPYth1DXQM6u2wiFq19RtfVZWJOmrzAfVHc9VRj9Xj4T+MVpR4bDWctvxVT1OPm9L23KQKvaqDmUo7uSPsBD36EIH7dFOBydDtSXfZTW0ien+lZr6C4nPuxzDbHJ+Jlo2brieimUBQNetX/ettnAglJ9536sJDkhsa120mkYPhVnvepbOtxPyU5ZDUpDNmMQR2/SORCBJcfvLSVZ4It4O67l6/EJnkFRLerIqOpk/W8jY3USQaLM2WM7sWBGxEFKDVcTFgrOH50Z94K2M/KweY2bAgMBAAGjUDBOMB0GA1UdDgQWBBSewI9OzfzbIxnl6XMkaQkYY1hHPjAfBgNVHSMEGDAWgBSewI9OzfzbIxnl6XMkaQkYY1hHPjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4IBAQAFfYPZbsYPHz4ypV/aO59do7CtHPnAMWr0NcQt4h9IW8gjihaNHt12V30QtHrVaXejXybB/LaGbPPyA64+l/SeC7ksrRxlitCwFqnws6ISXJaYU0iEFHGUD/cAj1iGloIsOm5IOdb3sdG/SsBv49G8es2wG0rDd0/s2fBVvXd4qUoXzKJAjYk1MFQxnGHomlt67SBrr2QLh+m2VHg+mkdi6yrdm9B9ylF8V55Vl82pPZXxphIRgqdos5YWeALS7dr5dSw9s5smFBxyy8IfCQMxagfNC59w22w2ULC/J7au/oP8ylusuxncxizdR/+5UazzAlOWtkjzaABzzBWM4hEK</ds:X509Certificate>

--- a/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
@@ -243,6 +243,7 @@ class MetadataRendererTest extends TestCase
         $doc->loadXML($xml);
 
         $objXMLSecDSig = new XMLSecurityDSig();
+        $objXMLSecDSig->idKeys = ['ID'];
 
         $objDSig = $objXMLSecDSig->locateSignature($doc);
         if (!$objDSig) {


### PR DESCRIPTION
This makes explicit what is signed. Otherwise validation fails
in some implemenations.

Would normally take the first element, the root, but our templates
have comment with TOS in them. Could just remove this? And then
change code to look for firstChild.