### PR TITLE
Test whether MFA AuthnContext must be added should be based on original SP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ More information about our release strategy can be found in the [Development Gui
 ## 6.3.4
 
 **Bugfix**
- - Whether MFA AuthnContext must be added should be based on original SP #893
+ - Whether MFA AuthnContext must be added should be based on original SP #893 #894
 
 ## 6.3.3
 **Bugfixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ We will continue to post relevant release notes on the GitHub release page. More
 
 More information about our release strategy can be found in the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes) on the EngineBlock wiki.
 
+## 6.3.4
+
+**Bugfix**
+ - Whether MFA AuthnContext must be added should be based on original SP #893
+
 ## 6.3.3
 **Bugfixes:**
  - Move NoPassive response processing up in the ACS proces #890

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
@@ -9,10 +9,21 @@ Feature:
     And no registered Idps
     And an Identity Provider named "SSO-IdP"
     And a Service Provider named "SSO-SP"
+    And a Service Provider named "Trusted SP"
 
   Scenario: The configured authn method should be set as AuthnContextClassRef if configured with the IdP configuration mapping
     Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
     When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SSO-IdP/sso"
+    And the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef[text()="http://schemas.microsoft.com/claims/multipleauthn"]'
+
+  Scenario: The configured authn method should be set as AuthnContextClassRef if configured with the IdP configuration mapping for Trusted Proxy
+    Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
+    And SP "Trusted SP" is a trusted proxy
+    And SP "Trusted SP" signs its requests
+    And  SP "Trusted SP" is authenticating for SP "SSO-SP"
+    When I log in at "Trusted SP"
     And I pass through EngineBlock
     Then the url should match "functional-testing/SSO-IdP/sso"
     And the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef[text()="http://schemas.microsoft.com/claims/multipleauthn"]'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
@@ -5,58 +5,58 @@ Feature:
 
   Background:
     Given an EngineBlock instance on "vm.openconext.org"
-      And no registered SPs
-      And no registered Idps
-      And an Identity Provider named "SSO-IdP"
-      And a Service Provider named "SSO-SP"
+    And no registered SPs
+    And no registered Idps
+    And an Identity Provider named "SSO-IdP"
+    And a Service Provider named "SSO-SP"
 
-    Scenario: The configured authn method should be set as AuthnContextClassRef if configured with the IdP configuration mapping
-      Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
-      When I log in at "SSO-SP"
-        And I pass through EngineBlock
-      Then the url should match "functional-testing/SSO-IdP/sso"
-        And the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef[text()="http://schemas.microsoft.com/claims/multipleauthn"]'
-
-    Scenario: The configured authn method should not be set as AuthnContextClassRef if not configured in the IdP configuration mapping
-      When I log in at "SSO-SP"
-        And I pass through EngineBlock
+  Scenario: The configured authn method should be set as AuthnContextClassRef if configured with the IdP configuration mapping
+    Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
     Then the url should match "functional-testing/SSO-IdP/sso"
-      And the response should not contain "http://schemas.microsoft.com/claims/multipleauthn"
+    And the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef[text()="http://schemas.microsoft.com/claims/multipleauthn"]'
+
+  Scenario: The configured authn method should not be set as AuthnContextClassRef if not configured in the IdP configuration mapping
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SSO-IdP/sso"
+    And the response should not contain "http://schemas.microsoft.com/claims/multipleauthn"
 
   Scenario: The configured authn method should also be set for unsolicited logins if configured in the IdP configuration mapping
     Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
     When An IdP initiated Single Sign on for SP "SSO-SP" is triggered by IdP "SSO-IdP"
-      And I pass through EngineBlock
+    And I pass through EngineBlock
     Then the url should match "functional-testing/SSO-IdP/sso"
     And the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef[text()="http://schemas.microsoft.com/claims/multipleauthn"]'
 
-    Scenario: A login should succeed if the configured authn method is set as AuthnContextClassRef in the IdP response
-      Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
-        And the IdP "SSO-IdP" sends AuthnContextClassRef with value "http://schemas.microsoft.com/claims/multipleauthn"
-      When I log in at "SSO-SP"
-        And I pass through EngineBlock
-        And I pass through the IdP
-        And I give my consent
-        And I pass through EngineBlock
-      Then the url should match "/functional-testing/SSO-SP/acs"
+  Scenario: A login should succeed if the configured authn method is set as AuthnContextClassRef in the IdP response
+    Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
+    And the IdP "SSO-IdP" sends AuthnContextClassRef with value "http://schemas.microsoft.com/claims/multipleauthn"
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+    Then the url should match "/functional-testing/SSO-SP/acs"
 
   Scenario: A login should succeed if the configured authn method is set as one of the values in the http://schemas.microsoft.com/claims/authnmethodsreferences attribute in the IdP response
     Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
-      And the IdP "SSO-IdP" sends attribute "http://schemas.microsoft.com/claims/authnmethodsreferences" with values "http://schemas.microsoft.com/claims/multipleauthn" and xsi:type is "xs:string"
+    And the IdP "SSO-IdP" sends attribute "http://schemas.microsoft.com/claims/authnmethodsreferences" with values "http://schemas.microsoft.com/claims/multipleauthn" and xsi:type is "xs:string"
     When I log in at "SSO-SP"
-      And I pass through EngineBlock
-      And I pass through the IdP
-      And I give my consent
-      And I pass through EngineBlock
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
     Then the url should match "/functional-testing/SSO-SP/acs"
 
   Scenario: A login should fail if the configured authn method is not in the IdP response as AuthnContextClassRef or as a value in the http://schemas.microsoft.com/claims/authnmethodsreferences attribute
     Given the IdP "SSO-IdP" is configured for MFA authn method "http://schemas.microsoft.com/claims/multipleauthn" for SP "SSO-SP"
     When I log in at "SSO-SP"
-      And I pass through EngineBlock
-      And I pass through the IdP
+    And I pass through EngineBlock
+    And I pass through the IdP
     Then I should see "Error - Multi factor authentication failed"
-      And the url should match "/authentication/feedback/invalid-mfa-authn-context-class-ref"
+    And the url should match "/authentication/feedback/invalid-mfa-authn-context-class-ref"
 
   Scenario: The SP provided authn method should be set as AuthnContextClassRef if SP configured with transparent_authn_context
     Given the IdP "SSO-IdP" is configured for MFA authn method "transparent_authn_context" for SP "SSO-SP"


### PR DESCRIPTION
This adds a test for the recently closed #893. I promised to test this feature, and writing a Behat scenario proved least difficult and should yield a good regression measure.