### PR TITLE
Move metadata organization business rules away from metadata assembler

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -336,18 +336,6 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
 
     private function assembleOrganization(stdClass $connection, $langCode)
     {
-        if (empty($connection->metadata->OrganizationName->$langCode)) {
-            return array();
-        }
-
-        if (empty($connection->metadata->OrganizationDisplayName->$langCode)) {
-            return array();
-        }
-
-        if (empty($connection->metadata->OrganizationURL->$langCode)) {
-            return array();
-        }
-
         return array('organization' . ucfirst($langCode) => new Organization(
             $connection->metadata->OrganizationName->$langCode,
             $connection->metadata->OrganizationDisplayName->$langCode,

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
@@ -124,7 +124,7 @@ class IdentityProviderEntity implements IdentityProviderEntityInterface
         return $this->entity->logo;
     }
 
-    public function hasValidOrganizationData(string $locale): bool
+    public function hasCompleteOrganizationData(string $locale): bool
     {
         $organization = $this->entity->getOrganization($locale);
         if ($organization

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
@@ -124,6 +124,19 @@ class IdentityProviderEntity implements IdentityProviderEntityInterface
         return $this->entity->logo;
     }
 
+    public function hasValidOrganizationData(string $locale): bool
+    {
+        $organization = $this->entity->getOrganization($locale);
+        if ($organization
+            && is_string($organization->displayName) && $organization->displayName !== ''
+            && is_string($organization->name) && $organization->name !== ''
+            && is_string($organization->url) && $organization->url !== ''
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * @param $locale
      * @return Organization

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
@@ -34,6 +34,8 @@ use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
  *
  * This adapter is used to support the ORM entity by encapsulating it. This will make it easier to replace the ORM
  * entity ultimately.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class ServiceProviderEntity implements ServiceProviderEntityInterface
 {
@@ -123,6 +125,19 @@ class ServiceProviderEntity implements ServiceProviderEntityInterface
     public function getLogo(): ?Logo
     {
         return $this->entity->logo;
+    }
+
+    public function hasValidOrganizationData(string $locale): bool
+    {
+        $organization = $this->entity->getOrganization($locale);
+        if ($organization
+            && is_string($organization->displayName) && $organization->displayName !== ''
+            && is_string($organization->name) && $organization->name !== ''
+            && is_string($organization->url) && $organization->url !== ''
+        ) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntity.php
@@ -127,7 +127,7 @@ class ServiceProviderEntity implements ServiceProviderEntityInterface
         return $this->entity->logo;
     }
 
-    public function hasValidOrganizationData(string $locale): bool
+    public function hasCompleteOrganizationData(string $locale): bool
     {
         $organization = $this->entity->getOrganization($locale);
         if ($organization

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
@@ -99,6 +99,19 @@ abstract class AbstractIdentityProvider implements IdentityProviderEntityInterfa
         return $this->entity->getLogo();
     }
 
+    public function hasValidOrganizationData(string $locale): bool
+    {
+        $organization = $this->entity->getOrganization($locale);
+        if ($organization
+            && is_string($organization->displayName) && $organization->displayName !== ''
+            && is_string($organization->name) && $organization->name !== ''
+            && is_string($organization->url) && $organization->url !== ''
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * @param $locale
      * @return Organization|null

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
@@ -99,7 +99,7 @@ abstract class AbstractIdentityProvider implements IdentityProviderEntityInterfa
         return $this->entity->getLogo();
     }
 
-    public function hasValidOrganizationData(string $locale): bool
+    public function hasCompleteOrganizationData(string $locale): bool
     {
         $organization = $this->entity->getOrganization($locale);
         if ($organization

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
@@ -100,7 +100,7 @@ abstract class AbstractServiceProvider implements ServiceProviderEntityInterface
         return $this->entity->getLogo();
     }
 
-    public function hasValidOrganizationData(string $locale): bool
+    public function hasCompleteOrganizationData(string $locale): bool
     {
         $organization = $this->entity->getOrganization($locale);
         if ($organization

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractServiceProvider.php
@@ -100,6 +100,19 @@ abstract class AbstractServiceProvider implements ServiceProviderEntityInterface
         return $this->entity->getLogo();
     }
 
+    public function hasValidOrganizationData(string $locale): bool
+    {
+        $organization = $this->entity->getOrganization($locale);
+        if ($organization
+            && is_string($organization->displayName) && $organization->displayName !== ''
+            && is_string($organization->name) && $organization->name !== ''
+            && is_string($organization->url) && $organization->url !== ''
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * @param $locale
      * @return Organization|null

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Helper/IdentityProviderMetadataHelper.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Helper/IdentityProviderMetadataHelper.php
@@ -53,6 +53,14 @@ class IdentityProviderMetadataHelper extends AbstractIdentityProvider
         return $this->entity->getOrganization($locale)->name;
     }
 
+    public function getOrganizationDisplayName($locale) : string
+    {
+        if (!$this->entity->getOrganization($locale)) {
+            return '';
+        }
+        return $this->entity->getOrganization($locale)->displayName;
+    }
+
     public function getOrganizationUrl($locale) : string
     {
         if (!$this->entity->getOrganization($locale)) {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Helper/ServiceProviderMetadataHelper.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Helper/ServiceProviderMetadataHelper.php
@@ -45,6 +45,14 @@ class ServiceProviderMetadataHelper extends AbstractServiceProvider
         return $this->entity->getOrganization($locale)->name;
     }
 
+    public function getOrganizationDisplayName($locale) : string
+    {
+        if (!$this->entity->getOrganization($locale)) {
+            return '';
+        }
+        return $this->entity->getOrganization($locale)->displayName;
+    }
+
     public function getOrganizationUrl($locale) : string
     {
         if (!$this->entity->getOrganization($locale)) {

--- a/src/OpenConext/EngineBlock/Metadata/Factory/IdentityProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/IdentityProviderEntityInterface.php
@@ -63,6 +63,8 @@ interface IdentityProviderEntityInterface
      */
     public function getLogo(): ?Logo;
 
+    public function hasValidOrganizationData(string $locale): bool;
+
     /**
      * @param $locale
      * @return Organization|null

--- a/src/OpenConext/EngineBlock/Metadata/Factory/IdentityProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/IdentityProviderEntityInterface.php
@@ -63,7 +63,11 @@ interface IdentityProviderEntityInterface
      */
     public function getLogo(): ?Logo;
 
-    public function hasValidOrganizationData(string $locale): bool;
+    /**
+     * The SAML2 metadata specification dictates to only display the OrganizationData when it is complete
+     * (url, display name and name). This method verifies the organization data is complete
+     */
+    public function hasCompleteOrganizationData(string $locale): bool;
 
     /**
      * @param $locale

--- a/src/OpenConext/EngineBlock/Metadata/Factory/ServiceProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/ServiceProviderEntityInterface.php
@@ -63,7 +63,11 @@ interface ServiceProviderEntityInterface
      */
     public function getLogo(): ?Logo;
 
-    public function hasValidOrganizationData(string $locale): bool;
+    /**
+     * The SAML2 metadata specification dictates to only display the OrganizationData when it is complete
+     * (url, display name and name). This method verifies the organization data is complete
+     */
+    public function hasCompleteOrganizationData(string $locale): bool;
 
     /**
      * @param $locale

--- a/src/OpenConext/EngineBlock/Metadata/Factory/ServiceProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/ServiceProviderEntityInterface.php
@@ -63,6 +63,8 @@ interface ServiceProviderEntityInterface
      */
     public function getLogo(): ?Logo;
 
+    public function hasValidOrganizationData(string $locale): bool;
+
     /**
      * @param $locale
      * @return Organization|null

--- a/src/OpenConext/EngineBlock/Metadata/Organization.php
+++ b/src/OpenConext/EngineBlock/Metadata/Organization.php
@@ -18,10 +18,6 @@
 
 namespace OpenConext\EngineBlock\Metadata;
 
-/**
- * Class Organization
- * @package OpenConext\EngineBlock\Metadata
- */
 class Organization
 {
     public $name;

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
@@ -195,6 +195,7 @@ abstract class AbstractEntityTest extends TestCase
             'getDisplayName',
             'setConsentSettings',
             'toggleWorkflowState',
+            'hasValidOrganizationData',
         ];
 
         // Get all state from the old mutable entity
@@ -234,7 +235,7 @@ abstract class AbstractEntityTest extends TestCase
     protected function getIdentityProviderValues(string $identityProviderInterface)
     {
 
-        $values = $this->getGetterBaseNameFromMethodNames($this->getGettersFromMethodNames($this->getMethods($identityProviderInterface)));
+        $values = $this->getGetterBaseNameFromMethodNames($this->getGettersFromMethodNames($this->getMethods($identityProviderInterface, ['hasValidOrganizationData'])));
 
         $replaceParameters = [
             'name' => [
@@ -281,7 +282,7 @@ abstract class AbstractEntityTest extends TestCase
      */
     protected function getServiceProviderValues(string $serviceProviderInterface)
     {
-        $values = $this->getGetterBaseNameFromMethodNames($this->getGettersFromMethodNames($this->getMethods($serviceProviderInterface)));
+        $values = $this->getGetterBaseNameFromMethodNames($this->getGettersFromMethodNames($this->getMethods($serviceProviderInterface, ['hasValidOrganizationData'])));
 
         $replaceParameters = [
             'name' => [

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
@@ -195,7 +195,7 @@ abstract class AbstractEntityTest extends TestCase
             'getDisplayName',
             'setConsentSettings',
             'toggleWorkflowState',
-            'hasValidOrganizationData',
+            'hasCompleteOrganizationData',
         ];
 
         // Get all state from the old mutable entity
@@ -235,7 +235,7 @@ abstract class AbstractEntityTest extends TestCase
     protected function getIdentityProviderValues(string $identityProviderInterface)
     {
 
-        $values = $this->getGetterBaseNameFromMethodNames($this->getGettersFromMethodNames($this->getMethods($identityProviderInterface, ['hasValidOrganizationData'])));
+        $values = $this->getGetterBaseNameFromMethodNames($this->getGettersFromMethodNames($this->getMethods($identityProviderInterface, ['hasCompleteOrganizationData'])));
 
         $replaceParameters = [
             'name' => [
@@ -282,7 +282,7 @@ abstract class AbstractEntityTest extends TestCase
      */
     protected function getServiceProviderValues(string $serviceProviderInterface)
     {
-        $values = $this->getGetterBaseNameFromMethodNames($this->getGettersFromMethodNames($this->getMethods($serviceProviderInterface, ['hasValidOrganizationData'])));
+        $values = $this->getGetterBaseNameFromMethodNames($this->getGettersFromMethodNames($this->getMethods($serviceProviderInterface, ['hasCompleteOrganizationData'])));
 
         $replaceParameters = [
             'name' => [

--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
@@ -1,17 +1,18 @@
+{% set hasOrganizationData = false %}
+{% for locale in locales %}
+    {% if metadata.hasValidOrganizationData(locale) %}
+        {% set hasOrganizationData = true %}
+    {% endif %}
+{% endfor %}
+
+{% if hasOrganizationData %}
 <md:Organization>
     {% for locale in locales %}
-        {% if metadata.organization(locale) is not empty %}
+        {% if metadata.hasValidOrganizationData(locale) %}
             <md:OrganizationName xml:lang="{{ locale }}">{{ metadata.organizationName(locale) }}</md:OrganizationName>
-        {% endif %}
-    {%  endfor %}
-    {% for locale in locales %}
-        {% if metadata.organization(locale) is not empty %}
             <md:OrganizationDisplayName xml:lang="{{ locale }}">{{ metadata.organizationName(locale) }}</md:OrganizationDisplayName>
-        {% endif %}
-    {%  endfor %}
-    {% for locale in locales %}
-        {% if metadata.organizationUrl(locale) is not null and metadata.organizationUrl(locale) is not empty %}
             <md:OrganizationURL xml:lang="{{ locale }}">{{ metadata.organizationUrl(locale) }}</md:OrganizationURL>
         {% endif %}
     {% endfor %}
 </md:Organization>
+{% endif %}

--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
@@ -10,7 +10,7 @@
     {% for locale in locales %}
         {% if metadata.hasValidOrganizationData(locale) %}
             <md:OrganizationName xml:lang="{{ locale }}">{{ metadata.organizationName(locale) }}</md:OrganizationName>
-            <md:OrganizationDisplayName xml:lang="{{ locale }}">{{ metadata.organizationName(locale) }}</md:OrganizationDisplayName>
+            <md:OrganizationDisplayName xml:lang="{{ locale }}">{{ metadata.organizationDisplayName(locale) }}</md:OrganizationDisplayName>
             <md:OrganizationURL xml:lang="{{ locale }}">{{ metadata.organizationUrl(locale) }}</md:OrganizationURL>
         {% endif %}
     {% endfor %}

--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
@@ -1,6 +1,6 @@
 {% set hasOrganizationData = false %}
 {% for locale in locales %}
-    {% if metadata.hasValidOrganizationData(locale) %}
+    {% if metadata.hasCompleteOrganizationData(locale) %}
         {% set hasOrganizationData = true %}
     {% endif %}
 {% endfor %}
@@ -8,7 +8,7 @@
 {% if hasOrganizationData %}
 <md:Organization>
     {% for locale in locales %}
-        {% if metadata.hasValidOrganizationData(locale) %}
+        {% if metadata.hasCompleteOrganizationData(locale) %}
             <md:OrganizationName xml:lang="{{ locale }}">{{ metadata.organizationName(locale) }}</md:OrganizationName>
             <md:OrganizationDisplayName xml:lang="{{ locale }}">{{ metadata.organizationDisplayName(locale) }}</md:OrganizationDisplayName>
             <md:OrganizationURL xml:lang="{{ locale }}">{{ metadata.organizationUrl(locale) }}</md:OrganizationURL>


### PR DESCRIPTION
1. Organization data is now always assembled in the PushMetadataAssembler
2. Still only displayed on the metadata field when all data is complete.
3. An additional bugfix was applied, where the displayname was never rendered

https://www.pivotaltracker.com/story/show/170744290