### PR TITLE
Send NoPassive status response back to issuing SP

### DIFF
--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -28,6 +28,7 @@ use SAML2\Configuration\Destination;
 use SAML2\Configuration\IdentityProvider as Saml2IdentityProvider;
 use SAML2\Configuration\PrivateKey;
 use SAML2\Configuration\ServiceProvider as Saml2ServiceProvider;
+use SAML2\Constants;
 use SAML2\EncryptedAssertion;
 use SAML2\Response\Exception\PreconditionNotMetException;
 use SAML2\HTTPPost;
@@ -401,6 +402,11 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
                 }
 
                 $status = $sspResponse->getStatus();
+
+                if (isset($status['SubCode']) && $status['SubCode'] === Constants::STATUS_NO_PASSIVE) {
+                    // When a no passive response status was returned from the IdP, return the response back to the ACS
+                    return new EngineBlock_Saml2_ResponseAnnotationDecorator($sspResponse);
+                }
 
                 $log->notice(
                     'Received an Error Response',

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/IsPassive.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/IsPassive.feature
@@ -1,0 +1,29 @@
+Feature:
+  In order to support passive authentications
+  As an SP
+  The IsPassive implementation in EB should function correctly
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+    And no registered SPs
+    And no registered Idps
+    And an Identity Provider named "Dummy IdP"
+    And a Service Provider named "Dummy SP"
+
+  Scenario: A passive AuthnRequest is handled without issue
+    Given SP "Dummy SP" is configured to generate a passive AuthnRequest
+    When I log in at "Dummy SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+    Then the response should match xpath '/samlp:Response/samlp:Status/samlp:StatusCode[@Value="urn:oasis:names:tc:SAML:2.0:status:Success"]'
+
+  Scenario: A NoPassive response is forwarded to the SP
+    Given SP "Dummy SP" is configured to generate a passive AuthnRequest
+    And the IdP is configured to always return Responses with StatusCode Responder/NoPassive
+    When I log in at "Dummy SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I pass through EngineBlock
+    Then the response should match xpath '/samlp:Response/samlp:Status/samlp:StatusCode[@Value="urn:oasis:names:tc:SAML:2.0:status:Responder"]/samlp:StatusCode[@Value="urn:oasis:names:tc:SAML:2.0:status:NoPassive"]'


### PR DESCRIPTION
These NoPassive status responses are sent by the IdP who is not
able/allowed to process a Passive authentication.

Previously we would show a custom error page. But on this occasion it's
better to let the SP decide how to proceed in this situation.

See: https://www.pivotaltracker.com/story/show/164238276
Closes: https://github.com/OpenConext/OpenConext-engineblock/issues/39