### PR TITLE
Remove non conforming SHO oid from config

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,21 @@
 # UPGRADE NOTES
 
+## 6.2 > 6.3
+# Removal of incorrect schacHomeOrganization ARP alias
+
+If your federation relies on the release of the urn:oid:1.3.6.1.4.1.1466.115.121.1.15 sHO alias in the ARP. Then please
+put the entry back manually. This config can be found in `application/configs/attributes.json` near line 330.
+
+The following alias can be added back (or review the git history):
+
+```
+     "urn:oid:1.3.6.1.4.1.25178.1.2.9": "urn:mace:terena.org:attribute-def:schacHomeOrganization",
+-->  "urn:oid:1.3.6.1.4.1.1466.115.121.1.15": "urn:mace:terena.org:attribute-def:schacHomeOrganization",
+     "urn:mace:terena.org:attribute-def:schacHomeOrganization": {
+         # Snipped config section for the sake of brevity
+     }
+```
+
 ## 6.1 > 6.2
 
 # Remove legacy application.ini configuration

--- a/application/configs/attributes.json
+++ b/application/configs/attributes.json
@@ -329,7 +329,6 @@
         }
     },
     "urn:oid:1.3.6.1.4.1.25178.1.2.9": "urn:mace:terena.org:attribute-def:schacHomeOrganization",
-    "urn:oid:1.3.6.1.4.1.1466.115.121.1.15": "urn:mace:terena.org:attribute-def:schacHomeOrganization",
     "urn:mace:terena.org:attribute-def:schacHomeOrganization": {
         "_Comment": "Note that urn:oid:1.3.6.1.4.1.1466.115.121.1.15 is a non-conforming version that is deprecated",
         "Description": {


### PR DESCRIPTION
~The urn:oid:1.3.6.1.4.1.1466.115.121.1.15 attribute was previously released by default when the SHO was in the ARP. This oid is not valid and was added for historic reasons. It's not clear which SP's still rely on this attribute. So by default the attribute is not released by EB, but can be enabled using the 'eb.arp_remove_non_conforming_sho_attribute' feature flag.~

Simply removing the alias from the config was a more pragmatic solution. Federations relying on the alias can manually put it back if need be.

See: https://www.pivotaltracker.com/story/show/164237578