### PR TITLE
Assemble authcontextclassref combinations

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -70,7 +70,8 @@ class Coins
         $stepupConnections,
         $disableScoping,
         $additionalLogging,
-        $signatureMethod
+        $signatureMethod,
+        $mfaEntities
     ) {
         return new self([
             'guestQualifier' => $guestQualifier,
@@ -80,6 +81,7 @@ class Coins
             'additionalLogging' => $additionalLogging,
             'signatureMethod' => $signatureMethod,
             'stepupConnections' => $stepupConnections,
+            'mfaEntities' => $mfaEntities,
         ]);
     }
 
@@ -210,6 +212,11 @@ class Coins
     public function signatureMethod()
     {
         return $this->getValue('signatureMethod', XMLSecurityKey::RSA_SHA256);
+    }
+
+    public function mfaEntities(): MfaEntityCollection
+    {
+        return $this->getValue('mfaEntities', MfaEntityCollection::fromArray([]));
     }
 
     private function getValue($key, $default = null)

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -615,7 +615,15 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         if (!isset($connection->mfa_entities)) {
             return [];
         }
-        $entities = json_decode(json_encode($connection->mfa_entities), true);
+
+        $entities = [];
+        foreach ($connection->mfa_entities as $sp) {
+            $entities[] = [
+                'name' => (string)$sp->name,
+                'level' => (string)$sp->level,
+            ];
+        }
+
         return [
             'mfaEntities' => MfaEntityCollection::fromArray($entities)
         ];

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -26,6 +26,7 @@ use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\IndexedService;
 use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\MfaEntityCollection;
 use OpenConext\EngineBlock\Metadata\Organization;
 use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\ShibMdScope;
@@ -268,6 +269,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         $properties += $this->assembleShibMdScopes($connection);
 
         $properties += $this->assembleStepupConnections($connection);
+        $properties += $this->assembleMfaEntities($connection);
 
         return Utils::instantiate(
             IdentityProvider::class,
@@ -606,5 +608,16 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
                 (array) $connection->arp_attributes
             )
         );
+    }
+
+    private function assembleMfaEntities(stdClass $connection): array
+    {
+        if (!isset($connection->mfa_entities)) {
+            return [];
+        }
+        $entities = json_decode(json_encode($connection->mfa_entities), true);
+        return [
+            'mfaEntities' => MfaEntityCollection::fromArray($entities)
+        ];
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -24,6 +24,7 @@ use OpenConext\EngineBlock\Metadata\ConsentSettings;
 use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
+use OpenConext\EngineBlock\Metadata\MfaEntityCollection;
 use OpenConext\EngineBlock\Metadata\Organization;
 use OpenConext\EngineBlock\Metadata\ShibMdScope;
 use OpenConext\EngineBlock\Metadata\Service;
@@ -125,6 +126,7 @@ class IdentityProvider extends AbstractRole
      * @param array $singleSignOnServices
      * @param ConsentSettings $consentSettings
      * @param StepupConnections|null $stepupConnections
+     * @param MfaEntityCollection|null $mfaEntities
      */
     public function __construct(
         $entityId,
@@ -165,7 +167,8 @@ class IdentityProvider extends AbstractRole
         $shibMdScopes = array(),
         $singleSignOnServices = array(),
         ConsentSettings $consentSettings = null,
-        StepupConnections $stepupConnections = null
+        StepupConnections $stepupConnections = null,
+        MfaEntityCollection $mfaEntities = null
     ) {
         parent::__construct(
             $entityId,
@@ -207,7 +210,8 @@ class IdentityProvider extends AbstractRole
             $stepupConnections,
             $disableScoping,
             $additionalLogging,
-            $signatureMethod
+            $signatureMethod,
+            $mfaEntities
         );
     }
 

--- a/src/OpenConext/EngineBlock/Metadata/MfaEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/MfaEntity.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use JsonSerializable;
+
+class MfaEntity implements JsonSerializable
+{
+    /**
+     * @var string $entityId
+     */
+    private $entityId;
+
+    /**
+     * @var string $level
+     */
+    private $level;
+
+    public function __construct(string $entityId, string $level)
+    {
+        $this->entityId = $entityId;
+        $this->level = $level;
+    }
+
+    public function entityId(): string
+    {
+        return $this->entityId;
+    }
+
+    /**
+     * @param $entityId
+     * @return string|null
+     */
+    public function level(): string
+    {
+        return $this->level;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'entityId' => $this->entityId,
+            'level' => $this->level,
+        ];
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/MfaEntityCollection.php
+++ b/src/OpenConext/EngineBlock/Metadata/MfaEntityCollection.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use Countable;
+use JsonSerializable;
+use OpenConext\EngineBlock\Assert\Assertion;
+
+class MfaEntityCollection implements JsonSerializable, Countable
+{
+    /**
+     * @var array $entities
+     */
+    private $entities = [];
+
+    public static function fromArray(array $data): MfaEntityCollection
+    {
+        $entities = [];
+        foreach ($data as $mfaEntityData) {
+            $entityId = (string) $mfaEntityData['name'];
+            $level = (string) $mfaEntityData['level'];
+            Assertion::keyNotExists($entities, $entityId, 'Duplicate SP entity ids are not allowed');
+            $entities[$entityId] = new MfaEntity($entityId, $level);
+        }
+        return new self($entities);
+    }
+
+    public function findByEntityId(string $entityId): ?MfaEntity
+    {
+        if (!array_key_exists($entityId, $this->entities)) {
+            return null;
+        }
+        return $this->entities[$entityId];
+    }
+
+    public function count(): int
+    {
+        return count($this->entities);
+    }
+
+    /**
+     * @param MfaEntity[] $entities
+     */
+    private function __construct(array $entities)
+    {
+        Assertion::allIsInstanceOf($entities, MfaEntity::class);
+        $this->entities = $entities;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->entities;
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Metadata/MfaEntityCollectionTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/MfaEntityCollectionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class MfaEntityCollectionTest extends TestCase
+{
+    public function test_works_with_empty_data()
+    {
+        $collection = MfaEntityCollection::fromArray([]);
+        $this->assertCount(0, $collection);
+    }
+
+    public function test_works_with_correct_data()
+    {
+        $collection = MfaEntityCollection::fromArray($this->validData());
+        $this->assertCount(2, $collection);
+        $entity = $collection->findByEntityId('https://teams.vm.openconext.org/shibboleth');
+        $this->assertInstanceOf(MfaEntity::class, $entity);
+        $this->assertEquals('https://teams.vm.openconext.org/shibboleth', $entity->entityId());
+        $this->assertEquals('http://schemas.microsoft.com/claims/multipleauthn', $entity->level());
+
+        $entity = $collection->findByEntityId('https://aa.vm.openconext.org/shibboleth');
+        $this->assertInstanceOf(MfaEntity::class, $entity);
+        $this->assertEquals('https://aa.vm.openconext.org/shibboleth', $entity->entityId());
+        $this->assertEquals('http://schemas.microsoft.com/claims/multipleauthn', $entity->level());
+    }
+
+    public function test_find_by_can_return_null()
+    {
+        $data = [
+            [
+                "name" => "https://teams.vm.openconext.org/shibboleth",
+                "level" => "http://schemas.microsoft.com/claims/multipleauthn",
+            ],
+        ];
+        $collection = MfaEntityCollection::fromArray($data);
+        $this->assertNull($collection->findByEntityId('tjoeptjoep'));
+    }
+
+    public function test_rejects_duplicate_entity_ids()
+    {
+        $data = [
+            [
+                "name" => "https://teams.vm.openconext.org/shibboleth",
+                "level" => "http://schemas.microsoft.com/claims/multipleauthn",
+            ],
+            [
+                "name" => "https://teams.vm.openconext.org/shibboleth",
+                "level" => "http://schemas.microsoft.com/claims/multipleauthn",
+            ],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Duplicate SP entity ids are not allowed');
+        MfaEntityCollection::fromArray($data);
+    }
+
+    private function validData(): array
+    {
+        return [
+            [
+                "name" => "https://teams.vm.openconext.org/shibboleth",
+                "level" => "http://schemas.microsoft.com/claims/multipleauthn",
+            ],
+            [
+                "name" => "https://aa.vm.openconext.org/shibboleth",
+                "level" => "http://schemas.microsoft.com/claims/multipleauthn",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Added ability to read the `mfa_entities` data from the Manage metadata push.

For some reason Travis no longer reports back to Github on the build status. But the link below can be used for details about the QA build.

Note: Build breaks on security issue that should be resolved in a separate PR
See: https://www.pivotaltracker.com/story/show/172718043
See: https://travis-ci.org/github/OpenConext/OpenConext-engineblock/builds/704306933