### PR TITLE
Change symfony cache path to reflect deploy path

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -64,7 +64,7 @@ class AppKernel extends Kernel
         // In the dev & test environments use a folder outside the shared filesystem. This greatly improves cache clear
         // and warmup time.
         if ($this->getEnvironment() === 'dev' || $this->getEnvironment() === 'test') {
-            return sprintf('/tmp/eb_cache/%s', $this->getEnvironment());
+            return sprintf('/tmp/engineblock/cache/%s', $this->getEnvironment());
         }
 
         return $this->rootDir . '/cache/' . $this->environment;


### PR DESCRIPTION
In deploy a different cache and log path are used. When performing a
clean install this will result in errors because an unknown path is
being used. This change will resolve that.