### PR TITLE
Improve consent test endpoint

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -43,6 +43,21 @@ jobs:
                     ./app/console cache:clear --env=ci && \
                     cd theme && CYPRESS_INSTALL_BINARY=0 npm ci && npm run build
                 '
+            - name: Run code quality tests
+              if: always()
+              run: |
+                  cd docker && docker-compose exec -T php-fpm.vm.openconext.org bash -c '
+                      echo -e "\nPHP Mess Detector\n" && \
+                      ./vendor/bin/phpmd src text ci/qa-config/phpmd.xml --exclude */Tests/* && \
+                      echo -e "\nPHP CodeSniffer\n" && \
+                      ./vendor/bin/phpcs --report=full --standard=ci/qa-config/phpcs.xml --warning-severity=0 --extensions=php src  && \
+                      echo -e "\nPHP CodeSniffer (legacy code)\n" && \
+                      ./vendor/bin/phpcs --standard=ci/qa-config/phpcs-legacy.xml --warning-severity=0 --extensions=php -s library  && \
+                      echo -e "\nDoc header check\n" && \
+                      ./vendor/bin/docheader check src/ tests/ library/ --exclude-dir resources --exclude-dir languages
+                  '
+              env:
+                  SYMFONY_ENV: ci
             - name: Run unit tests
               if: always()
               run: |
@@ -90,21 +105,6 @@ jobs:
               run: |
                   cd docker && docker-compose exec -T cypress bash -c '
                       cypress run --browser=firefox --headless
-                  '
-              env:
-                  SYMFONY_ENV: ci
-            - name: Run code quality tests
-              if: always()
-              run: |
-                  cd docker && docker-compose exec -T php-fpm.vm.openconext.org bash -c '
-                      echo -e "\nPHP Mess Detector\n" && \
-                      ./vendor/bin/phpmd src text ci/qa-config/phpmd.xml --exclude */Tests/* && \
-                      echo -e "\nPHP CodeSniffer\n" && \
-                      ./vendor/bin/phpcs --report=full --standard=ci/qa-config/phpcs.xml --warning-severity=0 --extensions=php src  && \
-                      echo -e "\nPHP CodeSniffer (legacy code)\n" && \
-                      ./vendor/bin/phpcs --standard=ci/qa-config/phpcs-legacy.xml --warning-severity=0 --extensions=php -s library  && \
-                      echo -e "\nDoc header check\n" && \
-                      ./vendor/bin/docheader check src/ tests/ library/ --exclude-dir resources
                   '
               env:
                   SYMFONY_ENV: ci

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -10,6 +10,10 @@ services:
 
 framework:
     test: ~
+    translator:
+        paths:
+            - '%kernel.root_dir%/../languages'
+            - '%kernel.root_dir%/../src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/languages'
     session:
         storage_id: session.storage.mock_file
         name: MOCKSESSION

--- a/build.xml
+++ b/build.xml
@@ -126,7 +126,7 @@
 
     <target name="doc-header" description="Check if the copyright header is valid">
         <exec executable="vendor/bin/docheader" failonerror="true">
-            <arg line="check src/ tests/ library/ --exclude-dir resources" />
+            <arg line="check src/ tests/ library/  --exclude-dir resources --exclude-dir languages" />
         </exec>
     </target>
 

--- a/docs/js_testing.md
+++ b/docs/js_testing.md
@@ -69,10 +69,12 @@ The consent screen is available on: `/functional-testing/consent`
 
 | **Query parameter** | **Default value** | **Explanation** |
 |---|----|----|
+| name-id | (string) 'user@openconext' | Type: string. The name id of the authenticating user |
 | idp-name | (string) 'DisplayName' | Type: string. The name displayed for the IdP that released the attributes |
 | sp-name | (string) 'DisplayName' | Type: string. The name displayed for the authenticating service provider |
 | hide-header | (bool) true | Type: boolean |
 | hide-footer | (bool) true | Type: boolean |
+| persistent-name-id | (bool) true | Type: boolean. Is the name id configured to be persistent? This affects the rendering of the attributes |
 
 ## Acceptance tests
 The WAYF acceptance tests utilize the `/functional-testing/wayf` endpoint in order to test the correct inner working of

--- a/docs/js_testing.md
+++ b/docs/js_testing.md
@@ -70,6 +70,7 @@ The consent screen is available on: `/functional-testing/consent`
 | **Query parameter** | **Default value** | **Explanation** |
 |---|----|----|
 | idp-name | (string) 'DisplayName' | Type: string. The name displayed for the IdP that released the attributes |
+| sp-name | (string) 'DisplayName' | Type: string. The name displayed for the authenticating service provider |
 
 ## Acceptance tests
 The WAYF acceptance tests utilize the `/functional-testing/wayf` endpoint in order to test the correct inner working of

--- a/docs/js_testing.md
+++ b/docs/js_testing.md
@@ -63,6 +63,14 @@ parameters can be used to manipulate the behaviour of the wayf that is rendered.
 
 For a list of realistic reproductions of the available error pages, see this JavasScript test: `theme/cypress/integration/visual-regression/error-page/ErrorPage.spec.js`
 
+### Consent
+The consent screen is available on: `/functional-testing/consent`
+
+
+| **Query parameter** | **Default value** | **Explanation** |
+|---|----|----|
+| idp-name | (string) 'DisplayName' | Type: string. The name displayed for the IdP that released the attributes |
+
 ## Acceptance tests
 The WAYF acceptance tests utilize the `/functional-testing/wayf` endpoint in order to test the correct inner working of
 the WAYF.

--- a/docs/js_testing.md
+++ b/docs/js_testing.md
@@ -75,6 +75,7 @@ The consent screen is available on: `/functional-testing/consent`
 | hide-header | (bool) true | Type: boolean |
 | hide-footer | (bool) true | Type: boolean |
 | persistent-name-id | (bool) true | Type: boolean. Is the name id configured to be persistent? This affects the rendering of the attributes |
+| aa-enabled | (bool) true | Type: boolean. Is attribute aggregation enabled, if flagged, two dummy AA sources are configured. And two attributes from those sources are included in the attribute list (EckID & OrcID ID).  |
 
 ## Acceptance tests
 The WAYF acceptance tests utilize the `/functional-testing/wayf` endpoint in order to test the correct inner working of

--- a/docs/js_testing.md
+++ b/docs/js_testing.md
@@ -71,6 +71,8 @@ The consent screen is available on: `/functional-testing/consent`
 |---|----|----|
 | idp-name | (string) 'DisplayName' | Type: string. The name displayed for the IdP that released the attributes |
 | sp-name | (string) 'DisplayName' | Type: string. The name displayed for the authenticating service provider |
+| hide-header | (bool) true | Type: boolean |
+| hide-footer | (bool) true | Type: boolean |
 
 ## Acceptance tests
 The WAYF acceptance tests utilize the `/functional-testing/wayf` endpoint in order to test the correct inner working of

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
@@ -46,10 +46,14 @@ class ConsentController
      */
     public function consentAction(Request $request)
     {
+        $idpName = null;
+        if ($request->query->has('idp-name')) {
+            $idpName = $request->query->get('idp-name');
+        }
         $processConsentUrl = '#';
         $fakeResponseId = '918723649';
         $fakeSp = TestEntitySeeder::buildSp();
-        $fakeIdP = TestEntitySeeder::buildIdP();
+        $fakeIdP = TestEntitySeeder::buildIdP($idpName);
         $supportContact = 'Helpdesk';
         $nameId = new NameID();
         $nameId->setValue('user@openconext');

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
@@ -18,6 +18,7 @@
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Controllers;
 
 use OpenConext\EngineBlockFunctionalTestingBundle\Helper\TestEntitySeeder;
+use SAML2\Constants;
 use SAML2\XML\saml\NameID;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -60,8 +61,7 @@ class ConsentController
         $fakeSp = TestEntitySeeder::buildSp($spName);
         $fakeIdP = TestEntitySeeder::buildIdP($idpName);
         $supportContact = 'Helpdesk';
-        $nameId = new NameID();
-        $nameId->setValue('user@openconext');
+
         $profileUrl = 'profile.openconext.org';
         $attributes = [
             'urn:mace:dir:attribute-def:displayName' => ['John Doe'],
@@ -90,8 +90,8 @@ class ConsentController
             'attributeMotivations' => $attributeMotivations,
             'minimalConsent' => $fakeIdP->getConsentSettings()->isMinimal($fakeSp->entityId),
             'consentCount' => 5,
-            'nameId' => $nameId,
-            'nameIdIsPersistent' => true,
+            'nameId' => $this->getNameId($request),
+            'nameIdIsPersistent' => $this->isPersistentNameId($request),
             'profileUrl' => $profileUrl,
             'showConsentExplanation' => $fakeIdP->getConsentSettings()->hasConsentExplanation($fakeSp->entityId),
             'consentSettings' => $fakeIdP->getConsentSettings(),
@@ -109,5 +109,21 @@ class ConsentController
     private function hideFooter(Request $request): bool
     {
         return (bool) $request->query->get('hide-footer', true);
+    }
+
+    private function getNameId(Request $request): NameID
+    {
+        $nameIdValue = $request->query->get('name-id', 'user@openconext');
+        $nameId = new NameID();
+        if ($nameIdValue !== 'user@openconext') {
+            $nameId->setFormat(Constants::NAMEID_UNSPECIFIED);
+        }
+        $nameId->setValue($nameIdValue);
+        return $nameId;
+    }
+
+    private function isPersistentNameId(Request $request): bool
+    {
+        return (bool) $request->query->get('persistent-name-id', true);
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
@@ -54,6 +54,7 @@ class ConsentController
         if ($request->query->has('sp-name')) {
             $spName = $request->query->get('sp-name');
         }
+
         $processConsentUrl = '#';
         $fakeResponseId = '918723649';
         $fakeSp = TestEntitySeeder::buildSp($spName);
@@ -95,8 +96,18 @@ class ConsentController
             'showConsentExplanation' => $fakeIdP->getConsentSettings()->hasConsentExplanation($fakeSp->entityId),
             'consentSettings' => $fakeIdP->getConsentSettings(),
             'spEntityId' => $fakeSp->entityId,
-            'hideHeader' => true,
-            'hideFooter' => true,
+            'hideHeader' => $this->hideHeader($request),
+            'hideFooter' => $this->hideFooter($request),
         ]), 200);
+    }
+
+    private function hideHeader(Request $request): bool
+    {
+        return (bool) $request->query->get('hide-header', true);
+    }
+
+    private function hideFooter(Request $request): bool
+    {
+        return (bool) $request->query->get('hide-footer', true);
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
@@ -47,12 +47,16 @@ class ConsentController
     public function consentAction(Request $request)
     {
         $idpName = null;
+        $spName = null;
         if ($request->query->has('idp-name')) {
             $idpName = $request->query->get('idp-name');
         }
+        if ($request->query->has('sp-name')) {
+            $spName = $request->query->get('sp-name');
+        }
         $processConsentUrl = '#';
         $fakeResponseId = '918723649';
-        $fakeSp = TestEntitySeeder::buildSp();
+        $fakeSp = TestEntitySeeder::buildSp($spName);
         $fakeIdP = TestEntitySeeder::buildIdP($idpName);
         $supportContact = 'Helpdesk';
         $nameId = new NameID();

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
@@ -122,15 +122,18 @@ class TestEntitySeeder
      * Build a very rudimentary SP entity
      * @return ServiceProvider
      */
-    public static function buildSp()
+    public static function buildSp(?string $spName = null)
     {
+        if (!$spName) {
+            $spName = 'DisplayName';
+        }
         $serviceProvider = new ServiceProvider('https://acme-sp.example.com');
-        $serviceProvider->nameNl = 'DisplayName NL';
-        $serviceProvider->nameEn = 'DisplayName EN';
-        $serviceProvider->namePt = 'DisplayName PT';
-        $serviceProvider->displayNameNl = 'DisplayName';
-        $serviceProvider->displayNameEn = 'DisplayName';
-        $serviceProvider->displayNamePt = 'DisplayName';
+        $serviceProvider->nameNl = $spName . ' NL';
+        $serviceProvider->nameEn = $spName . ' EN';
+        $serviceProvider->namePt = $spName . ' PT';
+        $serviceProvider->displayNameNl = $spName . '';
+        $serviceProvider->displayNameEn = $spName . '';
+        $serviceProvider->displayNamePt = $spName . '';
         $serviceProvider->logo = new Logo('/images/logo.png');
         return $serviceProvider;
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
@@ -139,15 +139,18 @@ class TestEntitySeeder
      * Build a very rudimentary IdP entity
      * @return IdentityProvider
      */
-    public static function buildIdP()
+    public static function buildIdP(?string $idpName)
     {
+        if (!$idpName) {
+            $idpName = 'DisplayName';
+        }
         $identityProvider = new IdentityProvider('https://acme-idp.example.com');
-        $identityProvider->nameNl = 'DisplayName NL';
-        $identityProvider->nameEn = 'DisplayName EN';
-        $identityProvider->namePt = 'DisplayName PT';
-        $identityProvider->displayNameNl = 'DisplayName NL';
-        $identityProvider->displayNameEn = 'DisplayName EN';
-        $identityProvider->displayNamePt = 'DisplayName PT';
+        $identityProvider->nameNl = $idpName . ' NL';
+        $identityProvider->nameEn = $idpName . ' EN';
+        $identityProvider->namePt = $idpName . ' PT';
+        $identityProvider->displayNameNl = $idpName . ' NL';
+        $identityProvider->displayNameEn = $idpName . ' EN';
+        $identityProvider->displayNamePt = $idpName . ' PT';
         $identityProvider->logo = new Logo('/images/logo.png');
         return $identityProvider;
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/languages/messages.en.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/languages/messages.en.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'consent_attribute_source_orcid' => 'ORCID iD',
+    'consent_attribute_source_sab' => 'SURFnet Authorisation Management',
+    'consent_attribute_source_logo_url_sab' => '/images/logo.png',
+];

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/languages/messages.nl.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/languages/messages.nl.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'consent_attribute_source_orcid' => 'ORCID iD',
+    'consent_attribute_source_sab' => 'SURFnet Autorisatie Beheer',
+    'consent_attribute_source_logo_url_sab' => '/images/logo.png',
+];

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/languages/messages.pt.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/languages/messages.pt.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'consent_attribute_source_orcid' => 'ORCID iD',
+    'consent_attribute_source_sab' => 'SURFnet Autorisatie Beheer',
+    'consent_attribute_source_logo_url_sab' => '/images/logo.png',
+];


### PR DESCRIPTION
The low hanging fruit for overriding the default consent functional testing controller has been updated here.

What remains to do is setting the attributes and more importantly the attribute sources.

The new query parameters available on this endpoint can be found in the js-testing readme file.

NameID overriding is a somewhat strange override. When you use the `name-id` query param, the name id is set to be `unspecified`. Even if you use the `persistent-name-id` feature flag. 