### PR TITLE
Whether MFA AuthnContext must be added should be based on original SP

### DIFF
--- a/library/EngineBlock/Corto/Filter/Input.php
+++ b/library/EngineBlock/Corto/Filter/Input.php
@@ -44,7 +44,7 @@ class EngineBlock_Corto_Filter_Input extends EngineBlock_Corto_Filter_Abstract
             new EngineBlock_Corto_Filter_Command_ValidateAuthnContextClassRef($logger, $authnContextClassRefBlacklistPattern),
 
             // Validate if the MFA authnContextClassRef is valid when configured
-            new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef(),
+            new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($logger),
 
             // Convert all OID attributes to URN and remove the OID variant
             new EngineBlock_Corto_Filter_Command_NormalizeAttributes(),

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -417,7 +417,7 @@ class EngineBlock_Corto_ProxyServer
         }
 
         // Add authncontextclassref if configured
-        $service = $identityProvider->getCoins()->mfaEntities()->findByEntityId($serviceProvider->getEntityId()->getEntityId());
+        $service = $identityProvider->getCoins()->mfaEntities()->findByEntityId($this->findOriginalServiceProvider($spRequest, $this->_logger)->entityId);
         if ($service instanceof MfaEntity) {
             $sspMessage->setRequestedAuthnContext([
                 'AuthnContextClassRef' => [

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -16,15 +16,16 @@
  * limitations under the License.
  */
 
-use OpenConext\EngineBlock\Metadata\Loa;
-use OpenConext\EngineBlock\Metadata\MfaEntity;
-use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
-use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Loa;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Metadata\MfaEntity;
 use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
+use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
 use OpenConext\Value\Saml\Entity;
 use OpenConext\Value\Saml\EntityId;
 use OpenConext\Value\Saml\EntityType;
@@ -416,8 +417,15 @@ class EngineBlock_Corto_ProxyServer
             throw new EngineBlock_Corto_ProxyServer_Exception(sprintf('Unknown message type: "%s"', get_class($sspMessage)));
         }
 
+        try {
+            $originalSpEnitytId = $this->findOriginalServiceProvider($spRequest, $this->_logger)->entityId;
+        } catch (EntityNotFoundException $e) {
+            // On debug requests, the entity ID can not be found in the database as this is the EngineBlock internal
+            // entity which does not reside in the database.
+            $originalSpEnitytId = $spEntityId;
+        }
         // Add authncontextclassref if configured
-        $service = $identityProvider->getCoins()->mfaEntities()->findByEntityId($this->findOriginalServiceProvider($spRequest, $this->_logger)->entityId);
+        $service = $identityProvider->getCoins()->mfaEntities()->findByEntityId($originalSpEnitytId);
         if ($service instanceof MfaEntity) {
             $sspMessage->setRequestedAuthnContext([
                 'AuthnContextClassRef' => [

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/ValidateMfaAuthnContextClassRefTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/ValidateMfaAuthnContextClassRefTest.php
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -26,7 +27,8 @@ use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\MfaEntityCollection;
 use PHPUnit\Framework\TestCase;
 use SAML2\Assertion;
-use SAML2\Response;
+use SAML2\AuthnRequest;
+use SAML2\Response as SAMLResponse;
 
 class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest extends TestCase
 {
@@ -42,22 +44,42 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
      */
     private $logger;
 
+    /**
+     * @var EngineBlock_Saml2_AuthnRequestAnnotationDecorator
+     */
+    private $request;
+    private $server;
+
     public function setUp()
     {
         $this->handler = new TestHandler();
         $this->logger  = new Logger('Test', array($this->handler));
+        $assertion = new Assertion();
+
+        $request = new AuthnRequest();
+        $response = new SAMLResponse();
+        $response->setAssertions(array($assertion));
+
+        $this->request = new EngineBlock_Saml2_AuthnRequestAnnotationDecorator($request);
+
+        $this->sp = new ServiceProvider('Test SP');
+        $this->server = m::mock(EngineBlock_Corto_ProxyServer::class);
+        $this->server
+            ->shouldReceive('findOriginalServiceProvider')
+            ->andReturn($this->sp)
+        ;
     }
 
     public function testNoConfiguredMfaCombinationShouldPass()
     {
-        $this->expectNotToPerformAssertions();
-
         $response = $this->createTestResponse('urn:oasis:names:tc:SAML:2.0:ac:classes:Password');
 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);
         $verifier->setIdentityProvider(new IdentityProvider('MFA IdP'));
-        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+        $verifier->setServiceProvider($this->sp);
+        $verifier->setRequest($this->request);
+        $verifier->setProxyServer($this->server);
 
         $verifier->execute();
     }
@@ -71,7 +93,9 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);
         $verifier->setIdentityProvider($identityProvider);
-        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+        $verifier->setServiceProvider($this->sp);
+        $verifier->setRequest($this->request);
+        $verifier->setProxyServer($this->server);
 
         $verifier->execute();
 
@@ -87,7 +111,9 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);
         $verifier->setIdentityProvider($identityProvider);
-        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+        $verifier->setServiceProvider($this->sp);
+        $verifier->setRequest($this->request);
+        $verifier->setProxyServer($this->server);
 
         $verifier->execute();
 
@@ -107,7 +133,9 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);
         $verifier->setIdentityProvider($identityProvider);
-        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+        $verifier->setServiceProvider($this->sp);
+        $verifier->setRequest($this->request);
+        $verifier->setProxyServer($this->server);
 
         $verifier->execute();
 
@@ -127,7 +155,9 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);
         $verifier->setIdentityProvider($identityProvider);
-        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+        $verifier->setServiceProvider($this->sp);
+        $verifier->setRequest($this->request);
+        $verifier->setProxyServer($this->server);
 
         $verifier->execute();
 
@@ -151,7 +181,9 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);
         $verifier->setIdentityProvider($identityProvider);
-        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+        $verifier->setServiceProvider($this->sp);
+        $verifier->setRequest($this->request);
+        $verifier->setProxyServer($this->server);
 
         $verifier->execute();
     }
@@ -171,7 +203,9 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);
         $verifier->setIdentityProvider($identityProvider);
-        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+        $verifier->setServiceProvider($this->sp);
+        $verifier->setRequest($this->request);
+        $verifier->setProxyServer($this->server);
 
         $verifier->execute();
 
@@ -187,7 +221,9 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
         $verifier = new EngineBlock_Corto_Filter_Command_ValidateMfaAuthnContextClassRef($this->logger);
         $verifier->setResponse($response);
         $verifier->setIdentityProvider($identityProvider);
-        $verifier->setServiceProvider(new ServiceProvider('Test SP'));
+        $verifier->setServiceProvider($this->sp);
+        $verifier->setRequest($this->request);
+        $verifier->setProxyServer($this->server);
 
         $verifier->execute();
 
@@ -227,7 +263,7 @@ class EngineBlock_Test_Corto_Filter_Command_ValidateMfaAuthnContextClassRefTest 
             ]);
         }
 
-        $response = new Response();
+        $response = new SAMLResponse();
         $response->setAssertions(array($assertion));
 
         return new EngineBlock_Saml2_ResponseAnnotationDecorator($response);


### PR DESCRIPTION
So this also works when the SP in question is behind a trusted proxy.