### PR TITLE
Print the key-id in the SSO locations of the IdP metadata

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineBlockIdentityProvider.php
@@ -38,13 +38,19 @@ class EngineBlockIdentityProvider extends AbstractIdentityProvider
      */
     private $urlProvider;
 
+    /**
+     * @var string|null
+     */
+    private $keyId;
+
     public function __construct(
         IdentityProviderEntityInterface $entity,
+        ?string $keyId,
         X509KeyPair $keyPair,
         UrlProvider $urlProvider
     ) {
         parent::__construct($entity);
-
+        $this->keyId = $keyId;
         $this->keyPair = $keyPair;
         $this->urlProvider = $urlProvider;
     }
@@ -83,7 +89,7 @@ class EngineBlockIdentityProvider extends AbstractIdentityProvider
      */
     public function getSingleSignOnServices(): array
     {
-        $ssoLocation = $this->urlProvider->getUrl('authentication_idp_sso', false, null, null);
+        $ssoLocation = $this->urlProvider->getUrl('authentication_idp_sso', false, $this->keyId, null);
         return [new Service($ssoLocation, Constants::BINDING_HTTP_REDIRECT)];
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProvider.php
@@ -47,13 +47,20 @@ class ProxiedIdentityProvider extends AbstractIdentityProvider
      */
     private $urlProvider;
 
+    /**
+     * @var string|null
+     */
+    private $keyId;
+
     public function __construct(
         IdentityProviderEntityInterface $entity,
         EngineBlockConfiguration $engineBlockConfiguration,
+        ?string $keyId,
         X509KeyPair $keyPair,
         UrlProvider $urlProvider
     ) {
         parent::__construct($entity);
+        $this->keyId = $keyId;
         $this->engineBlockConfiguration = $engineBlockConfiguration;
         $this->keyPair = $keyPair;
         $this->urlProvider = $urlProvider;
@@ -95,7 +102,13 @@ class ProxiedIdentityProvider extends AbstractIdentityProvider
 
     public function getSingleSignOnServices(): array
     {
-        $ssoLocation = $this->urlProvider->getUrl('authentication_idp_sso', false, null, $this->getEntityId());
+        $ssoLocation = $this->urlProvider->getUrl(
+            'authentication_idp_sso',
+            false,
+            $this->keyId,
+            $this->getEntityId()
+        );
+
         return [new Service($ssoLocation, Constants::BINDING_HTTP_REDIRECT)];
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactory.php
@@ -59,7 +59,7 @@ class IdentityProviderFactory
     /**
      * Use this method to create a bare Engineblock IdP entity
      */
-    public function createEngineBlockEntityFrom(string $keyId): IdentityProviderEntityInterface
+    public function createEngineBlockEntityFrom(?string $keyId): IdentityProviderEntityInterface
     {
         $entityId = $this->urlProvider->getUrl('metadata_idp', false, null, null);
 
@@ -71,7 +71,7 @@ class IdentityProviderFactory
     /**
      * Use this method to create an IdP entity that is displayed on the IdPs metadata overview.
      */
-    public function createIdentityProviderEntityFromEntity(IdentityProvider $entity, string $keyId): IdentityProviderEntityInterface
+    public function createIdentityProviderEntityFromEntity(IdentityProvider $entity, ?string $keyId): IdentityProviderEntityInterface
     {
         return $this->buildIdentityProviderFromEntity($entity, $keyId);
     }
@@ -91,13 +91,14 @@ class IdentityProviderFactory
      * - EngineBlockIdentityProvider: Set the functional fields to act as proxy:
      *   (signing certificate, supported nameid formats, sso/slo services, response processing service)
      */
-    private function buildEngineBlockEntityFromEntity(IdentityProvider $entity, string $keyId): IdentityProviderEntityInterface
+    private function buildEngineBlockEntityFromEntity(IdentityProvider $entity, ?string $keyId): IdentityProviderEntityInterface
     {
         return new EngineBlockIdentityProvider(  // Set EngineBlock specific functional properties so EB could act as proxy
             new EngineBlockIdentityProviderInformation( // Set EngineBlock specific presentation properties
                 new IdentityProviderEntity($entity),
                 $this->engineBlockConfiguration
             ),
+            $keyId,
             $this->keyPairFactory->buildFromIdentifier($keyId),
             $this->urlProvider
         );
@@ -112,7 +113,7 @@ class IdentityProviderFactory
      * - IdentityProviderEntity: The adapter to convert the ORM entity to support the immutable IdentityProviderEntityInterface interface
      * - ProxiedIdentityProvider: Set the functional fields to act as an IdP proxied by EngineBlock
      */
-    private function buildIdentityProviderFromEntity(IdentityProvider $entity, string $keyId): IdentityProviderEntityInterface
+    private function buildIdentityProviderFromEntity(IdentityProvider $entity, ?string $keyId): IdentityProviderEntityInterface
     {
         // Set IdP specific properties where the IdP is proxied by EngineBlock. So the EB certificate, contact persons
         // and SSO location are overridden
@@ -120,6 +121,7 @@ class IdentityProviderFactory
             new ProxiedIdentityProvider(
                 new IdentityProviderEntity($entity),
                 $this->engineBlockConfiguration,
+                $keyId,
                 $this->keyPairFactory->buildFromIdentifier($keyId),
                 $this->urlProvider
             )

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
@@ -69,7 +69,7 @@ class IdpsMetadataRepository
     /**
      * @return IdentityProviderEntityCollection
      */
-    public function findIdentityProviders(string $keyId)
+    public function findIdentityProviders(?string $keyId)
     {
         return $this->convertIdentityProviders(
             $this->repository->findIdentityProviders(),
@@ -83,7 +83,7 @@ class IdpsMetadataRepository
      */
     public function findIdentityProvidersByEntityId(
         array $identityProviderEntityIds,
-        string $keyId
+        ?string $keyId
     ) {
         return $this->convertIdentityProviders(
             $this->repository->findIdentityProvidersByEntityId($identityProviderEntityIds),
@@ -96,7 +96,7 @@ class IdpsMetadataRepository
      */
     private function convertIdentityProviders(
         array $idps,
-        string $keyId
+        ?string $keyId
     ): IdentityProviderEntityCollection {
 
         $collection = new IdentityProviderEntityCollection();

--- a/src/OpenConext/EngineBlock/Metadata/X509/KeyPairFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/X509/KeyPairFactory.php
@@ -41,8 +41,11 @@ class KeyPairFactory
      *
      * @throws RuntimeException
      */
-    public function buildFromIdentifier(string $identifier) : X509KeyPair
+    public function buildFromIdentifier(?string $identifier) : X509KeyPair
     {
+        if ($identifier === null) {
+            $identifier = self::DEFAULT_KEY_PAIR_IDENTIFIER;
+        }
         Assertion::nonEmptyString($identifier, 'identifier');
 
         if (array_key_exists($identifier, $this->keyPairConfiguration)) {

--- a/src/OpenConext/EngineBlock/Xml/MetadataProvider.php
+++ b/src/OpenConext/EngineBlock/Xml/MetadataProvider.php
@@ -84,11 +84,8 @@ class MetadataProvider
 
     /**
      * Generate XML metadata for an IdP
-     *
-     * @param string $keyId
-     * @return string
      */
-    public function metadataForIdp(string $keyId): string
+    public function metadataForIdp(?string $keyId): string
     {
         $identityProvider = $this->idpFactory->createEngineBlockEntityFrom($keyId);
 
@@ -111,7 +108,7 @@ class MetadataProvider
      */
     public function metadataForIdps(
         ?string $spEntityId,
-        string $keyId
+        ?string $keyId
     ): string {
 
         if ($spEntityId) {

--- a/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
+++ b/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
@@ -99,7 +99,7 @@ class MetadataRenderer
         return $signedXml;
     }
 
-    public function fromIdentityProviderEntity(IdentityProviderEntityInterface $idp, string $keyId) : string
+    public function fromIdentityProviderEntity(IdentityProviderEntityInterface $idp, ?string $keyId) : string
     {
         $this->signingKeyPair = $this->keyPairFactory->buildFromIdentifier($keyId);
         $template = '@theme/Authentication/View/Metadata/idp.xml.twig';
@@ -110,7 +110,7 @@ class MetadataRenderer
         return $signedXml;
     }
 
-    public function fromIdentityProviderEntities(IdentityProviderEntityCollection $idps, string $keyId) : string
+    public function fromIdentityProviderEntities(IdentityProviderEntityCollection $idps, ?string $keyId) : string
     {
         $this->signingKeyPair = $this->keyPairFactory->buildFromIdentifier($keyId);
         $template = '@theme/Authentication/View/Metadata/idps.xml.twig';

--- a/src/OpenConext/EngineBlockBundle/Controller/MetadataController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/MetadataController.php
@@ -61,10 +61,6 @@ class MetadataController
      */
     public function idpMetadataAction($keyId = null)
     {
-        if (empty($keyId)) {
-            $keyId = KeyPairFactory::DEFAULT_KEY_PAIR_IDENTIFIER;
-        }
-
         $metadataXml = $this->metadataService->metadataForIdp($keyId);
 
         $response = new Response($metadataXml);
@@ -100,10 +96,6 @@ class MetadataController
      */
     public function allIdpsMetadataAction(Request $request, $keyId = null)
     {
-        if (empty($keyId)) {
-            $keyId = KeyPairFactory::DEFAULT_KEY_PAIR_IDENTIFIER;
-        }
-
         $spEntityId = $request->query->get('sp-entity-id', null);
 
         $metadataXml = $this->metadataService->metadataForIdps($spEntityId, $keyId);

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockIdentityProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/EngineblockIdentityProviderTest.php
@@ -68,7 +68,7 @@ class EngineblockIdentityProviderTest extends AbstractEntityTest
                 // SLO: EngineBlockIdentityProvider::getSingleLogoutService
                 ['authentication_logout', false, null, null],
                 // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
-                ['authentication_idp_sso', false, null, null]
+                ['authentication_idp_sso', false, 'default', null]
             ) ->willReturnOnConsecutiveCalls(
                 // SLO
                 'sloLocation',
@@ -76,7 +76,7 @@ class EngineblockIdentityProviderTest extends AbstractEntityTest
                 'ssoLocation'
             );
 
-        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, 'default', $this->keyPairMock, $this->urlProvider);
 
         $supportedNameIdFormats = [
             Constants::NAMEID_PERSISTENT,
@@ -101,7 +101,7 @@ class EngineblockIdentityProviderTest extends AbstractEntityTest
             ->with('authentication_logout', false, null, null)
             ->willReturn('sloLocation');
 
-        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, 'default', $this->keyPairMock, $this->urlProvider);
 
         $this->assertEquals($decorator->getSingleLogoutService(), new Service('sloLocation', Constants::BINDING_HTTP_REDIRECT));
     }
@@ -112,7 +112,7 @@ class EngineblockIdentityProviderTest extends AbstractEntityTest
             'singleLogoutService' => null,
         ]);
 
-        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, 'default', $this->keyPairMock, $this->urlProvider);
 
         $this->assertEquals($decorator->getSingleLogoutService(), null);
     }
@@ -125,13 +125,13 @@ class EngineblockIdentityProviderTest extends AbstractEntityTest
             ->method('getUrl')
             ->withConsecutive(
                 // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
-                ['authentication_idp_sso', false, null, null]  // we would expect the fourth paremeter to be null and not 'entity-id' becasue we are EB
+                ['authentication_idp_sso', false, 'default', null]  // we would expect the fourth paremeter to be null and not 'entity-id' becasue we are EB
             ) ->willReturnOnConsecutiveCalls(
                 // SSO
                 'ssoLocation'
             );
 
-        $decorator = new EngineBlockIdentityProvider($this->adapter, $this->keyPairMock, $this->urlProvider);
+        $decorator = new EngineBlockIdentityProvider($this->adapter, 'default', $this->keyPairMock, $this->urlProvider);
 
         $this->assertEquals([new Service('ssoLocation', Constants::BINDING_HTTP_REDIRECT)], $decorator->getSingleSignOnServices());
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Decorator/ProxiedIdentityProviderTest.php
@@ -71,6 +71,7 @@ class ProxiedIdentityProviderTest extends AbstractEntityTest
         $decorator = new ProxiedIdentityProvider(
             $this->adapter,
             $configuration,
+            null,
             $this->keyPairMock,
             $this->urlProvider
         );

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/IdentityProviderFactoryTest.php
@@ -17,13 +17,11 @@
 
 namespace OpenConext\EngineBlock\Metadata\Factory\Factory;
 
-use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Factory\AbstractEntityTest;
 use OpenConext\EngineBlock\Metadata\Factory\Adapter\IdentityProviderEntity;
-use OpenConext\EngineBlock\Metadata\Factory\Decorator\ProxiedIdentityProvider;
 use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration;
 use OpenConext\EngineBlock\Metadata\Logo;
@@ -136,7 +134,7 @@ class IdentityProviderFactoryTest extends AbstractEntityTest
             ->method('getUrl')
             ->withConsecutive(
             // SSO: EngineBlockIdentityProvider::getSingleSignOnServices
-                ['authentication_idp_sso', false, null, 'entity-id']
+                ['authentication_idp_sso', false, 'default', 'entity-id']
             ) ->willReturnOnConsecutiveCalls(
             // SSO
                 'proxiedSsoLocation'


### PR DESCRIPTION
The rollover key was not present in the IdP metadata of EngineBlock. This is taken care of in this commit.

An additional challenge arose: The Key Id is not always explicitly defined when opening the IdP metadata, in fact it is only used in roll-over scenarios. Setting the default by default caused the SSO URl to be filled with key:default. Where this is not a requirement.

https://www.pivotaltracker.com/story/show/174672018