### PR TITLE
Log AuthnContextClassRef on successful login

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/LogLogin.php
+++ b/library/EngineBlock/Corto/Filter/Command/LogLogin.php
@@ -48,16 +48,14 @@ class EngineBlock_Corto_Filter_Command_LogLogin extends EngineBlock_Corto_Filter
         // Remove the SP that is our next hop
         array_pop($requesterChain);
 
-        $originalResponse = ($this->_response->getOriginalResponse() ? $this->_response->getOriginalResponse() : $this->_response);
-
         $this->authenticationLogger->logLogin(
             $this->_serviceProvider,
             $this->_identityProvider,
             $this->_collabPersonId,
             $this->_request->getKeyId(),
             $requesterChain,
-            $originalResponse->getIntendedNameId(),
-            $originalResponse->getAttainedLoa()
+            $this->_response->getNameIdValue(),
+            $this->_response->getAssertion()->getAuthnContextClassRef()
         );
     }
 }

--- a/library/EngineBlock/Corto/Module/Service/ProcessedAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/ProcessedAssertionConsumer.php
@@ -55,7 +55,6 @@ class EngineBlock_Corto_Module_Service_ProcessedAssertionConsumer implements Eng
             $this->_server->setKeyId($receivedRequest->getKeyId());
         }
 
-        $currentProcess = $this->_processingStateHelper->getStepByRequestId($receivedRequest->getId(), ProcessingStateHelperInterface::STEP_CONSENT);
         $this->_processingStateHelper->clearStepByRequestId($receivedRequest->getId());
 
         $wantlogging = true;

--- a/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
@@ -233,7 +233,6 @@ class EngineBlock_Corto_Module_Service_StepupAssertionConsumer implements Engine
     {
         $processStep = $this->_processingStateHelper->getStepByRequestId($receivedRequest->getId(), ProcessingStateHelperInterface::STEP_STEPUP);
         $processStep->getResponse()->getAssertion()->setAuthnContextClassRef($loa->getIdentifier());
-        $processStep->getResponse()->setAttainedLoa($loa->getIdentifier()); // set attained loa so this could be logged later on
         $this->_processingStateHelper->updateStepResponseByRequestId($receivedRequest->getId(), ProcessingStateHelperInterface::STEP_STEPUP, $processStep->getResponse());
     }
 

--- a/library/EngineBlock/Saml2/ResponseAnnotationDecorator.php
+++ b/library/EngineBlock/Saml2/ResponseAnnotationDecorator.php
@@ -75,11 +75,6 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     protected $intendedNameId;
 
     /**
-     * @var string|null
-     */
-    protected $attainedLoa;
-
-    /**
      * @param Response $response
      */
     function __construct(Response $response)
@@ -267,22 +262,6 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     public function getOriginalIssuer()
     {
         return $this->originalIssuer;
-    }
-
-    /**
-     * @return \OpenConext\EngineBlock\Metadata\Loa
-     */
-    public function getAttainedLoa()
-    {
-        return $this->attainedLoa;
-    }
-
-    /**
-     * @param string|null $attainedLoa
-     */
-    public function setAttainedLoa($attainedLoa)
-    {
-        $this->attainedLoa = $attainedLoa;
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
+++ b/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
@@ -49,7 +49,7 @@ class AuthenticationLogger
      * @param array $proxiedServiceProviders
      * @param string $workflowState
      * @param string $originalNameId
-     * @param string|null $attainedLoa
+     * @param string|null $authnContextClassRef
      * @param KeyId|null $keyId
      */
     public function logGrantedLogin(
@@ -59,7 +59,7 @@ class AuthenticationLogger
         array $proxiedServiceProviders,
         $workflowState,
         $originalNameId,
-        $attainedLoa,
+        $authnContextClassRef,
         KeyId $keyId = null
     ) {
         $proxiedServiceProviderEntityIds = array_map(
@@ -82,7 +82,7 @@ class AuthenticationLogger
                 'proxied_sp_entity_ids' => $proxiedServiceProviderEntityIds,
                 'workflow_state'        => $workflowState,
                 'original_name_id'      => $originalNameId,
-                'attained_loa'          => $attainedLoa,
+                'authncontextclassref'  => $authnContextClassRef,
             ]
         );
     }

--- a/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
+++ b/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
@@ -46,7 +46,7 @@ class AuthenticationLoggerAdapter
      * @param                   $keyId
      * @param ServiceProvider[] $proxiedServiceProviders
      * @param string $originalNameId
-     * @param string|null $attainedLoa
+     * @param string|null $authnContextClassRef
      */
     public function logLogin(
         ServiceProvider $serviceProvider,
@@ -55,7 +55,7 @@ class AuthenticationLoggerAdapter
         $keyId,
         array $proxiedServiceProviders,
         $originalNameId,
-        $attainedLoa
+        $authnContextClassRef
     ) {
         $keyId = $keyId ? new KeyId($keyId) : null;
 
@@ -73,7 +73,7 @@ class AuthenticationLoggerAdapter
             $proxiedSpEntities,
             $serviceProvider->workflowState,
             $originalNameId,
-            $attainedLoa,
+            $authnContextClassRef,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
@@ -54,7 +54,7 @@ class AuthenticationLoggerTest extends TestCase
         $spProxy1EntityId         = 'SpProxy1EntityId';
         $spProxy2EntityId         = 'SpProxy2EntityId';
         $originalNameId           = 'urn:collab:person:original:some-person';
-        $attainedLoa              = 'http://vm.openconext.org/assurance/loa1';
+        $authnContextClassRef     = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
 
         $serviceProvider       = new Entity(new EntityId($serviceProviderEntityId), EntityType::SP());
         $identityProvider      = new Entity(new EntityId($identityProviderEntityId), EntityType::IdP());
@@ -72,7 +72,7 @@ class AuthenticationLoggerTest extends TestCase
             'proxied_sp_entity_ids' => [$spProxy1EntityId, $spProxy2EntityId],
             'workflow_state' => AbstractRole::WORKFLOW_STATE_PROD,
             'original_name_id' => $originalNameId,
-            'attained_loa' => $attainedLoa,
+            'authncontextclassref' => $authnContextClassRef,
         ];
 
         $mockLogger = m::mock('\Psr\Log\LoggerInterface');
@@ -112,7 +112,7 @@ class AuthenticationLoggerTest extends TestCase
             [$serviceProviderProxy1, $serviceProviderProxy2],
             AbstractRole::WORKFLOW_STATE_PROD,
             $originalNameId,
-            $attainedLoa,
+            $authnContextClassRef,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
@@ -53,7 +53,7 @@ class AuthenticationLoggerAdapterTest extends TestCase
         $spProxy1EntityId         = 'SpProxy1EntityId';
         $spProxy2EntityId         = 'SpProxy2EntityId';
         $originalNameId           = 'urn:collab:person:original:some-person';
-        $attainedLoa              = 'http://vm.openconext.org/assurance/loa1';
+        $authnContextClassRef     = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
 
         $mockAuthenticationLogger = m::mock(AuthenticationLogger::class);
         $mockAuthenticationLogger
@@ -73,7 +73,7 @@ class AuthenticationLoggerAdapterTest extends TestCase
                     ),
                     AbstractRole::WORKFLOW_STATE_PROD,
                     $originalNameId,
-                    $attainedLoa,
+                    $authnContextClassRef,
                     new ValueObjectEqualsMatcher(new KeyId($keyIdValue)),
                 ]
             )
@@ -90,7 +90,7 @@ class AuthenticationLoggerAdapterTest extends TestCase
                 new ServiceProvider($spProxy2EntityId),
             ],
             $originalNameId,
-            $attainedLoa
+            $authnContextClassRef
         );
     }
 }


### PR DESCRIPTION
The Loa was not logged when AM was being used. This change
logs the authncontextclassref instead which won't get lost during
deserializing the entiy when using AM.

https://www.pivotaltracker.com/story/show/171404731