### PR TITLE
Enable skipped API tests

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -2,6 +2,12 @@ imports:
     - { resource: functional_testing.yml }
     - { resource: config_dev.yml }
 
+# Test service DI container overwrites (used for test and ci envs)
+services:
+    engineblock.features:
+        class: OpenConext\EngineBlockBundle\Configuration\TestFeatureConfiguration
+        public: true
+
 framework:
     test: ~
     session:

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -37,6 +37,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('api.deprovision', true));
         $this->setFeature(new Feature('api.metadata_push', true));
         $this->setFeature(new Feature('api.consent_listing', true));
+        $this->setFeature(new Feature('eb.run_all_manipulations_prior_to_consent', true));
     }
 
     public function setFeature(Feature $feature): void

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Configuration;
+
+use OpenConext\EngineBlock\Assert\Assertion;
+use OpenConext\EngineBlock\Exception\LogicException;
+
+/**
+ * By default the feature configuration enables the features, they can be reset/disabled
+ * by calling the setFeature method.
+ */
+class TestFeatureConfiguration implements FeatureConfigurationInterface
+{
+    /**
+     * @var Feature[]
+     */
+    private $features = [];
+
+    public function __construct()
+    {
+        $this->setFeature(new Feature('api.deprovision', true));
+        $this->setFeature(new Feature('api.metadata_push', true));
+        $this->setFeature(new Feature('api.consent_listing', true));
+    }
+
+    public function setFeature(Feature $feature): void
+    {
+        $this->features[$feature->getFeatureKey()] = $feature;
+    }
+
+    public function hasFeature($featureKey)
+    {
+        Assertion::nonEmptyString($featureKey, 'featureKey');
+
+        return array_key_exists($featureKey, $this->features);
+    }
+
+    public function isEnabled($featureKey)
+    {
+        if (!$this->hasFeature($featureKey)) {
+            $features = implode(
+                ', ',
+                array_map(
+                    function (Feature $feature) {
+                        return $feature->getFeatureKey();
+                    },
+                    $this->features
+                )
+            );
+            throw new LogicException(
+                sprintf(
+                    'Cannot state if feature "%s" is enabled as it does not exist. Please ensure that you configured it '
+                    .'correctly or verify with hasFeature() that the feature exists. Features configured: "%s"',
+                    $featureKey,
+                    $features
+                )
+            );
+        }
+
+        return $this->features[$featureKey]->isEnabled();
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
@@ -21,6 +21,7 @@ namespace OpenConext\EngineBlockBundle\Controller\Api;
 use OpenConext\EngineBlock\Metadata\Entity\Assembler\MetadataAssemblerInterface;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataPushRepository;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiAccessDeniedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiMethodNotAllowedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiNotFoundHttpException;
@@ -47,7 +48,7 @@ class ConnectionsController
     private $authorizationChecker;
 
     /**
-     * @var FeatureConfiguration
+     * @var FeatureConfigurationInterface
      */
     private $featureConfiguration;
 
@@ -64,14 +65,14 @@ class ConnectionsController
     /**
      * @param MetadataAssemblerInterface $assembler
      * @param AuthorizationCheckerInterface $authorizationChecker
-     * @param FeatureConfiguration $featureConfiguration
+     * @param FeatureConfigurationInterface $featureConfiguration
      * @param DoctrineMetadataPushRepository $repository
      * @param string|null $memoryLimit
      */
     public function __construct(
         MetadataAssemblerInterface $assembler,
         AuthorizationCheckerInterface $authorizationChecker,
-        FeatureConfiguration $featureConfiguration,
+        FeatureConfigurationInterface $featureConfiguration,
         DoctrineMetadataPushRepository $repository,
         $memoryLimit
     ) {

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
@@ -102,8 +102,6 @@ class ConnectionsControllerTest extends WebTestCase
             'PHP_AUTH_PW' => 'no_roles',
         ]);
 
-        $this->enableMetadataPushApiFeatureFor($client);
-
         $client->request('POST', 'https://engine-api.vm.openconext.org/api/connections');
         $this->assertStatusCode(Response::HTTP_FORBIDDEN, $client);
 
@@ -126,8 +124,6 @@ class ConnectionsControllerTest extends WebTestCase
             'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.metadataPush.username'),
             'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.metadataPush.password'),
         ]);
-
-        $this->enableMetadataPushApiFeatureFor($client);
 
         $client->request(
             'POST',
@@ -158,8 +154,6 @@ class ConnectionsControllerTest extends WebTestCase
             'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.metadataPush.username'),
             'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.metadataPush.password'),
         ]);
-
-        $this->enableMetadataPushApiFeatureFor($client);
 
         foreach ($this->validConnectionsData() as $step) {
 
@@ -230,8 +224,6 @@ class ConnectionsControllerTest extends WebTestCase
             'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.metadataPush.password'),
         ]);
 
-        $this->enableMetadataPushApiFeatureFor($client);
-
         foreach ($this->validConnectionsWithCoinsData() as $connection) {
 
             $payload = $this->createJsonData([$connection]);
@@ -285,8 +277,6 @@ class ConnectionsControllerTest extends WebTestCase
             'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.metadataPush.username'),
             'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.metadataPush.password'),
         ]);
-
-        $this->enableMetadataPushApiFeatureFor($client);
 
         $payload = '{"connections" : {
             "2d96e27a-76cf-4ca2-ac70-ece5d4c49523": {
@@ -394,14 +384,6 @@ class ConnectionsControllerTest extends WebTestCase
     {
         self::bootKernel();
         return self::$kernel->getContainer();
-    }
-
-    private function enableMetadataPushApiFeatureFor(Client $client)
-    {
-        $featureToggles = new FeatureConfiguration([
-            'api.metadata_push' => new Feature('api.metadata_push', true)
-        ]);
-        $client->getContainer()->set('engineblock.features', $featureToggles);
     }
 
     private function disableMetadataPushApiFeatureFor(Client $client)

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
@@ -126,8 +126,6 @@ final class ConsentControllerTest extends WebTestCase
             'PHP_AUTH_PW' => 'no_roles',
         ]);
 
-        $this->enableConsentApiFeatureFor($client);
-
         $client->request('GET', 'https://engine-api.vm.openconext.org/consent/' . $userId);
 
         $this->assertStatusCode(Response::HTTP_FORBIDDEN, $client);
@@ -151,8 +149,6 @@ final class ConsentControllerTest extends WebTestCase
             'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.profile.password'),
         ]);
 
-        $this->enableConsentApiFeatureFor($client);
-
         $client->request('GET', 'https://engine-api.vm.openconext.org/consent/' . $userId);
 
         $this->assertStatusCode(Response::HTTP_OK, $client);
@@ -173,7 +169,6 @@ final class ConsentControllerTest extends WebTestCase
      */
     public function a_consent_listing_for_a_given_user_is_retrieved_from_the_consent_api()
     {
-        $this->markTestSkipped('See https://www.pivotaltracker.com/story/show/174085599');
         $userId = 'my-name-id';
         $spEntityId = 'https://my-test-sp.test';
         $attributeHash = 'abe55dff15fe253d91220e945cd0f2c5f4727430';
@@ -208,7 +203,6 @@ final class ConsentControllerTest extends WebTestCase
 
         $this->addServiceProviderFixture($serviceProvider);
         $this->addConsentFixture($userId, $spEntityId, $attributeHash, $consentType, $consentDate);
-        $this->enableConsentApiFeatureFor($client);
 
         $client->request('GET', 'https://engine-api.vm.openconext.org/consent/' . $userId);
 
@@ -263,14 +257,6 @@ final class ConsentControllerTest extends WebTestCase
     {
         self::bootKernel();
         return self::$kernel->getContainer();
-    }
-
-    private function enableConsentApiFeatureFor(Client $client)
-    {
-        $featureToggles = new FeatureConfiguration([
-            'api.consent_listing' => new Feature('api.consent_listing', true)
-        ]);
-        $client->getContainer()->set('engineblock.features', $featureToggles);
     }
 
     private function disableConsentApiFeatureFor(Client $client)

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionControllerTest.php
@@ -118,8 +118,6 @@ final class DeprovisionControllerTest extends WebTestCase
             'PHP_AUTH_PW' => 'no_roles',
         ]);
 
-        $this->enableDeprovisionApiFeatureFor($client);
-
         $client->request('GET', 'https://engine-api.vm.openconext.org/deprovision/' . $collabPersonId);
 
         $this->assertStatusCode(Response::HTTP_FORBIDDEN, $client);
@@ -135,14 +133,10 @@ final class DeprovisionControllerTest extends WebTestCase
      */
     public function no_user_data_is_returned_if_collab_person_id_is_unknown($method, $path)
     {
-        $collabPersonId = 'urn:collab:person:test';
-
         $client = $client = static::createClient([], [
             'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.deprovision.username'),
             'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.deprovision.password'),
         ]);
-
-        $this->enableDeprovisionApiFeatureFor($client);
 
         $client->request($method, 'https://engine-api.vm.openconext.org/' . trim($path, '/'));
 
@@ -183,7 +177,6 @@ final class DeprovisionControllerTest extends WebTestCase
      */
     public function all_user_data_for_collab_person_id_is_retrieved_and_deleted($method, $path)
     {
-        $this->markTestSkipped('See https://www.pivotaltracker.com/story/show/174085599');
         $userId = 'urn:collab:person:test';
         $userUuid = '550e8400-e29b-41d4-a716-446655440000';
         $spEntityId1 = 'https://my-first-sp.test';
@@ -208,7 +201,6 @@ final class DeprovisionControllerTest extends WebTestCase
         $this->addSamlPersistentIdFixture($userUuid, $spUuid2, $persistentId2);
         $this->addConsentFixture($userId, $spEntityId1, $attributeHash, $consentType, $consentDate);
         $this->addConsentFixture($userId, $spEntityId2, $attributeHash, $consentType, $consentDate);
-        $this->enableDeprovisionApiFeatureFor($client);
 
         $client->request($method, 'https://engine-api.vm.openconext.org/' . trim($path, '/'));
 
@@ -307,17 +299,6 @@ final class DeprovisionControllerTest extends WebTestCase
     {
         self::bootKernel();
         return self::$kernel->getContainer();
-    }
-
-    /**
-     * @param Client $client
-     */
-    private function enableDeprovisionApiFeatureFor(Client $client)
-    {
-        $featureToggles = new FeatureConfiguration([
-            'api.deprovision' => new Feature('api.deprovision', true)
-        ]);
-        $client->getContainer()->set('engineblock.features', $featureToggles);
     }
 
     /**


### PR DESCRIPTION
The previously skipped api tests failed on the inability to overwrite the `engineblock.features service`. This is disallowed for obvious
reasons, by using a test stand in for the feature configuration this problem can be resolved.

The test stand in has a setter to customize the contents of the features. Note that this version of the configuration should only be
used in testing scenarios.

See: https://www.pivotaltracker.com/story/show/174085599