### PR TITLE
Add trusted proxy signing verification

### DIFF
--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -193,10 +193,22 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             );
         }
 
+        $requestsMustBeSigned = $serviceProvider->requestsMustBeSigned;
+        $isTrustedProxy = $serviceProvider->getCoins()->isTrustedProxy();
+
+        if ($isTrustedProxy && !$requestsMustBeSigned){
+            throw new EngineBlock_Corto_Module_Bindings_Exception(
+                sprintf(
+                    'SP "%s" is marked as Trusted Proxy but does not have "redirect:sign" enabled.',
+                    $spEntityId
+                )
+            );
+        }
+
         // Determine if we should check the signature of the message
         $wantRequestsSigned = (
             // If the destination wants the AuthnRequests signed
-            $serviceProvider->requestsMustBeSigned
+            $requestsMustBeSigned
             ||
             // Or we currently demand that all AuthnRequests are sent signed
             $this->_server->getConfig('WantsAuthnRequestsSigned')

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
@@ -76,19 +76,6 @@ Feature:
       And I should see "Step Up"
       And I should not see "Loa SP"
 
-  Scenario: User logs in via trusted proxy and sees consent for the destination
-    Given SP "Step Up" is authenticating for SP "Loa SP"
-      And SP "Step Up" is a trusted proxy
-      # Test to see that we don't trust trusted proxies without request signing
-      #And SP "Step Up" signs its requests
-     When I log in at "Step Up"
-      And I select "AlwaysAuth" on the WAYF
-      And I pass through EngineBlock
-      And I pass through the IdP
-     Then I should see "needs your information"
-      And I should see "Step Up"
-      And I should not see "Loa SP"
-
   Scenario: User logs in via trusted signing proxy and sees consent for the destination
     Given SP "Step Up" is authenticating for SP "Loa SP"
       And SP "Step Up" is a trusted proxy
@@ -234,6 +221,7 @@ Feature:
   Scenario: User logs in to two SPs via trusted proxy
    Given SP "Step Up" is authenticating for SP "Loa SP"
      And SP "Step Up" is a trusted proxy
+     And SP "Step Up" signs its requests
      And SP "Step Up" does not require consent
     When I log in at "Step Up"
      And I select "AlwaysAuth" on the WAYF
@@ -249,3 +237,9 @@ Feature:
     Then I should not see "Error - No organisations found"
          # The WAYF should be visible
      And I should see "Select an organisation to login to the service"
+
+  Scenario: Trusted proxy not signing requests results in an error
+    Given SP "Step Up" is authenticating for SP "Loa SP"
+    And SP "Step Up" is a trusted proxy
+    When I log in at "Step Up"
+    Then I should see "Error - An error occurred"


### PR DESCRIPTION
When the trusted proxy does not sing its requests, we error out of the single sing on flow. The error is generic and has a non descriptive error message is raised.

See https://www.pivotaltracker.com/story/show/153995599