### PR TITLE
Allow empty sfo key

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 1. [Release Procedure][release]
 1. [EngineBlock Input and Output Command Chains][filter]
 1. [Attribute Aggregation](attribute_aggregation.md)
+1. [Stepup second factor integration](stepup_callout.md)
 1. [Release notes for releases < 5.0.0][release-notes]
 1. [Javscript testing][js-testing]
 

--- a/docs/stepup_callout.md
+++ b/docs/stepup_callout.md
@@ -1,0 +1,33 @@
+# Engineblock Stepup second factor integration
+
+It's possible to require second factor authentication in EngineBlock using OpenConext StepUp in second factor only (SFO) mode. When configured correctly, EngineBlock will utilize StepUp Gateways SFO to do a second factor callout. In order to do so the EB configuration needs to be configured in a certain way to allow this on a per IdP or per SP basis. The following coin metadata attributes need to be passed from the Manage (or other software) instance that is pushing EngineBlock metadata into EngineBlock.
+
+
+## Engineblock metadata configuration
+### SP
+#### metadata:coin:stepup:allow_no_token
+**Type:** boolean
+
+To continue with LOA 1 if no second factor token found
+
+#### metadata:coin:stepup:requireloa
+The LOA minimal required
+
+**Type:** boolean
+
+
+
+
+### IdP
+#### metadata:coin:stepup_connections
+
+**Type:** object
+* name: _entityId_,
+* level: _requiredLoa_
+
+An entry per SP which should use the SFO capabilities.
+
+
+## Engineblock global configuration
+The EngineBlock installation also needs additional configuration in order to facilitate the SFO second factor authentications. For details on these configuration settings, please review the SFO section in the [app/config/parameters.yml.dist](app/config/parameters.yml.dist) file.
+

--- a/src/OpenConext/EngineBlock/Exception/MissingStepupEndpointConfigurationException.php
+++ b/src/OpenConext/EngineBlock/Exception/MissingStepupEndpointConfigurationException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Exception;
+
+use InvalidArgumentException as CoreInvalidArgumentException;
+
+class MissingStepupEndpointConfigurationException extends CoreInvalidArgumentException implements Exception
+{
+
+}

--- a/src/OpenConext/EngineBlock/Stepup/StepupEndpoint.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupEndpoint.php
@@ -42,8 +42,8 @@ class StepupEndpoint
     {
         Assertion::string($entityId, 'EntityId should be a string');
         Assertion::string($ssoLocation, 'SSO location should be a string');
-        Assertion::string($keyFile, 'KeyFile should be a string');
-        Assertion::file($keyFile, sprintf("Keyfile '%s' should be a valid file", $keyFile));
+        Assertion::nullOrString($keyFile, 'KeyFile should be a string');
+        Assertion::nullOrFile($keyFile, sprintf("Keyfile '%s' should be a valid file", $keyFile));
 
         $this->entityId = $entityId;
         $this->ssoLocation = $ssoLocation;

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-namespace OpenConext\EngineBlockBundle\Tests;
+namespace OpenConext\EngineBlock\Stepup;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupGatewayLoaMappingTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupGatewayLoaMappingTest.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-namespace OpenConext\EngineBlockBundle\Tests;
+namespace OpenConext\EngineBlock\Stepup;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;


### PR DESCRIPTION
Allow empty SFO key to support EB without SFO. This change will allow SFO configuration without a valid key needed in the configuration.

https://github.com/OpenConext/OpenConext-engineblock/issues/852