### PR TITLE
Do not apply ValidateMfaAuthnContextClassRef filter for transparent use case

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/ValidateMfaAuthnContextClassRef.php
+++ b/library/EngineBlock/Corto/Filter/Command/ValidateMfaAuthnContextClassRef.php
@@ -17,6 +17,7 @@
  */
 
 use OpenConext\EngineBlock\Assert\Assertion;
+use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -34,7 +35,8 @@ class EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef extends E
     public function execute()
     {
         $mfaEntity = $this->_identityProvider->getCoins()->mfaEntities()->findByEntityId($this->_serviceProvider->entityId);
-        if (!$mfaEntity) {
+        // SP's configured to pass auth context transparently are not checked for an expected (configured) class ref.
+        if (!$mfaEntity || $mfaEntity instanceof TransparentMfaEntity) {
             return;
         }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
@@ -65,6 +65,10 @@ Feature:
     And I pass through EngineBlock
     Then the url should match "functional-testing/SSO-IdP/sso"
     And the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef[text()="http://my-very-own-context.example.com/level9"]'
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+    Then the url should match "/functional-testing/SSO-SP/acs"
 
   Scenario: The SP provided authn method should NOT be set as AuthnContextClassRef if SP configured is not with transparent_authn_context
     Given the IdP "SSO-IdP" is configured for MFA authn method "not_configured_transparent_authn_context" for SP "SSO-SP"

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/ValidateMfaAuthnContextClassRefTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/ValidateMfaAuthnContextClassRefTest.php
@@ -78,7 +78,6 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $this->assertInstanceOf(EngineBlock_Corto_Filter_Command_Abstract::class, $verifier);
     }
 
-
     public function testMatchedAuthnMethodsReferenceAttributeShouldPass()
     {
         $response = $this->createTestResponse('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', ['http://schemas.microsoft.com/claims/multipleauthn']);
@@ -94,7 +93,6 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
 
         $this->assertInstanceOf(EngineBlock_Corto_Filter_Command_Abstract::class, $verifier);
     }
-
 
     public function testMatchedAuthnMethodsReferenceAttributeWithMultipleValuesShouldPass()
     {
@@ -136,7 +134,6 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $this->assertInstanceOf(EngineBlock_Corto_Filter_Command_Abstract::class, $verifier);
     }
 
-
     public function testNotMatchedAuthnContextClassRefShouldThrowException()
     {
         $this->expectException(EngineBlock_Corto_Exception_InvalidMfaAuthnContextClassRef::class);
@@ -170,6 +167,22 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         ]);
 
         $identityProvider = $this->createConfiguredSpIdpCombination('Test IdP', "Test SP", "http://schemas.microsoft.com/claims/multipleauthn");
+
+        $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
+        $verifier->setResponse($response);
+        $verifier->setIdentityProvider($identityProvider);
+        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+
+        $verifier->execute();
+
+        $this->assertInstanceOf(EngineBlock_Corto_Filter_Command_Abstract::class, $verifier);
+    }
+
+    public function testMatchedTransparentAuthnContextClassRefShouldPass()
+    {
+        $response = $this->createTestResponse('foobar.example.com');
+
+        $identityProvider = $this->createConfiguredSpIdpCombination('Test IdP', "Test SP", "transparent_authn_context");
 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);


### PR DESCRIPTION
When the SP is configured to transparently pass its authentication context to and from the IdP.

See: https://www.pivotaltracker.com/story/show/173305494