### PR TITLE
Implement the special case AuthnContextClassRef config option for transparent RequestedAuthnContext

### DIFF
--- a/library/EngineBlock/Saml2/AuthnRequestAnnotationDecorator.php
+++ b/library/EngineBlock/Saml2/AuthnRequestAnnotationDecorator.php
@@ -72,6 +72,14 @@ class EngineBlock_Saml2_AuthnRequestAnnotationDecorator extends EngineBlock_Saml
         return $this->sspMessage->getRequesterID();
     }
 
+    /**
+     * @return array|null
+     */
+    public function getRequestedAuthnContext()
+    {
+        return $this->sspMessage->getRequestedAuthnContext();
+    }
+
     public function setDebugRequest()
     {
         $this->debug = true;

--- a/src/OpenConext/EngineBlock/Metadata/MfaEntityCollection.php
+++ b/src/OpenConext/EngineBlock/Metadata/MfaEntityCollection.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlock\Metadata;
 
+use Assert\AssertionFailedException;
 use Countable;
 use JsonSerializable;
 use OpenConext\EngineBlock\Assert\Assertion;
@@ -33,7 +34,7 @@ class MfaEntityCollection implements JsonSerializable, Countable
      * This method is used to build the collection from a metadata push
      * @param array $data
      * @return MfaEntityCollection
-     * @throws \Assert\AssertionFailedException
+     * @throws AssertionFailedException
      */
     public static function fromMetadataPush(array $data): MfaEntityCollection
     {
@@ -42,7 +43,7 @@ class MfaEntityCollection implements JsonSerializable, Countable
             $entityId = (string) $mfaEntityData['name'];
             $level = (string) $mfaEntityData['level'];
             Assertion::keyNotExists($entities, $entityId, 'Duplicate SP entity ids are not allowed');
-            $entities[$entityId] = new MfaEntity($entityId, $level);
+            $entities[$entityId] = MfaEntityFactory::from($entityId, $level);
         }
         return new self($entities);
     }
@@ -51,20 +52,20 @@ class MfaEntityCollection implements JsonSerializable, Countable
      * This method is used tto deserialize coin data
      * @param array $data
      * @return MfaEntityCollection
-     * @throws \Assert\AssertionFailedException
+     * @throws AssertionFailedException
      */
     public static function fromCoin(array $data): MfaEntityCollection
     {
         $entities = [];
         foreach ($data as $mfaEntityData) {
-            $entity = MfaEntity::fromJson($mfaEntityData);
+            $entity = MfaEntityFactory::fromJson($mfaEntityData);
             Assertion::keyNotExists($entities, $entity->entityId(), 'Duplicate SP entity ids are not allowed');
             $entities[$entity->entityId()] = $entity;
         }
         return new self($entities);
     }
 
-    public function findByEntityId(string $entityId): ?MfaEntity
+    public function findByEntityId(string $entityId): ?MfaEntityInterface
     {
         if (!array_key_exists($entityId, $this->entities)) {
             return null;
@@ -78,11 +79,11 @@ class MfaEntityCollection implements JsonSerializable, Countable
     }
 
     /**
-     * @param MfaEntity[] $entities
+     * @param MfaEntityInterface[] $entities
      */
     private function __construct(array $entities)
     {
-        Assertion::allIsInstanceOf($entities, MfaEntity::class);
+        Assertion::allIsInstanceOf($entities, MfaEntityInterface::class);
         $this->entities = $entities;
     }
 

--- a/src/OpenConext/EngineBlock/Metadata/MfaEntityFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/MfaEntityFactory.php
@@ -22,7 +22,7 @@ use OpenConext\EngineBlock\Assert\Assertion;
 
 class MfaEntityFactory
 {
-    private const TRANSPARENT_AUTHN_CONTEXT = 'transparant_authn_context';
+    private const TRANSPARENT_AUTHN_CONTEXT = 'transparent_authn_context';
 
     public static function from(string $entityId, string $level)
     {

--- a/src/OpenConext/EngineBlock/Metadata/MfaEntityFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/MfaEntityFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use OpenConext\EngineBlock\Assert\Assertion;
+
+class MfaEntityFactory
+{
+    private const TRANSPARENT_AUTHN_CONTEXT = 'transparant_authn_context';
+
+    public static function from(string $entityId, string $level)
+    {
+        if ($level === self::TRANSPARENT_AUTHN_CONTEXT) {
+            return new TransparentMfaEntity($entityId, $level);
+        }
+
+        return new MfaEntity($entityId, $level);
+    }
+
+    public static function fromJson($mfaEntityData)
+    {
+        Assertion::keyExists($mfaEntityData, 'entityId', 'MFA entityId must be specified');
+        Assertion::keyExists($mfaEntityData, 'level', 'MFA entity level must be specified');
+        Assertion::string($mfaEntityData['entityId'], 'MFA entityId must be of type string');
+        Assertion::string($mfaEntityData['level'], 'MFA level must be of type string');
+
+        if ($mfaEntityData['level'] === self::TRANSPARENT_AUTHN_CONTEXT) {
+            return new TransparentMfaEntity($mfaEntityData['entityId'], $mfaEntityData['level']);
+        }
+
+        return new MfaEntity($mfaEntityData['entityId'], $mfaEntityData['level']);
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/MfaEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/MfaEntityInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+interface MfaEntityInterface
+{
+    public function entityId(): string;
+
+    public function level(): string;
+}

--- a/src/OpenConext/EngineBlock/Metadata/TransparentMfaEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/TransparentMfaEntity.php
@@ -19,9 +19,8 @@
 namespace OpenConext\EngineBlock\Metadata;
 
 use JsonSerializable;
-use OpenConext\EngineBlock\Assert\Assertion;
 
-class MfaEntity implements MfaEntityInterface, JsonSerializable
+class TransparentMfaEntity implements MfaEntityInterface, JsonSerializable
 {
     /**
      * @var string $entityId

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -637,4 +637,15 @@ class MockSpContext extends AbstractSubContext
 
         $this->mockSpRegistry->save();
     }
+
+    /**
+     * @Given /^the SP "([^"]*)" sends AuthnContextClassRef with value "([^"]*)"$/
+     */
+    public function theSPSendsAuthnContextClassRefWithValue($spName, $authnContextClassRefValue)
+    {
+        $mockSp = $this->mockSpRegistry->get($spName);
+        $request = $mockSp->getAuthnRequest();
+        $request->setRequestedAuthnContext(['AuthnContextClassRef' => [$authnContextClassRefValue]]);
+        $this->mockSpRegistry->save();
+    }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
@@ -57,3 +57,19 @@ Feature:
       And I pass through the IdP
     Then I should see "Error - Multi factor authentication failed"
       And the url should match "/authentication/feedback/invalid-mfa-authn-context-class-ref"
+
+  Scenario: The SP provided authn method should be set as AuthnContextClassRef if SP configured with transparent_authn_context
+    Given the IdP "SSO-IdP" is configured for MFA authn method "transparent_authn_context" for SP "SSO-SP"
+    And the SP "SSO-SP" sends AuthnContextClassRef with value "http://my-very-own-context.example.com/level9"
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SSO-IdP/sso"
+    And the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef[text()="http://my-very-own-context.example.com/level9"]'
+
+  Scenario: The SP provided authn method should NOT be set as AuthnContextClassRef if SP configured is not with transparent_authn_context
+    Given the IdP "SSO-IdP" is configured for MFA authn method "not_configured_transparent_authn_context" for SP "SSO-SP"
+    And the SP "SSO-SP" sends AuthnContextClassRef with value "http://my-very-own-context.example.com/level9"
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SSO-IdP/sso"
+    And the response should not contain "http://my-very-own-context.example.com/level9"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockServiceProvider.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Mock/MockServiceProvider.php
@@ -171,4 +171,14 @@ class MockServiceProvider extends AbstractMockEntityRole
     {
         return SPSSODescriptor::class;
     }
+
+    public function getAuthnContextClassRef(): string
+    {
+        return $this->descriptor->Extensions['AuthnContextClassRef'] ?? '';
+    }
+
+    public function setAuthnContextClassRef($classRef)
+    {
+        $this->descriptor->Extensions['AuthnContextClassRef'] = $classRef;
+    }
 }

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -23,6 +23,7 @@ use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\MfaEntityCollection;
 use OpenConext\EngineBlock\Metadata\StepupConnections;
+use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
 use OpenConext\EngineBlock\Validator\AllowedSchemeValidator;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -290,6 +291,40 @@ class PushMetadataAssemblerTest extends TestCase
         $mfaEntities = $idp->getCoins()->mfaEntities();
         $this->assertInstanceOf(MfaEntityCollection::class, $mfaEntities);
         $this->assertCount(0, $mfaEntities);
+    }
+
+    public function test_it_assembles_mfa_entity_settings_with_transparent_option()
+    {
+        $connection = '{
+            "2d96e27a-76cf-4ca2-ac70-ece5d4c49524": {
+                "mfa_entities": [{
+                    "name": "https://teams.vm.openconext.org/shibboleth",
+                    "level": "http://schemas.microsoft.com/claims/multipleauthn"
+                }, {
+                    "name": "https://aa.vm.openconext.org/shibboleth",
+                    "level": "http://schemas.microsoft.com/claims/multipleauthn"
+                }, {
+                    "name": "https://test-sp.vm.openconext.org",
+                    "level": "transparent_authn_context"
+                }],
+                "name": "https:\/\/serviceregistry.vm.openconext.org\/simplesaml\/module.php\/saml\/sp\/metadata.php\/default-idp",
+                "state": "prodaccepted",
+                "type": "saml20-idp"
+            }
+	    }';
+
+        $input = json_decode($connection);
+
+        $connections = $this->assembler->assemble($input);
+
+        /** @var IdentityProvider $idp */
+        $idp = $connections[0];
+        $this->assertInstanceOf(IdentityProvider::class, $idp);
+        $mfaEntities = $idp->getCoins()->mfaEntities();
+        $this->assertInstanceOf(MfaEntityCollection::class, $mfaEntities);
+        $this->assertCount(3, $mfaEntities);
+        $transparent = $mfaEntities->findByEntityId('https://test-sp.vm.openconext.org');
+        $this->assertInstanceOf(TransparentMfaEntity::class, $transparent);
     }
 
     public function invalidAcsLocations()

--- a/tests/unit/OpenConext/EngineBlock/Metadata/MfaEntityFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/MfaEntityFactoryTest.php
@@ -24,7 +24,7 @@ class MfaEntityFactoryTest extends TestCase
 {
     public function test_it_distinguishes_between_regular_and_transparent_entities()
     {
-        $this->assertInstanceOf(TransparentMfaEntity::class, MfaEntityFactory::from('https://example.com', 'transparant_authn_context'));
+        $this->assertInstanceOf(TransparentMfaEntity::class, MfaEntityFactory::from('https://example.com', 'transparent_authn_context'));
         $this->assertInstanceOf(MfaEntity::class, MfaEntityFactory::from('https://example.com', 'http://schemas.microsoft.com/claims/multipleauthn'));
     }
 
@@ -32,7 +32,7 @@ class MfaEntityFactoryTest extends TestCase
     {
         $data = [
             'entityId' => 'https://example.com',
-            'level' => 'transparant_authn_context',
+            'level' => 'transparent_authn_context',
         ];
         $this->assertInstanceOf(TransparentMfaEntity::class, MfaEntityFactory::fromJson($data));
         $data['level'] = 'http://schemas.microsoft.com/claims/multipleauthn';
@@ -51,11 +51,11 @@ class MfaEntityFactoryTest extends TestCase
 
     public function provideInvalidJsonData()
     {
-        yield [['entityId' => null, 'level' => 'transparant_authn_context'], 'MFA entityId must be of type string'];
-        yield [['entityId' => 0, 'level' => 'transparant_authn_context'], 'MFA entityId must be of type string'];
-        yield [['entityId' => true, 'level' => 'transparant_authn_context'], 'MFA entityId must be of type string'];
-        yield [['entityIde' => true, 'level' => 'transparant_authn_context'], 'MFA entityId must be specified'];
-        yield [['level' => 'transparant_authn_context'], 'MFA entityId must be specified'];
+        yield [['entityId' => null, 'level' => 'transparent_authn_context'], 'MFA entityId must be of type string'];
+        yield [['entityId' => 0, 'level' => 'transparent_authn_context'], 'MFA entityId must be of type string'];
+        yield [['entityId' => true, 'level' => 'transparent_authn_context'], 'MFA entityId must be of type string'];
+        yield [['entityIde' => true, 'level' => 'transparent_authn_context'], 'MFA entityId must be specified'];
+        yield [['level' => 'transparent_authn_context'], 'MFA entityId must be specified'];
         yield [['entityId' => 'https://example.com', 'level' => 0], 'MFA level must be of type string'];
         yield [['entityId' => 'https://example.com', 'level' => false], 'MFA level must be of type string'];
         yield [['entityId' => 'https://example.com', 'level' => null], 'MFA level must be of type string'];

--- a/tests/unit/OpenConext/EngineBlock/Metadata/MfaEntityFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/MfaEntityFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use PHPUnit\Framework\TestCase;
+
+class MfaEntityFactoryTest extends TestCase
+{
+    public function test_it_distinguishes_between_regular_and_transparent_entities()
+    {
+        $this->assertInstanceOf(TransparentMfaEntity::class, MfaEntityFactory::from('https://example.com', 'transparant_authn_context'));
+        $this->assertInstanceOf(MfaEntity::class, MfaEntityFactory::from('https://example.com', 'http://schemas.microsoft.com/claims/multipleauthn'));
+    }
+
+    public function test_it_distinguishes_between_regular_and_transparent_entities_from_json()
+    {
+        $data = [
+            'entityId' => 'https://example.com',
+            'level' => 'transparant_authn_context',
+        ];
+        $this->assertInstanceOf(TransparentMfaEntity::class, MfaEntityFactory::fromJson($data));
+        $data['level'] = 'http://schemas.microsoft.com/claims/multipleauthn';
+        $this->assertInstanceOf(MfaEntity::class, MfaEntityFactory::fromJson($data));
+    }
+
+    /**
+     * @dataProvider provideInvalidJsonData
+     */
+    public function test_from_json_factory_method_performs_input_validation($data, $expectedMessage)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+        MfaEntityFactory::fromJson($data);
+    }
+
+    public function provideInvalidJsonData()
+    {
+        yield [['entityId' => null, 'level' => 'transparant_authn_context'], 'MFA entityId must be of type string'];
+        yield [['entityId' => 0, 'level' => 'transparant_authn_context'], 'MFA entityId must be of type string'];
+        yield [['entityId' => true, 'level' => 'transparant_authn_context'], 'MFA entityId must be of type string'];
+        yield [['entityIde' => true, 'level' => 'transparant_authn_context'], 'MFA entityId must be specified'];
+        yield [['level' => 'transparant_authn_context'], 'MFA entityId must be specified'];
+        yield [['entityId' => 'https://example.com', 'level' => 0], 'MFA level must be of type string'];
+        yield [['entityId' => 'https://example.com', 'level' => false], 'MFA level must be of type string'];
+        yield [['entityId' => 'https://example.com', 'level' => null], 'MFA level must be of type string'];
+        yield [['entityId'=> 'https://example.com'], 'MFA entity level must be specified'];
+    }
+}


### PR DESCRIPTION
The `transparent_authn_context` MFA entity level is interpreted. And Engine will pass the RequestedAuthnContext transparantly to the targetted IdP.

The story goes into greater detail on why this feature was added.

https://www.pivotaltracker.com/story/show/173305494