### PR TITLE
Style the redirect form

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
@@ -49,6 +49,7 @@ class ConsentController
             'message' => $encodedMessage,
             'xtra' => '<input type="hidden" name="RelayState" value="relaystate">',
             'name' => 'SAMLResponse',
+            'preventAutoSubmit' => true
         ]), 200);
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2010 SURFnet B.V.
  *
@@ -22,8 +23,8 @@ use SAML2\Constants;
 use SAML2\XML\saml\NameID;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
 use Twig_Environment;
+use function base64_encode;
 
 class ConsentController
 {
@@ -37,6 +38,18 @@ class ConsentController
         Twig_Environment $twig
     ) {
         $this->twig = $twig;
+    }
+
+    public function sendAction()
+    {
+        $action = '#';
+        $encodedMessage = base64_encode('the encoded message, no problem this is bogus on the test endpoint');
+        return new Response($this->twig->render('@theme/Authentication/View/Proxy/form.html.twig', [
+            'action' => $action,
+            'message' => $encodedMessage,
+            'xtra' => '<input type="hidden" name="RelayState" value="relaystate">',
+            'name' => 'SAMLResponse',
+        ]), 200);
     }
 
     /**

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/routing.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/routing.yml
@@ -55,6 +55,11 @@ functional_testing_consent:
     defaults:
         _controller: engineblock.functional_test.controller.consent:consentAction
 
+functional_testing_send_form:
+    path: "/send"
+    defaults:
+        _controller: engineblock.functional_test.controller.consent:sendAction
+
 functional_testing_gateway:
     path: "/gateway/second-factor-only/single-sign-on"
     defaults:

--- a/theme/base/stylesheets/application.scss
+++ b/theme/base/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import 'shared';
 @import 'pages/consent';
 @import 'pages/wayf';
+@import 'pages/form';

--- a/theme/base/stylesheets/pages/form.scss
+++ b/theme/base/stylesheets/pages/form.scss
@@ -23,5 +23,14 @@
             padding: 2rem 2rem 0 0;
             width: 30%;
         }
+        > form {
+            > noscript {
+                input.form__noJsSubmit {
+                    @include button-primary($buttonBlue);
+                    text-align: center;
+                    width: 100%;
+                }
+            }
+        }
     }
 }

--- a/theme/base/stylesheets/pages/form.scss
+++ b/theme/base/stylesheets/pages/form.scss
@@ -1,0 +1,27 @@
+/*******************************************************************
+    CSS specific to the form page (auto submitted page that sends
+    SAML response to SP
+ ******************************************************************/
+
+.form {
+    > main {
+        background-color: $gray;
+        color: $black;
+        font-size: $f-normal;
+        padding: 0 2rem 2.5rem;
+        @include screen('mobile') {
+            padding: 0 1rem 1.25rem;
+        }
+
+        > header {
+            h2.form__subHeader {
+                padding: 1.5rem 2rem 2.125rem 0;
+            }
+        }
+
+        > img.form__spinner {
+            padding: 2rem 2rem 0 0;
+            width: 30%;
+        }
+    }
+}

--- a/theme/base/stylesheets/shared.scss
+++ b/theme/base/stylesheets/shared.scss
@@ -75,6 +75,7 @@ body {
 
     > .container {
         > header {
+            > h1.redirectBar,
             > p.loginBar {
                 @include font-style-xl;
                 background-color: $darkishBlue;

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Shared/header.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Shared/header.html.twig
@@ -1,6 +1,6 @@
 <header>
     <h1>{{ pageTitle }}</h1>
-    {% if h2 %}
+    {% if h2 is defined %}
         <h2>{{ h2 }}</h2>
     {% endif %}
 </header>

--- a/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
@@ -17,7 +17,7 @@
             <link href="/stylesheets/application.css?v={{ assetsVersion }}" rel="stylesheet" type="text/css"/>
         {% endspaceless %}{% endblock %}
     </head>
-    <body class="index" {#onload="document.forms[0].submit()"#}>
+    <body class="index" {% if preventAutoSubmit is not defined %} onload="document.forms[0].submit()" {% endif %}>
 
     <div class="container form">
 

--- a/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
@@ -2,39 +2,51 @@
 
 {% block content %}
     <!DOCTYPE html>
-    <html>
+    <html lang="{{ locale()|escape('html_attr') }}">
     <head>
+        <title>{{ defaultTitle }} - {{ 'post_data'|trans }}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <meta name="robots" content="noindex, nofollow"/>
-        <meta content="ie=edge,chrome=1" http-equiv="x-ua-compatible">
-        <meta content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width" name="viewport">
+        <meta content="IE=edge" http-equiv="x-ua-compatible">
+        <meta content="initial-scale=1.0,width=device-width" name="viewport">
+        <meta content="yes" name="apple-mobile-web-app-capable">
         <meta content="translucent-black" name="apple-mobile-web-app-status-bar-style">
         <link href="/favicon.ico" rel="shortcut icon">
-        <link href="/stylesheets/application.css" rel="stylesheet" type="text/css"/>
-        <title>{{ defaultTitle }} - {{ 'post_data'|trans }}</title>
+
+        {% block stylesheets %}{% spaceless %}
+            <link href="/stylesheets/application.css?v={{ assetsVersion }}" rel="stylesheet" type="text/css"/>
+        {% endspaceless %}{% endblock %}
     </head>
-    <body class="index" onload="document.forms[0].submit()">
-    <div class="mod-redirect">
-        <img class="rotate-img" src="/images/spinner.svg" alt=""/>
+    <body class="index" {#onload="document.forms[0].submit()"#}>
 
-        <h1>{{ 'processing'|trans }}</h1>
+    <div class="container form">
 
-        <p>{{ 'processing_waiting'|trans }}</p>
+        <header>
+            <h1 class="redirectBar">{{ 'processing'|trans }}</h1>
+        </header>
 
-        <p>{{ 'processing_long'|trans }}</p>
-        <noscript>
-            <p>
-                <strong>{{ 'note'|trans }}:</strong>
-                {{ 'note_no_script'|trans }}
-            </p>
-        </noscript>
-        <form id="ProcessForm" method="post" action="{{ action }}">
-            <input type="hidden" name="{{ name }}" value="{{ message }}"/>
 
-            {{ xtra|raw }}
+        <main>
+            <header>
+                <h2 class="form__subHeader">{{ 'processing_waiting'|trans }}</h2>
+            </header>
 
-            <noscript><input type="submit" value="Submit" class="c-button"/></noscript>
-        </form>
+            <p>{{ 'processing_long'|trans }}</p>
+
+            <img src="/images/spinner.svg" alt="" class="form__spinner">
+
+            <form id="ProcessForm" method="post" action="{{ action }}">
+                <input type="hidden" name="{{ name }}" value="{{ message }}"/>
+                {{ xtra|raw }}
+                <noscript>
+                    <p>
+                        <strong>{{ 'note'|trans }}:</strong>
+                        {{ 'note_no_script'|trans }}
+                    </p>
+                    <input type="submit" value="Submit" class="c-button"/>
+                </noscript>
+            </form>
+        </main>
     </div>
 
     </body>

--- a/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
@@ -43,7 +43,7 @@
                         <strong>{{ 'note'|trans }}:</strong>
                         {{ 'note_no_script'|trans }}
                     </p>
-                    <input type="submit" value="Submit" class="c-button"/>
+                    <input type="submit" value="Submit" class="form__noJsSubmit"/>
                 </noscript>
             </form>
         </main>

--- a/theme/base/templates/modules/Authentication/View/Proxy/wayf_content.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/wayf_content.html.twig
@@ -2,7 +2,7 @@
 {% include '@theme/Authentication/View/Proxy/Partials/WAYF/noScript.html.twig' %}
 {% include '@theme/Default/Partials/LoginBar.html.twig' with { loginName: 'suite_name'|trans } %}
 <main class="wayf">
-    {% include '@theme/Authentication/View/Proxy/Partials/Shared/header.html.twig' with { h2: false } %}
+    {% include '@theme/Authentication/View/Proxy/Partials/Shared/header.html.twig' %}
     {% block wayf_content %}
         <div class="wayf__content" id="idp-picker">
             {% include '@theme/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig' %}

--- a/theme/skeune/stylesheets/application.scss
+++ b/theme/skeune/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import 'base/stylesheets/shared';
 @import 'base/stylesheets/pages/consent';
 @import 'base/stylesheets/pages/wayf';
+@import 'base/stylesheets/pages/form';


### PR DESCRIPTION
## Background
This is the form EB pages use to send back SAML messages (supports both SAMLResponse and SAMLRequest) but I only know of it using it to send back SAMLResponses to the SP.

## Test notes
I added a functional testing endpoint to render the form. In order to prevent the infinite loop and test other stuff:

1. Manually remove the auto submit code from the body tag of the twig template to prevent a submit loop
2. You can test no-js capabilities by disabling JS in your browser (duh)

See: `https://engine.vm.openconext.org/functional-testing/send`

## Screenshots

Mobile:
![Screenshot from 2020-10-01 12-58-22](https://user-images.githubusercontent.com/28252948/94801103-d7ed9d80-03e5-11eb-8125-dd6c18e0a0fa.png)

Larger browser screen:
![Screenshot from 2020-10-01 12-50-25](https://user-images.githubusercontent.com/28252948/94800340-b9d36d80-03e4-11eb-8ae6-a20be14c87a7.png)

No-JS
![Screenshot from 2020-10-01 12-55-05](https://user-images.githubusercontent.com/28252948/94800772-5bf35580-03e5-11eb-9a2c-1d8f58f51e3e.png)

## Remarks
I'm aware the no-js styling is lacking in theming, and does not have good a11y feature (like outline on focus). For now I'd like to await a first review of the basic styling. 


