### PR TITLE
If the SP provided a RequestedAuthnContext in the AuthnRequest, replicate this to the IdP

### DIFF
--- a/library/EngineBlock/Saml2/AuthnRequestFactory.php
+++ b/library/EngineBlock/Saml2/AuthnRequestFactory.php
@@ -51,6 +51,7 @@ class EngineBlock_Saml2_AuthnRequestFactory
         $sspRequest->setDestination($idpMetadata->singleSignOnServices[0]->location);
         $sspRequest->setForceAuthn($originalRequest->getForceAuthn());
         $sspRequest->setIsPassive($originalRequest->getIsPassive());
+        $sspRequest->setRequestedAuthnContext($originalRequest->getRequestedAuthnContext());
         $sspRequest->setAssertionConsumerServiceURL($server->getUrl($acsServiceName));
         $sspRequest->setProtocolBinding(Constants::BINDING_HTTP_POST);
         $sspRequest->setIssuer($server->getUrl($issuerServiceName));

--- a/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/ProxyServerTest.php
@@ -98,6 +98,45 @@ class EngineBlock_Test_Corto_ProxyServerTest extends TestCase
         $this->assertEquals($nameIdPolicy['Format'], 'fooFormat');
     }
 
+    public function testRequestedAuthnContextNotSetByDefault()
+    {
+        $proxyServer = $this->factoryProxyServer();
+
+        $originalRequest = $this->factoryOriginalRequest();
+
+        $identityProvider = $proxyServer->getRepository()->fetchIdentityProviderByEntityId('testIdp');
+        /** @var AuthnRequest $enhancedRequest */
+        $enhancedRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest(
+            $originalRequest,
+            $identityProvider,
+            $proxyServer
+        );
+
+        $authnContext = $enhancedRequest->getRequestedAuthnContext();
+        $this->assertNull($authnContext);
+    }
+
+    public function testRequestedAuthnContextIsSetFromOriginalRequest()
+    {
+        $proxyServer = $this->factoryProxyServer();
+
+        $originalRequest = $this->factoryOriginalRequest();
+        $originalRequest->setRequestedAuthnContext(['AuthnContextClassRef' => ['urn:mace:surfnet.nl:my-context-class']]);
+
+        $identityProvider = $proxyServer->getRepository()->fetchIdentityProviderByEntityId('testIdp');
+        /** @var AuthnRequest $enhancedRequest */
+        $enhancedRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest(
+            $originalRequest,
+            $identityProvider,
+            $proxyServer
+        );
+
+        $authnContext = $enhancedRequest->getRequestedAuthnContext();
+        $this->assertCount(1, $authnContext);
+        $this->assertCount(1, $authnContext['AuthnContextClassRef']);
+        $this->assertEquals($authnContext['AuthnContextClassRef'][0], 'urn:mace:surfnet.nl:my-context-class');
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
This allows the SP to communicate e.g. desired authentication parameters (strength) to the IdP in a generic way.