### PR TITLE
Refactor JS code for consent page

### DIFF
--- a/theme/base/javascripts/application.js
+++ b/theme/base/javascripts/application.js
@@ -1,6 +1,6 @@
 import {initializeIndex} from ".";
-import {initializeConsent} from ".";
 import {initializeWayf} from ".";
+import {initializeConsent} from './consent';
 
 initializeIndex();
 initializeWayf();

--- a/theme/base/javascripts/consent.js
+++ b/theme/base/javascripts/consent.js
@@ -1,9 +1,6 @@
-import {initConsentPage} from "./modules/ConsentPage";
+import {initializePage} from './page';
+import {addAccessibilitySupport} from './consent/addA11ySupport';
 
-export function initializeConsent() {
-    document.body.className = document.body.className.replace('no-js', '');
-    if (document.querySelector('.mod-content.consent') !== null) {
-        initConsentPage();
-        return;
-    }
-}
+export const initializeConsent = () => {
+  initializePage('main.consent', addAccessibilitySupport);
+};

--- a/theme/base/javascripts/consent/addA11ySupport.js
+++ b/theme/base/javascripts/consent/addA11ySupport.js
@@ -1,0 +1,33 @@
+export const addAccessibilitySupport = () => {
+  /**
+   * Ensure hitting enter on a label will trigger the same interaction as it does when clicking it with a mouse.
+   * This makes the tooltips / modals reachable by keyboard.
+   * It also ensures the "show more info" button is reachable by keyboard.
+   */
+  document.querySelector('body').addEventListener('keydown', function(e) {
+    if (e.keyCode === 13) {
+      var label = e.target;
+      if (label.tagName === 'LABEL' && label.tabIndex === 0) {
+        var clickEvent = new MouseEvent('click');
+        label.dispatchEvent(clickEvent);
+      }
+    }
+  });
+
+  /**
+   * Ensure that for people with a screenreader the aria-pressed status is updated.
+   * This ensures content in a tooltip / modal is actually announced to them upon opening the tooltip / modal.
+   */
+  var labels = document.querySelectorAll('label[aria-pressed]');
+  for (var i = 0; i < labels.length; i++) {
+    labels[i].addEventListener('click', function(e) {
+      var label = e.target;
+      var ariaPressed = label.getAttribute('aria-pressed');
+      var newValue = {
+        false: true,
+        true: false,
+      };
+      label.setAttribute('aria-pressed', newValue[ariaPressed]);
+    });
+  }
+};

--- a/theme/base/javascripts/consent/focusAcceptButton.js
+++ b/theme/base/javascripts/consent/focusAcceptButton.js
@@ -1,0 +1,23 @@
+// Only focus on the accept terms button if it is visible on the page (to prevent scrolldown)
+/**
+ * Only focus on the accept terms button if it is visible on the page (to prevent scrolldown)
+ *
+ * @param querySelector   string    the css selector for the accept button
+ */
+export const focusAcceptButton = (querySelector) => {
+  if (isVisibleOnPage(querySelector)){
+    document.querySelector(querySelector).focus();
+  }
+};
+/**
+ * Tests if the element (specified by css selector) is visible on the page. Once the element is partly in view the method
+ * will start returning true.
+ *
+ * @param querySelector   string    the css selector for the element
+ * @returns {boolean}
+ */
+const isVisibleOnPage = (querySelector) => {
+  const windowHeight = window.innerHeight;
+  const elementTopPosition = document.querySelector(querySelector).offsetTop;
+  return windowHeight > elementTopPosition;
+};

--- a/theme/base/javascripts/page.js
+++ b/theme/base/javascripts/page.js
@@ -1,0 +1,18 @@
+/**
+ * Function which executes necessary JS on the Consent Page
+ *
+ * @param querySelector         string  the query selector which can determine if it's the consent page or not
+ * @param callbackAfterLoad     function   function to be executed after the page has fully loaded
+ * @param callbackAllways       function   function to be executed before the page is fully loaded.
+ */
+export const initializePage = (querySelector, callbackAfterLoad, callbackAllways) => {
+  if (callbackAllways) {
+    callbackAllways();
+  }
+
+  if (document.querySelector(querySelector) !== null && callbackAfterLoad) {
+    window.addEventListener('load', () => {
+      callbackAfterLoad();
+    });
+  }
+};

--- a/theme/base/stylesheets/pages/consent.scss
+++ b/theme/base/stylesheets/pages/consent.scss
@@ -360,7 +360,7 @@
             margin: 2rem 0 0;
 
             > form {
-                button {
+                .cta_consent_ok {
                     @include button-primary($buttonBlue);
                     margin-bottom: 1.5rem;
                     width: 100%;
@@ -371,7 +371,7 @@
                 }
             }
 
-            > label {
+            > label[for="cta_consent_nok"] {
                 @include button-tertiary($gray);
                 display: block;
                 width: 100%;

--- a/theme/base/templates/layouts/scripts/default.html.twig
+++ b/theme/base/templates/layouts/scripts/default.html.twig
@@ -21,35 +21,6 @@
             }
         }
     </style>
-
-    <script>
-        // todo add this to the js once we reshaped the custom theme architecture
-        // todo once it's added to the normal js, rewrite as es6 (with typescript?)
-        window.addEventListener('load', function(){
-            document.querySelector('body').addEventListener('keydown', function(e) {
-                if (e.keyCode === 13) {
-                    var label = e.target;
-                    if (label.tagName === 'LABEL' && label.tabIndex === 0) {
-                        var clickEvent = new MouseEvent('click');
-                        label.dispatchEvent(clickEvent);
-                    }
-                }
-            });
-
-            var labels = document.querySelectorAll('label[aria-pressed]');
-            for (var i = 0; i < labels.length; i++) {
-                labels[i].addEventListener('click', function(e) {
-                    var label = e.target;
-                    var ariaPressed = label.getAttribute('aria-pressed');
-                    var newValue = {
-                        false: true,
-                        true: false,
-                    };
-                    label.setAttribute('aria-pressed', newValue[ariaPressed]);
-                });
-            }
-        })
-    </script>
 </head>
 <body>
 {% block nojs %}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/ctas.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/ctas.html.twig
@@ -6,6 +6,7 @@
         <input type="hidden" name="consent" value="yes"/>
         {% include '@theme/Default/Partials/button.html.twig' with
             {
+                buttonClass: 'cta_consent_ok',
                 text: 'consent_ok'|trans
             }
         %}

--- a/theme/base/templates/modules/Default/Partials/button.html.twig
+++ b/theme/base/templates/modules/Default/Partials/button.html.twig
@@ -1,4 +1,4 @@
-<button type="{{ buttonType|default('submit') }}">
+<button type="{{ buttonType|default('submit') }}" {% if buttonClass is defined %} class="{{ buttonClass }}"{% endif %}>
     <span class="secondaryBorder">
         {{ text }}
     </span>

--- a/theme/openconext/javascripts/application.js
+++ b/theme/openconext/javascripts/application.js
@@ -1,6 +1,6 @@
 import {initializeIndex} from "../../base/javascripts";
-import {initializeConsent} from "../../base/javascripts/consent";
 import {initializeWayf} from "../../base/javascripts/wayf";
+import {initializeConsent} from './consent';
 
 initializeIndex();
 initializeWayf();

--- a/theme/openconext/javascripts/consent.js
+++ b/theme/openconext/javascripts/consent.js
@@ -1,0 +1,17 @@
+import {focusAcceptButton} from '../../base/javascripts/consent/focusAcceptButton';
+import {initTooltips} from './consent/initTooltips';
+import {initAttributesToggle} from './consent/initAttributesToggle';
+import {initSlideIns} from './consent/initSlideIns';
+import {initializePage} from '../../base/javascripts/page';
+import {hideNoScript} from './hideNoScript';
+
+export const initializeConsent = () => {
+  const callbacksAfterLoad = () => {
+    focusAcceptButton('#accept_terms_button');
+    initTooltips();
+    initAttributesToggle();
+    initSlideIns();
+  };
+
+  initializePage('.mod-content.consent', callbacksAfterLoad, hideNoScript);
+};

--- a/theme/openconext/javascripts/consent/initAttributesToggle.js
+++ b/theme/openconext/javascripts/consent/initAttributesToggle.js
@@ -1,0 +1,13 @@
+export const initAttributesToggle = () => {
+  Array.prototype.forEach.call(
+    document.querySelectorAll('tr.toggle-attributes a'),
+    (anchor) => anchor.addEventListener(
+      'click',
+      (event) => {
+        event.preventDefault();
+
+        anchor.closest('tbody').classList.toggle('expanded');
+      }
+    )
+  );
+};

--- a/theme/openconext/javascripts/consent/initSlideIns.js
+++ b/theme/openconext/javascripts/consent/initSlideIns.js
@@ -1,0 +1,33 @@
+export const initSlideIns = () => {
+  Array.prototype.forEach.call(
+    document.querySelectorAll('a[data-slidein]'),
+    (anchor) => anchor.addEventListener(
+      'click',
+      (event) => {
+        event.preventDefault();
+
+        const slideIn = document.querySelector(
+          '.slidein.' + anchor.getAttribute('data-slidein')
+        );
+
+        if (slideIn !== null) {
+          slideIn.classList.add('visible');
+          document.body.classList.add('slidein-open');
+
+          slideIn.querySelector('a.close').addEventListener(
+            'click',
+            (event) => {
+              event.preventDefault();
+
+              slideIn.classList.remove('visible');
+              document.body.classList.remove('slidein-open');
+            },
+            {
+              once: true
+            }
+          );
+        }
+      }
+    )
+  );
+};

--- a/theme/openconext/javascripts/consent/initTooltips.js
+++ b/theme/openconext/javascripts/consent/initTooltips.js
@@ -1,0 +1,27 @@
+import tippy from 'tippy.js';
+
+export const initTooltips = () => {
+  const anchors = document.querySelectorAll('a.tooltip');
+
+  tippy(
+    anchors,
+    {
+      animation: 'scale',
+      arrow: true,
+      arrowTransform: 'scale(2)',
+      distance: 30,
+      duration: 200,
+      followCursor: true,
+      placement: 'top',
+      theme: 'light',
+    }
+  );
+
+  Array.prototype.forEach.call(
+    anchors,
+    (anchor) => anchor.addEventListener(
+      'click',
+      (event) => event.preventDefault()
+    )
+  );
+};

--- a/theme/openconext/javascripts/hideNoScript.js
+++ b/theme/openconext/javascripts/hideNoScript.js
@@ -1,0 +1,3 @@
+export const hideNoScript = () => {
+  document.body.className = document.body.className.replace('no-js', '');
+};


### PR DESCRIPTION
Made a generic initializePage function.
Split up all js functions in seperate files for the consent page, put those in a consent subfolder.
Created a initializeConsent function for both openconext / base (skeune) which contains all relevant JS with updated selectors.
Removed the inline JS from default.html.twig.
Imported the JS for consent in application.js for both openconext / base (skeune).