### PR TITLE
Disassemble the EB debug feature

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -75,12 +75,6 @@ encryption.keys.default.privateFile = "/etc/openconext/engineblock.pem"
 ; encryption.keys.KEYID.publicFile = "/etc/openconext/engineblock.KEYID.crt"
 ; encryption.keys.KEYID.privateFile = "/etc/openconext/engineblock.KEYID.pem"
 
-; Setting the debug mode to true will cause EngineBlock to display more information
-; about errors that have occurred and it will show the messages it sends and receives
-; for the authentication.
-; NEVER TURN THIS ON FOR PRODUCTION
-debug = false
-
 ; Store attributes with their values, meaning that if an Idp suddenly
 ; sends a new value (like a new e-mail address) consent has to be
 ; given again.

--- a/bin/composer/dump-required-ini-params.sh
+++ b/bin/composer/dump-required-ini-params.sh
@@ -107,15 +107,6 @@ function escapeYamlValue($value)
 
 $ymlContent = array(
     'parameters' => array(
-        // Setting the debug mode to true will cause EngineBlock to display
-        // more information about errors that have occurred and it will show
-        // the messages it sends and receives for the authentication.
-        //
-        // NEVER TURN THIS ON FOR PRODUCTION!
-        //
-        // Note: this setting is independent from Symfony debug mode.
-        'debug'                                                   => $config->get('debug', false),
-
         // Note: due to legacy reasons, hostname must be left empty (hostname
         // from the Host header will be used) or set to match the domain
         // setting. For example:

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -46,14 +46,6 @@ class EngineBlock_Application_DiContainer extends Pimple
     }
 
     /**
-     * @return bool
-     */
-    public function isDebug()
-    {
-        return (bool) $this->container->getParameter('debug');
-    }
-
-    /**
      * @return string
      */
     public function getHostname()

--- a/library/EngineBlock/Application/ErrorHandler.php
+++ b/library/EngineBlock/Application/ErrorHandler.php
@@ -66,10 +66,6 @@ class EngineBlock_Application_ErrorHandler
         $this->_application->reportError($e);
 
         $message = 'An exceptional condition occurred, it has been logged and sent to the administrator.';
-        if ($this->_application->getDiContainer()->isDebug()) {
-            $message .= PHP_EOL . '<br /><br /> ERROR: ' . PHP_EOL;
-            $message .= '<br /><strong style="color: red"><pre>' . var_export($e, true) . '</pre></strong>';
-        }
         die($message);
     }
 

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -131,8 +131,6 @@ class EngineBlock_ApplicationSingleton
         if ($this->_activationStrategy) {
             $this->_activationStrategy->activate();
             $logger->notice($reason);
-        } elseif ($this->getDiContainer()->isDebug()) {
-            $logger->notice(sprintf("No log buffer to flush. Reason given for flushing: '%s'.", $reason));
         } else {
             $logger->warning(sprintf("Unable to flush the log buffer. Reason given for flushing: '%s'.", $reason));
         }

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -355,7 +355,6 @@ class EngineBlock_Corto_Adapter
         $settings = $application->getDiContainer();
 
         $proxyServer->setConfigs(array(
-            'debug' => $settings->isDebug(),
             'ConsentStoreValues' => $settings->isConsentStoreValuesActive(),
             'metadataValidUntilSeconds' => 86400, // This sets the time (in seconds) the entity metadata is valid.
             'forbiddenSignatureMethods' => $settings->getForbiddenSignatureMethods()

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -932,20 +932,7 @@ class EngineBlock_Corto_ProxyServer
     public function redirect($location, $message)
     {
         $this->getLogger()->info("Redirecting to $location");
-
-        if ($this->getConfig('debug', true)) {
-            $output = $this->twig->render(
-                '@theme/Authentication/View/Proxy/redirect.html.twig',
-                [
-                    'location' => $location,
-                    'message' => $message,
-                ]
-            );
-            $this->sendOutput($output);
-        } else {
-            $this->sendHeader('Location', $location);
-        }
-
+        $this->sendHeader('Location', $location);
     }
 
     public function setCookie($name, $value, $expire = null, $path = null, $domain = null, $secure = null, $httpOnly = null)

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Debug.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Debug.php
@@ -32,25 +32,8 @@ class Debug extends Twig_Extension
     {
         return [
             new TwigFunction('var_export', [$this, 'varExport']),
-            new TwigFunction('var_dump', [$this, 'varDump']),
             new TwigFunction('print_r', [$this, 'printHumanReadable']),
         ];
-    }
-
-    /**
-     * Provides var dump functionality for use in Twig templates
-     *
-     * @SuppressWarnings(PHPMD.CamelCaseParameterName)
-     *
-     * @param mixed $expression
-     * @param mixed $_
-     * @return string
-     */
-    public function varDump($expression, $_ = null)
-    {
-        ob_start();
-        var_dump(func_get_args());
-        return ob_get_clean();
     }
 
     /**

--- a/tests/unit/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/DebugTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/DebugTest.php
@@ -49,30 +49,4 @@ class DebugTest extends TestCase
         $output = $this->debug->varExport(['testString']);
         $this->assertContains('0 => \'testString\'', $output);
     }
-
-    /**
-     * @dataProvider varDumpTestValues
-     * @param $input
-     * @param $expectation
-     */
-    public function testVarDump($input, $expectation)
-    {
-        $output = $this->debug->varDump($input);
-        $this->assertContains($expectation, $output);
-    }
-
-    public function varDumpTestValues()
-    {
-        return [
-            ['testString', 'string(10) "testString"'],
-            [123, 'int(123)'],
-            [['testString', 123], 'array(2) {
-    [0] =>
-    string(10) "testString"
-    [1] =>
-    int(123)
-  }']
-        ];
-    }
-
 }

--- a/theme/material/templates/modules/Authentication/View/Proxy/form.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/form.html.twig
@@ -13,7 +13,7 @@
         <link href="/stylesheets/application.css" rel="stylesheet" type="text/css"/>
         <title>{{ defaultTitle }} - {{ 'post_data'|trans }}</title>
     </head>
-    <body class="index" {% if trace is empty %}onload="document.forms[0].submit()"{% endif %}>
+    <body class="index" onload="document.forms[0].submit()">
     <div class="mod-redirect">
         <img class="rotate-img" src="/images/spinner.svg" alt=""/>
 
@@ -34,17 +34,6 @@
             {{ xtra|raw }}
 
             <noscript><input type="submit" value="Submit" class="c-button"/></noscript>
-
-            {% if trace is not empty %}
-                <input id="submitbutton" type="submit" value="Submit" class="c-button"/>
-                <pre class="trace">
-                    {{ trace }}
-                </pre>
-                <script type="text/javascript">
-                    document.getElementById('submitbutton').focus();
-                </script>
-            {% endif %}
-
         </form>
     </div>
 

--- a/theme/material/templates/modules/Default/View/Error/error.html.twig
+++ b/theme/material/templates/modules/Default/View/Error/error.html.twig
@@ -61,20 +61,6 @@
 
             <p>{{ 'error_help_desc'|trans|raw }}</p>
 
-            {% if exception is defined %}
-                <div class="l-overflow">
-                    <strong>{{ exception.message }}</strong>
-                    <pre>
-                    {{ var_dump(exception) }}
-
-                    {% if exception.xdebug_message is defined %}
-                        {{ exception.xdebug_message|raw }}
-                    {% endif %}
-                    </pre>
-                </div>
-            {% endif %}
-
-
         </div>
         {% spaceless %}{% include "@theme/Default/View/Error/partial/footer.html.twig" %}{% endspaceless %}
     </div>


### PR DESCRIPTION
It was not used, and provided minimal additional information. Removing it seemed logical.

Regarding the debug Twig extension, the var_dump function was removed. But the print_r and var_export functions have been left in place. As the debug route (used to test EB from the home page) still uses it to create debug info for the helpdesk mail.

https://www.pivotaltracker.com/story/show/164757722