### PR TITLE
Store entityId of issuer, not the value object

### DIFF
--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -251,9 +251,6 @@ class EngineBlock_ApplicationSingleton
         if (isset($_SESSION['currentServiceProvider'])) {
             $feedbackInfo['serviceProvider'] = $_SESSION['currentServiceProvider'];
             $spEntityId = $_SESSION['currentServiceProvider'];
-            if ($spEntityId instanceof Issuer) {
-                $spEntityId = $spEntityId->getValue();
-            }
             $feedbackInfo['serviceProviderName'] = $this->getServiceProviderName($spEntityId);
         }
 

--- a/library/EngineBlock/Corto/Model/Response/Cache.php
+++ b/library/EngineBlock/Corto/Model/Response/Cache.php
@@ -39,8 +39,8 @@ class EngineBlock_Corto_Model_Response_Cache
         }
 
         $_SESSION['CachedResponses'][] = array(
-            'sp'  => $receivedRequest->getIssuer(),
-            'idp' => $receivedResponse->getIssuer(),
+            'sp'  => $receivedRequest->getIssuer()->getValue(),
+            'idp' => $receivedResponse->getIssuer()->getValue(),
         );
     }
 

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -153,7 +153,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
             $log->notice(sprintf(
                 'Received signed AuthnRequest from Issuer "%s" with signature method algorithm "%s"',
-                $sspRequest->getIssuer(),
+                $sspRequest->getIssuer()->getValue(),
                 $signatureMethod
             ));
 
@@ -168,7 +168,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         $this->assertValidAcsLocationScheme($acsLocation);
 
         // check the IssueInstant against our own time to see if the SP's clock is getting out of sync
-        $this->_checkIssueInstant( $sspRequest->getIssueInstant(), 'SP',  $sspRequest->getIssuer() );
+        $this->_checkIssueInstant( $sspRequest->getIssueInstant(), 'SP',  $sspRequest->getIssuer()->getValue());
 
         $ebRequest = new EngineBlock_Saml2_AuthnRequestAnnotationDecorator($sspRequest);
 
@@ -180,7 +180,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
             );
         }
         // Remember sp for debugging
-        $_SESSION['currentServiceProvider'] = $ebRequest->getIssuer();
+        $_SESSION['currentServiceProvider'] = $ebRequest->getIssuer()->getValue();
 
         // Verify that we know this SP and have metadata for it.
         $serviceProvider = $this->_verifyKnownSP(


### PR DESCRIPTION
The Issuer object was stored in the CachedResponses session. Causing problems with successive use of the
CachedResponses data which is expected to be a string representation of the SP/IdP entityID.

https://www.pivotaltracker.com/story/show/174627328