### PR TITLE
Add automatic a11y test and fix problems

### DIFF
--- a/theme/base/stylesheets/pages/wayf.scss
+++ b/theme/base/stylesheets/pages/wayf.scss
@@ -140,7 +140,7 @@
                 @include grid-position(1, 2, 2, 3);
                 color: $buttonBlue;
                 cursor: pointer;
-                font-size: $f-normal;
+                font-size: $f-large;
                 font-weight: $bolder;
                 line-height: 1.5;
                 margin: auto 0 calculateRem(34px) calculateRem(5px);
@@ -244,12 +244,10 @@
             }
 
             > .wayf__search {
+                @include relative;
                 margin: 2rem 0 1.25rem;
 
                 > .search__field {
-                    @include poirot;
-                    background-position: right .5rem center;
-                    background-size: 1.5rem 1.5rem;
                     border: 1px solid $gray;
                     border-radius: 6px;
                     box-shadow: 0 1px 0 2px #5e6873;
@@ -259,6 +257,17 @@
                     line-height: 1.5;
                     padding: 1rem;
                     width: 100%;
+                }
+
+                > .search__submit {
+                    @include absolute(top 0 right 0);
+                    @include button-reset($white);
+                    @include poirot;
+                    background-position: center center;
+                    background-size: 1.5rem 1.5rem;
+                    border-radius: 6px;
+                    height: 3rem;
+                    width: 3rem;
                 }
             }
 

--- a/theme/base/stylesheets/shared.scss
+++ b/theme/base/stylesheets/shared.scss
@@ -152,6 +152,10 @@ body {
                     &:focus {
                         line-height: 1.75;
                     }
+
+                    &:focus {
+                        outline: 3px dotted $white;
+                    }
                 }
 
                 ul.comp-language {

--- a/theme/base/stylesheets/shared.scss
+++ b/theme/base/stylesheets/shared.scss
@@ -23,16 +23,20 @@ body {
         box-sizing: border-box
     }
 
+    *:focus {
+        outline: 3px dotted $darkishBlue;
+        padding-left: 5px;
+        padding-right: 5px;
+    }
+
     a {
         &:hover {
             text-decoration: underline;
         }
     }
 
-    *:focus {
-        outline: 3px dotted $darkishBlue;
-        padding-left: 5px;
-        padding-right: 5px;
+    button {
+        cursor: pointer;
     }
 
     h3 {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp.html.twig
@@ -12,8 +12,8 @@
             <h3>{{ idp['displayTitle'] }}</h3>
 
             {% if idp['noAccess'] is defined and idp['noAccess'] or delete %}
-                <button data-connected="{{ idp['connected'] }}">
-{#                    {% if idp['noAccess'] is defined and idp['noAccess'] %}#}
+                <button data-connected="{{ idp['connected'] }}" type="button"> {# todo: add js here and also prevent the event from bubbling and so triggering the link ancestor #}
+{#                    {% if idp['noAccess'] is defined and idp['noAccess'] %}#} {# todo: turn this if back on once all js is added & tested #}
                         <span class="idp__disabled">
                             <span class="visually-hidden">
                                 {{ 'wayf_no_access_account'|trans }}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/search.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/search.html.twig
@@ -9,4 +9,5 @@
         placeholder="{{ 'wayf_search_placeholder'|trans }}"
         type="search"
     />
+    <button type="submit" class="search__submit"><span class="visually-hidden">{{ 'search'|trans }}</span></button>
 </form>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/search.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/search.html.twig
@@ -1,4 +1,4 @@
-<form class="wayf__search" method="post" action="{{ action }}">
+<form class="wayf__search" method="post" action="{{ action }}" role="search" aria-label="{{ 'wayf_search_aria'|trans }}">
     <input type="hidden" name="ID" value="{{ requestId }}"/>{# needed for the ContinueToIdp module #}
     <input type="hidden" id="form-idp" name="idp" value=""/>{# needed for the ContinueToIdp module #}
     <label for="wayf_search" class="visually-hidden">{{ 'search'|trans }}</label>

--- a/theme/cypress/integration/skeune/wayf/a11y.spec.js
+++ b/theme/cypress/integration/skeune/wayf/a11y.spec.js
@@ -1,6 +1,6 @@
 context('Consent a11y verify', () => {
   beforeEach(() => {
-    cy.visit('https://engine.vm.openconext.org/functional-testing/consent');
+    cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
   });
 
   it('contains no a11y problems on load', () => {

--- a/theme/cypress/support/commands.js
+++ b/theme/cypress/support/commands.js
@@ -22,3 +22,7 @@ Cypress.Commands.add('matchImageSnapshots', (viewport, pageDetails) => {
 Cypress.Commands.add('buildTheme', (themeName) => {
   cy.exec(`EB_THEME=${themeName} npm run buildtheme`);
 });
+
+Cypress.Commands.add('hideDebugBar', () => {
+  cy.get('.sf-toolbar').invoke('attr', 'style', 'display: none');
+});

--- a/theme/skeune/translations/messages.en.php
+++ b/theme/skeune/translations/messages.en.php
@@ -13,6 +13,7 @@ return [
     'wayf_remaining_idps_title' => 'Add an account from the list below',
     'wayf_select_account'       => 'Select an account from the list below',
     'wayf_search_placeholder'   => 'Search...',
+    'wayf_search_aria'          => 'Search identity providers',
     'wayf_your_accounts'        => 'Your accounts',
     'wayf_add_account'          => 'Add another account',
     'wayf_no_access_helpdesk'   => 'If you want, you can request access to this service. We will send the request to the helpdesk of your institution.',

--- a/theme/skeune/translations/messages.en.php
+++ b/theme/skeune/translations/messages.en.php
@@ -2,11 +2,12 @@
 return [
     // General
     'logo'  => 'logo',
+    'search'    => 'Search',
 
     // WAYF
     'wayf_nothing_found'        => 'Nothing found',
     'wayf_apu'                  => 'Please try again with some different keywords',
-    'wayf_noscript_warning'     => '<p>For this page to function optimally you need JavaScript turned on.</p><p>Without JavaScript you will not be able to remember previously used accounts.  If you want to use that functionality, please enable JavaScript.</p><p><strong>You can, off course, still log in.<strong></strong></p>',
+    'wayf_noscript_warning'     => '<p>For this page to function optimally you need JavaScript turned on.</p><p>Without JavaScript you will not be able to remember previously used accounts.  If you want to use that functionality, please enable JavaScript.</p><p><strong>You can, off course, still log in.</strong></p>',
     'wayf_no_access_account'    => 'No access with this account',
     'wayf_delete_account'       => 'Delete from your accounts',
     'wayf_remaining_idps_title' => 'Add an account from the list below',

--- a/theme/skeune/translations/messages.nl.php
+++ b/theme/skeune/translations/messages.nl.php
@@ -13,6 +13,7 @@ return [
     'wayf_remaining_idps_title' => 'Voeg een account toe uit de onderstaande lijst',
     'wayf_select_account'       => 'Selecteer een account uit de onderstaande lijst',
     'wayf_search_placeholder'   => 'Zoeken...',
+    'wayf_search_aria'          => 'Zoek een identity provider',
     'wayf_your_accounts'        => 'Uw accounts',
     'wayf_add_account'          => 'Voeg een account toe',
     'wayf_no_access_helpdesk'   => 'U kan toegang vragen tot deze dienst.  We sturen deze aanvraag door naar de helpdesk van uw instituut.',

--- a/theme/skeune/translations/messages.nl.php
+++ b/theme/skeune/translations/messages.nl.php
@@ -2,11 +2,12 @@
 return [
     // General
     'logo'  => 'logo',
+    'search'    => 'Zoeken',
 
     // WAYF
     'wayf_nothing_found'        => 'Niets gevonden',
     'wayf_apu'                  => 'Probeert u het opnieuw met andere zoektermen',
-    'wayf_noscript_warning'     => '<p>Om deze pagina optimaal te laten functioneren moet JavaScript aan staan.</p><p>Zonder JavaScript zal u geen vorig gebruikte accounts kunnen onthouden.  Indien u deze functionaliteit toch wenst te gebruiken, vragen wij u vriendelijk om JavaScript aan te zetten.</p><p><strong>U kan, vanzelfsprekend, nog steeds inloggen.<strong></strong></p>',
+    'wayf_noscript_warning'     => '<p>Om deze pagina optimaal te laten functioneren moet JavaScript aan staan.</p><p>Zonder JavaScript zal u geen vorig gebruikte accounts kunnen onthouden.  Indien u deze functionaliteit toch wenst te gebruiken, vragen wij u vriendelijk om JavaScript aan te zetten.</p><p><strong>U kan, vanzelfsprekend, nog steeds inloggen.</strong></p>',
     'wayf_no_access_account'    => 'Geen toegang met deze account',
     'wayf_delete_account'       => 'Verwijderen uit uw accounts',
     'wayf_remaining_idps_title' => 'Voeg een account toe uit de onderstaande lijst',

--- a/theme/skeune/translations/messages.pt.php
+++ b/theme/skeune/translations/messages.pt.php
@@ -13,6 +13,7 @@ return [
     'wayf_remaining_idps_title' => 'Add an account from the list below',
     'wayf_select_account'       => 'Select an account from the list below',
     'wayf_search_placeholder'   => 'Search...',
+    'wayf_search_aria'          => 'Search identity providers',
     'wayf_your_accounts'        => 'Your accounts',
     'wayf_add_account'          => 'Add another account',
     'wayf_no_access_helpdesk'   => 'If you want, you can request access to this service. We will send the request to the helpdesk of your institution.',

--- a/theme/skeune/translations/messages.pt.php
+++ b/theme/skeune/translations/messages.pt.php
@@ -2,11 +2,12 @@
 return [
     // General
     'logo'  => 'logo',
+    'search'    => 'Search',
 
     // WAYF
     'wayf_nothing_found'        => 'Nothing found',
     'wayf_apu'                  => 'Please try again with some different keywords',
-    'wayf_noscript_warning'     => '<p>For this page to function optimally you need JavaScript turned on.</p><p>Without JavaScript you will not be able to remember previously used accounts.  If you want to use that functionality, please enable JavaScript.</p><p><strong>You can, off course, still log in.<strong></strong></p>',
+    'wayf_noscript_warning'     => '<p>For this page to function optimally you need JavaScript turned on.</p><p>Without JavaScript you will not be able to remember previously used accounts.  If you want to use that functionality, please enable JavaScript.</p><p><strong>You can, off course, still log in.</strong></p>',
     'wayf_no_access_account'    => 'No access with this account',
     'wayf_delete_account'       => 'Delete from your accounts',
     'wayf_remaining_idps_title' => 'Add an account from the list below',


### PR DESCRIPTION
Added a new command to get rid of the symfony debugbar during testing.

- There was a contrast issue with the edit button, because the font wasn't large enough.  Increased the font size to resolve.
- There was an issue with an extra open strong tag.  Removing it fixed that.
- The search form lacked a submit button.  Fixed that while keeping the styling the same.  Also added an aria-role as per best practice.
- The focus styles for the footer didn't show clearly as it was blue on blue.  Changed those to white.
- Buttons lacked a pointer when hovering above them, added those generically.
- The Idp lacked a type for it's button: added that.  It also has a button nested in a link.  So added a comment to disable event bubbling on the button to avoid accidentally triggering the link.