### PR TITLE
Log original NameID and given LOA on successful login

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/LogLogin.php
+++ b/library/EngineBlock/Corto/Filter/Command/LogLogin.php
@@ -48,12 +48,16 @@ class EngineBlock_Corto_Filter_Command_LogLogin extends EngineBlock_Corto_Filter
         // Remove the SP that is our next hop
         array_pop($requesterChain);
 
+        $originalResponse = ($this->_response->getOriginalResponse() ? $this->_response->getOriginalResponse() : $this->_response);
+
         $this->authenticationLogger->logLogin(
             $this->_serviceProvider,
             $this->_identityProvider,
             $this->_collabPersonId,
             $this->_request->getKeyId(),
-            $requesterChain
+            $requesterChain,
+            $originalResponse->getIntendedNameId(),
+            $originalResponse->getAttainedLoa()
         );
     }
 }

--- a/library/EngineBlock/Corto/Module/Service/ProcessedAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/ProcessedAssertionConsumer.php
@@ -81,11 +81,6 @@ class EngineBlock_Corto_Module_Service_ProcessedAssertionConsumer implements Eng
         }
 
          // Done processing! Send off to SP
-        $nextResponse = $currentProcess->getResponse();
-        $response->setDestination($nextResponse->getDestination());
-        $response->setDeliverByBinding($nextResponse->getOriginalIssuer());
-        $response->setOriginalIssuer($nextResponse->getOriginalBinding());
-
         $this->_server->unsetProcessingMode();
 
         $sentResponse = $this->_server->createEnhancedResponse($receivedRequest, $response);

--- a/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
@@ -233,6 +233,7 @@ class EngineBlock_Corto_Module_Service_StepupAssertionConsumer implements Engine
     {
         $processStep = $this->_processingStateHelper->getStepByRequestId($receivedRequest->getId(), ProcessingStateHelperInterface::STEP_STEPUP);
         $processStep->getResponse()->getAssertion()->setAuthnContextClassRef($loa->getIdentifier());
+        $processStep->getResponse()->setAttainedLoa($loa->getIdentifier()); // set attained loa so this could be logged later on
         $this->_processingStateHelper->updateStepResponseByRequestId($receivedRequest->getId(), ProcessingStateHelperInterface::STEP_STEPUP, $processStep->getResponse());
     }
 

--- a/library/EngineBlock/Saml2/ResponseAnnotationDecorator.php
+++ b/library/EngineBlock/Saml2/ResponseAnnotationDecorator.php
@@ -75,6 +75,11 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     protected $intendedNameId;
 
     /**
+     * @var string|null
+     */
+    protected $attainedLoa;
+
+    /**
      * @param Response $response
      */
     function __construct(Response $response)
@@ -262,6 +267,22 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     public function getOriginalIssuer()
     {
         return $this->originalIssuer;
+    }
+
+    /**
+     * @return \OpenConext\EngineBlock\Metadata\Loa
+     */
+    public function getAttainedLoa()
+    {
+        return $this->attainedLoa;
+    }
+
+    /**
+     * @param string|null $attainedLoa
+     */
+    public function setAttainedLoa($attainedLoa)
+    {
+        $this->attainedLoa = $attainedLoa;
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
+++ b/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
@@ -43,12 +43,14 @@ class AuthenticationLogger
      * KeyId is nullable in order to be able to differentiate between asking no specific key,
      * the default key KeyId('default') and a specific key.
      *
-     * @param Entity         $serviceProvider
-     * @param Entity         $identityProvider
+     * @param Entity $serviceProvider
+     * @param Entity $identityProvider
      * @param CollabPersonId $collabPersonId
-     * @param array          $proxiedServiceProviders
-     * @param string         $workflowState
-     * @param KeyId|null     $keyId
+     * @param array $proxiedServiceProviders
+     * @param string $workflowState
+     * @param string $originalNameId
+     * @param string|null $attainedLoa
+     * @param KeyId|null $keyId
      */
     public function logGrantedLogin(
         Entity $serviceProvider,
@@ -56,6 +58,8 @@ class AuthenticationLogger
         CollabPersonId $collabPersonId,
         array $proxiedServiceProviders,
         $workflowState,
+        $originalNameId,
+        $attainedLoa,
         KeyId $keyId = null
     ) {
         $proxiedServiceProviderEntityIds = array_map(
@@ -76,7 +80,9 @@ class AuthenticationLogger
                 'idp_entity_id'         => $identityProvider->getEntityId()->getEntityId(),
                 'key_id'                => $keyId ? $keyId->getKeyId() : null,
                 'proxied_sp_entity_ids' => $proxiedServiceProviderEntityIds,
-                'workflow_state'        => $workflowState
+                'workflow_state'        => $workflowState,
+                'original_name_id'      => $originalNameId,
+                'attained_loa'          => $attainedLoa,
             ]
         );
     }

--- a/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
+++ b/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
@@ -40,18 +40,22 @@ class AuthenticationLoggerAdapter
     }
 
     /**
-     * @param ServiceProvider   $serviceProvider
-     * @param IdentityProvider  $identityProvider
+     * @param ServiceProvider $serviceProvider
+     * @param IdentityProvider $identityProvider
      * @param                   $collabPersonId
      * @param                   $keyId
      * @param ServiceProvider[] $proxiedServiceProviders
+     * @param string $originalNameId
+     * @param string|null $attainedLoa
      */
     public function logLogin(
         ServiceProvider $serviceProvider,
         IdentityProvider $identityProvider,
         $collabPersonId,
         $keyId,
-        array $proxiedServiceProviders
+        array $proxiedServiceProviders,
+        $originalNameId,
+        $attainedLoa
     ) {
         $keyId = $keyId ? new KeyId($keyId) : null;
 
@@ -68,6 +72,8 @@ class AuthenticationLoggerAdapter
             new CollabPersonId($collabPersonId),
             $proxiedSpEntities,
             $serviceProvider->workflowState,
+            $originalNameId,
+            $attainedLoa,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
@@ -53,6 +53,8 @@ class AuthenticationLoggerTest extends TestCase
         $keyIdValue               = '20160403';
         $spProxy1EntityId         = 'SpProxy1EntityId';
         $spProxy2EntityId         = 'SpProxy2EntityId';
+        $originalNameId           = 'urn:collab:person:original:some-person';
+        $attainedLoa              = 'http://vm.openconext.org/assurance/loa1';
 
         $serviceProvider       = new Entity(new EntityId($serviceProviderEntityId), EntityType::SP());
         $identityProvider      = new Entity(new EntityId($identityProviderEntityId), EntityType::IdP());
@@ -69,6 +71,8 @@ class AuthenticationLoggerTest extends TestCase
             'key_id' => $keyIdValue,
             'proxied_sp_entity_ids' => [$spProxy1EntityId, $spProxy2EntityId],
             'workflow_state' => AbstractRole::WORKFLOW_STATE_PROD,
+            'original_name_id' => $originalNameId,
+            'attained_loa' => $attainedLoa,
         ];
 
         $mockLogger = m::mock('\Psr\Log\LoggerInterface');
@@ -107,6 +111,8 @@ class AuthenticationLoggerTest extends TestCase
             $collabPersonId,
             [$serviceProviderProxy1, $serviceProviderProxy2],
             AbstractRole::WORKFLOW_STATE_PROD,
+            $originalNameId,
+            $attainedLoa,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
@@ -27,6 +27,7 @@ use OpenConext\EngineBlock\Logger\AuthenticationLogger;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Loa;
 use OpenConext\Mockery\Matcher\ValueObjectEqualsMatcher;
 use OpenConext\Mockery\Matcher\ValueObjectListEqualsMatcher;
 use OpenConext\Value\Saml\Entity;
@@ -51,6 +52,8 @@ class AuthenticationLoggerAdapterTest extends TestCase
         $keyIdValue               = '20160403';
         $spProxy1EntityId         = 'SpProxy1EntityId';
         $spProxy2EntityId         = 'SpProxy2EntityId';
+        $originalNameId           = 'urn:collab:person:original:some-person';
+        $attainedLoa              = 'http://vm.openconext.org/assurance/loa1';
 
         $mockAuthenticationLogger = m::mock(AuthenticationLogger::class);
         $mockAuthenticationLogger
@@ -69,6 +72,8 @@ class AuthenticationLoggerAdapterTest extends TestCase
                         ]
                     ),
                     AbstractRole::WORKFLOW_STATE_PROD,
+                    $originalNameId,
+                    $attainedLoa,
                     new ValueObjectEqualsMatcher(new KeyId($keyIdValue)),
                 ]
             )
@@ -83,7 +88,9 @@ class AuthenticationLoggerAdapterTest extends TestCase
             [
                 new ServiceProvider($spProxy1EntityId),
                 new ServiceProvider($spProxy2EntityId),
-            ]
+            ],
+            $originalNameId,
+            $attainedLoa
         );
     }
 }


### PR DESCRIPTION
The original NameID and attained LOA were missing and are now added
to the 'login granted' log.

https://www.pivotaltracker.com/story/show/171404731

The node-sass security warning is fixed in https://github.com/OpenConext/OpenConext-engineblock/pull/847.