### PR TITLE
Change language cookie defaults

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -224,6 +224,8 @@ addgueststatus.guestqualifier = "urn:collab:org:example.org"
 cookie.lang.domain = ".example.org"
 ; Cookie expiry time, specify the time in seconds, set empty to let the cookie get expired after the session
 cookie.lang.expiry = 5184000 ; 60 days in seconds
+; cookie.lang.secure = false ; By default the secure flag is set to be true
+; cookie.lang.http_only = true ; By default the http_only flag is set to false
 
 defaults.title      = "OpenConext"
 defaults.header     = "OpenConext"

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -183,7 +183,7 @@ $ymlContent = array(
         'cookie.locale.domain'                                    => $config->get('cookie.lang.domain'),
         'cookie.locale.expiry'                                    => (int) $config->get('cookie.lang.expiry'),
         'cookie.locale.http_only'                                 => (bool) $config->get('cookie.lang.http_only', false),
-        'cookie.locale.secure'                                    => (bool) $config->get('cookie.lang.secure', false),
+        'cookie.locale.secure'                                    => (bool) $config->get('cookie.lang.secure', true),
 
         'feature_eb_encrypted_assertions'                         => (bool) $config->get('engineblock.feature.encrypted_assertions'),
         'feature_eb_encrypted_assertions_require_outer_signature' => (bool) $config->get('engineblock.feature.encrypted_assertions_require_outer_signature'),


### PR DESCRIPTION
**Description**
By default we now set the secure flag on the lang cookie. The in-config-file documentation was also updated to advertise the possible lang cookie settings available.

**Relates to**
Github issue: #831 
Pivotal ticket: https://www.pivotaltracker.com/story/show/171253291