### PR TITLE
Show proxied SP and proxy in feedback info

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -48,6 +48,7 @@ return $overrides + [
     'identityProvider'      => 'IdP',
     'serviceProvider'       => 'SP',
     'serviceProviderName'   => 'SP Name',
+    'proxyServiceProvider'  => 'Proxy SP',
     'ipAddress'             => 'IP',
     'statusCode'            => 'Status Code',
     'artCode'               => 'EC',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -48,6 +48,7 @@ return $overrides + [
     'identityProvider'      => 'IdP',
     'serviceProvider'       => 'SP',
     'serviceProviderName'   => 'SP Name',
+    'proxyServiceProvider'  => 'Proxy SP',
     'ipAddress'             => 'IP',
     'statusCode'            => 'Statuscode',
     'artCode'               => 'EC',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -48,6 +48,7 @@ return $overrides + [
     'identityProvider'      => 'IdP',
     'serviceProvider'       => 'SP',
     'serviceProviderName'   => 'SP Name',
+    'proxyServiceProvider'  => 'Proxy SP',
     'ipAddress'             => 'IP',
     'statusCode'            => 'Código de Estado',
     'artCode'               => 'EC',

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -252,6 +252,10 @@ class EngineBlock_ApplicationSingleton
             $feedbackInfo['serviceProviderName'] = $this->getServiceProviderName($_SESSION['currentServiceProvider']);
         }
 
+        if (isset($_SESSION['proxyServiceProvider'])) {
+            $feedbackInfo['proxyServiceProvider'] = $_SESSION['proxyServiceProvider'];
+        }
+
         // @todo  reset this when login is succesful
         // Find the current identity provider
         if (isset($_SESSION['currentIdentityProvider'])) {

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -81,6 +81,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
         // When dealing with an SP that acts as a trusted proxy, we should perform SSO on the proxying SP and not the
         // proxy itself.
         if ($sp->getCoins()->isTrustedProxy()) {
+            $proxySp = $sp;
             // Overwrite the trusted proxy SP instance with that of the SP that uses the trusted proxy.
             $sp = $this->_server->findOriginalServiceProvider($request, $log);
         }
@@ -167,6 +168,12 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
 
         // 0 IdPs found! Throw an exception.
         if (count($candidateIDPs) === 0) {
+            // When a trusted proxy is used, the currentServiceProvider is set to the entityId of the original issuing
+            // SP. This prevents the display of the Proxy in the feedback information.
+            if (isset($proxySp) && $proxySp->getCoins()->isTrustedProxy()) {
+                $_SESSION['currentServiceProvider'] = $sp->entityId;
+                $_SESSION['proxyServiceProvider'] = $proxySp->entityId;
+            }
             throw new EngineBlock_Corto_Module_Service_SingleSignOn_NoIdpsException('No candidate IdPs found');
         }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -115,6 +115,15 @@ Feature:
      And I should see "SP Name:"
      And I should not see "IdP:"
 
+  Scenario: I want to log on, but the proxied Service Provider may not access any Identity Providers
+    Given SP "Trusted SP" is a trusted proxy
+    And SP "Trusted SP" signs its requests
+    And  SP "Trusted SP" is authenticating for SP "Unconnected SP"
+    When I log in at "Trusted SP"
+    Then I should see "Error - No organisations found"
+    And I should see "SP Name: Unconnected SP"
+    And I should see "SP Proxy:"
+
   Scenario: I want to log on but this Service Provider is not yet registered at OpenConext
     When I log in at "Unregistered SP"
     Then I should see "Error - Unknown service"

--- a/theme/material/stylesheets/error-page/modules/_feedback-info.sass
+++ b/theme/material/stylesheets/error-page/modules/_feedback-info.sass
@@ -22,7 +22,8 @@
   &--identityprovider,
   &--idp-hash,
   &--serviceprovider,
-  &--serviceprovidername
+  &--serviceprovidername,
+  &--proxyserviceprovider
     +min-width($small + 1)
       grid-column-end: span 2
       order: -1


### PR DESCRIPTION
![proxy-sp-feedback-info](https://user-images.githubusercontent.com/28252948/89501530-c57b2d00-d7c3-11ea-8451-fc52e24c3463.png)

When no ids are connected to a proxied SP, previously the SP info of the proxy was displayed on the feedback info. This change will ensure both the SP and proxy SP are represented on the feedback info page.

@thijskh Two questions: 
1) Do you agree with the proposed labels in the feedback info table? __Proxy SP__ and _Proxy SP Name_ ? Shorter abbreviations might be more economical.

2) The columns might need reorganization to get optimal screen realestate for the proxy sp name. For now I'd like to show you this for verification.

See: https://www.pivotaltracker.com/story/show/174036058