### PR TITLE
Clean up unused usage of authnrequest destination

### DIFF
--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -183,9 +183,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         $_SESSION['currentServiceProvider'] = $ebRequest->getIssuer()->getValue();
 
         // Verify that we know this SP and have metadata for it.
-        $serviceProvider = $this->_verifyKnownSP(
-            $spEntityId->getValue()
-        );
+        $serviceProvider = $this->_verifyKnownSP($spEntityId->getValue());
 
         if (!$serviceProvider instanceof ServiceProvider) {
             throw new EngineBlock_Corto_Module_Bindings_Exception(

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -184,8 +184,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
         // Verify that we know this SP and have metadata for it.
         $serviceProvider = $this->_verifyKnownSP(
-            $spEntityId->getValue(),
-            $ebRequest->getDestination()
+            $spEntityId->getValue()
         );
 
         if (!$serviceProvider instanceof ServiceProvider) {
@@ -513,11 +512,10 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
      * Verify if a message has an issuer that is known as an SP to us. If not, it
      * throws a Corto_Module_Bindings_VerificationException.
      * @param string $messageIssuer
-     * @param string $destination
      * @return AbstractRole Remote Entity that issued the message
      * @throws EngineBlock_Exception_UnknownServiceProvider
      */
-    protected function _verifyKnownSP(string $messageIssuer, string $destination = '')
+    protected function _verifyKnownSP(string $messageIssuer)
     {
         $remoteEntity = $this->_server->getRepository()->findServiceProviderByEntityId($messageIssuer);
 
@@ -534,8 +532,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
 
         throw new EngineBlock_Exception_UnknownServiceProvider(
             sprintf('Issuer "%s" is not a known remote entity? (please add SP to Remote Entities)', $messageIssuer),
-            $messageIssuer,
-            $destination
+            $messageIssuer
         );
     }
 

--- a/library/EngineBlock/Exception/UnknownServiceProvider.php
+++ b/library/EngineBlock/Exception/UnknownServiceProvider.php
@@ -19,22 +19,15 @@
 class EngineBlock_Exception_UnknownServiceProvider extends Exception
 {
     private $_entityId;
-    private $_destination;
 
-    function __construct($message, $entityId, $destination)
+    function __construct($message, $entityId)
     {
         parent::__construct($message);
         $this->_entityId = $entityId;
-        $this->_destination = $destination;
     }
 
     public function getEntityId()
     {
         return $this->_entityId;
-    }
-
-    public function getDestination()
-    {
-        return $this->_destination;
     }
 }

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -160,7 +160,6 @@ class RedirectToFeedbackPageExceptionListener
 
             $redirectParams  = [
                 'entity-id'   => $exception->getEntityId(),
-                'destination' => $exception->getDestination()
             ];
         } elseif ($exception instanceof EngineBlock_Exception_UnknownIdentityProvider) {
             $message         = 'Unknown Identity Provider';


### PR DESCRIPTION
This is actually a bugfix. Sending an AuthnRequest to EB >= 6.3.1 that has no `Destination` parameter (which is indeed optional in the spec):

```xml
<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
                    ID="CORTO7b58fe48a7c62ea17e02b50a68b0dfa021d69280"
                    Version="2.0"
                    IssueInstant="2020-09-22T14:43:47Z"
                    >
    <saml:Issuer>http://example.org</saml:Issuer>
</samlp:AuthnRequest>
```

Would yield a fatal error:
```
Argument 2 passed to EngineBlock_Corto_Module_Bindings::_verifyKnownSP() must be of the type string, null given, called in /opt/openconext/OpenConext-engineblock-6.3.4/library/EngineBlock/Corto/Module/Bindings.php on line 188
```

Type `string` was added to the `$destination` parameter of `_verifyKnownSP()` in 6.3.1. Simple solution is to also allow null, but closer inspection shows that the destination is only passed down to a possible exception but there also not used at all (anymore?). So the even better solution seems to just clean it all up.