### PR TITLE
Put temporary code in place to make WAYF function

### DIFF
--- a/theme/base/javascripts/wayf.js
+++ b/theme/base/javascripts/wayf.js
@@ -16,6 +16,20 @@ export function initializeWayf() {
         return;
     }
 
+  // Temporary code to get wayf to function. Only submit by clicking on a IdP functions for now
+  const form = document.querySelector('.wayf__search');
+  if (form !== null) {
+    // Set a quick and dirty click listener on every IdP
+    document.querySelectorAll('.wayf__idp').forEach((article) => {
+      article.addEventListener('click', (event) => {
+        event.preventDefault();
+        // And set the EnittyId associated with that IdP on the hidden form field. And submit the form
+        form.elements['form-idp'].value = event.target.closest('article').dataset.entityId;
+        form.submit();
+      });
+    });
+
+  } else {
     const $searchBar                  = document.querySelector('.mod-search-input');
     const $connectedIdpPickerTarget   = document.getElementById('idp-picker');
     const $connectedIdpListTarget     = $connectedIdpPickerTarget.querySelector('.selection');
@@ -109,6 +123,7 @@ export function initializeWayf() {
     if (window.innerWidth > 800) {
         $searchBar.focus();
     }
+  }
 }
 
 function throttle(action, delay) {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp.html.twig
@@ -1,4 +1,4 @@
-<article class="wayf__idp {% if idp['noAccess'] is defined and idp['noAccess'] %} wayf__idp--noAccess{% endif %}" data-keywords="{{ idp['keywords'] }}">
+<article data-entity-id="{{ idp['entityId'] }}" class="wayf__idp {% if idp['noAccess'] is defined and idp['noAccess'] %} wayf__idp--noAccess{% endif %}" data-keywords="{{ idp['keywords'] }}">
     <a href="">  {# {{ idp['link'] }} todo ensure this link is in the connectedIdps array #}
         <picture class="idp__logo">
             <source srcset="" media="(min-width: 800px)"/>

--- a/theme/base/templates/modules/Authentication/View/Proxy/wayf_content.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/wayf_content.html.twig
@@ -13,4 +13,5 @@
         </div>
     {% endblock %}
 </main>
+{% include '@theme/Authentication/View/Proxy/Partials/WAYF/scriptConfig.html.twig' %}
 {% include '@theme/Default/Partials/footer.html.twig' %}


### PR DESCRIPTION
This change adds support for the Skeune WAYF design, which is WIP to
begin with. So the change to the wayf.js must be considered temporary
code.

In order to continue to the IdP, an entity Id must be set on the form.
This form consists of hidden form fields (request id, entityId and so
forth) the form is then submitted.

The other code is only accessible when using the old theme.