### PR TITLE
Response without NameID is valid behaviour

### DIFF
--- a/library/EngineBlock/Corto/Filter/Abstract.php
+++ b/library/EngineBlock/Corto/Filter/Abstract.php
@@ -72,7 +72,7 @@ abstract class EngineBlock_Corto_Filter_Abstract
         else if ($response->getCollabPersonId()) {
             $collabPersonId = $response->getCollabPersonId();
         }
-        else if ($responseNameId->getValue()) {
+        else if (isset($responseNameId) && $responseNameId->getValue()) {
             $collabPersonId = $responseNameId->getValue();
         }
         else {


### PR DESCRIPTION
Should fix:
Oct  3 13:52:09 sv1810952 EBLOG[1527]: [2020-10-03 13:52:09] app.ERROR: Call to a member function getValue() on null {"session_id":"o6v872d3nh68rrlt1tn40jrv2g","request_id":"5f7865e9c3ebe"} {"exception":"[object] (Error(code: 0): Call to a member function getValue() on null at /apps/installation/OpenConext-engineblock/OpenConext-engineblock-6.3.5/library/EngineBlock/Corto/Filter/Abstract.php:75)"}

Although I haven't tested this yet..