### PR TITLE
Fix use of nonexistent 'support_url'.

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Proxy/consent-slidein-about.html.twig
+++ b/theme/material/templates/modules/Authentication/View/Proxy/consent-slidein-about.html.twig
@@ -5,6 +5,6 @@
     <section>
         {{ 'consent_slidein_about_text'|trans({'%profileUrl%': profileUrl})|raw }}
     </section>
-    <a href="{{ 'support_url'|trans }}" target="_blank">{{ 'slidein_read_more'|trans }}</a>
+    <a href="{{ 'openconext_support_url'|trans }}" target="_blank">{{ 'slidein_read_more'|trans }}</a>
   </div>
 </div>


### PR DESCRIPTION
The template tries to translate 'support_url' which is not in
languages/ (so results in just the string "support_url" as the url).
Probably 'openconext_support_url' was intended; this works.