### PR TITLE
Also add c14n method to the reference transforms in XML metadata.

### DIFF
--- a/src/OpenConext/EngineBlock/Xml/DocumentSigner.php
+++ b/src/OpenConext/EngineBlock/Xml/DocumentSigner.php
@@ -42,12 +42,13 @@ class DocumentSigner
         $rootNode = $doc->childNodes[1];
 
         // Create sign object
+        $canonicalMethod = XMLSecurityDSig::EXC_C14N;
         $objDSig = new XMLSecurityDSig();
-        $objDSig->setCanonicalMethod(XMLSecurityDSig::EXC_C14N);
+        $objDSig->setCanonicalMethod($canonicalMethod);
         $objDSig->addReference(
             $rootNode,
             self::SIGN_ALGORITHM,
-            ['http://www.w3.org/2000/09/xmldsig#enveloped-signature'],
+            ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', $canonicalMethod],
             ['id_name' => 'ID', 'overwrite' => false]
         );
 

--- a/tests/unit/OpenConext/EngineBlock/Xml/DocumentSignerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/DocumentSignerTest.php
@@ -57,12 +57,13 @@ XML;
          <ds:Reference URI="#EB12345">
             <ds:Transforms>
                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+               <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
             </ds:Transforms>
             <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
             <ds:DigestValue>nM+i0lfnpkNm/iH9c4XsvqUL3PaH+4OPethgW0fzI/Y=</ds:DigestValue>
          </ds:Reference>
       </ds:SignedInfo>
-      <ds:SignatureValue>NbMqns50Fr0qpW5jnEdliAS8+jXv//AH5kAvBKvxWt2PS8Xeo8qZnJoR6cxriaeytB0JgRsmPEyZw59e+OAvz/Dox/6gEgrMPiPDSvTRaEPR4a9BVCw71i3aam4bEc6TfdRC9RZ44LETlLqTwYvmVlVF5iWx1E5yR4WV0/esnwDHiUXqXddgDS0zqih8YiDjRrqJFxb0PvothVkwGkyN5fLgl2fNqTbA0VzY5YtTVOEsbVWBpE0Xl9kJMIctnT8P57uWcleRRLMHUqroUc8zzjO3wq2kB7JPNFU1tQVgnoYMPVPaUNQS8ARfQp2nuGmCxNcsprz1o6xXeu9jpNcgKw==</ds:SignatureValue>
+      <ds:SignatureValue>bOVp1xOLDY5Rfm/JtAtyfNvspmd1Eybx53SEJrEb07bbtMqfg0DkkPYx701oXpcvbkRZxDmtH13qvpY4VKvLDszZ4dZoNcVEsIMdoBFtweEN4NZv8if671MqqVyElp81b5Pzh+lT2fqDCW6/wOhJb3Ml31NxacKITMfMbf1f7ZfavlaT1CSw+lC5+wXcfLnSwk2GcsS9UBuWc2IFl3hmOhOe38xOT3u59ojM4XT/Z3/w+KQIU7R9o0WhKX1mBWbW18hhmcBGlXAmfRxST9bjLolQS+ymd4HGDqT18HETrO+AbRmdLW7Wz/KkoOJQPDdoOMyKK+0MJDDmj8cQKiH9UA==</ds:SignatureValue>
       <ds:KeyInfo>
          <ds:X509Data>
             <ds:X509Certificate>MIIDXzCCAkegAwIBAgIJAM4CwNsdIhJ3MA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMMBkVuZ2luZTERMA8GA1UECwwIU2VydmljZXMxEzARBgNVBAoMCk9wZW5Db25leHQxCzAJBgNVBAYTAk5MMB4XDTE0MDUxMjEzMjIxNloXDTI0MDUxMTEzMjIxNlowRjEPMA0GA1UEAwwGRW5naW5lMREwDwYDVQQLDAhTZXJ2aWNlczETMBEGA1UECgwKT3BlbkNvbmV4dDELMAkGA1UEBhMCTkwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2aQ9OYsAASWR/aN5NB2mQqFsBc13uN0nSbjkk1Um8VouGo7OmSM0eiur5my8UvPYth1DXQM6u2wiFq19RtfVZWJOmrzAfVHc9VRj9Xj4T+MVpR4bDWctvxVT1OPm9L23KQKvaqDmUo7uSPsBD36EIH7dFOBydDtSXfZTW0ien+lZr6C4nPuxzDbHJ+Jlo2brieimUBQNetX/ettnAglJ9536sJDkhsa120mkYPhVnvepbOtxPyU5ZDUpDNmMQR2/SORCBJcfvLSVZ4It4O67l6/EJnkFRLerIqOpk/W8jY3USQaLM2WM7sWBGxEFKDVcTFgrOH50Z94K2M/KweY2bAgMBAAGjUDBOMB0GA1UdDgQWBBSewI9OzfzbIxnl6XMkaQkYY1hHPjAfBgNVHSMEGDAWgBSewI9OzfzbIxnl6XMkaQkYY1hHPjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4IBAQAFfYPZbsYPHz4ypV/aO59do7CtHPnAMWr0NcQt4h9IW8gjihaNHt12V30QtHrVaXejXybB/LaGbPPyA64+l/SeC7ksrRxlitCwFqnws6ISXJaYU0iEFHGUD/cAj1iGloIsOm5IOdb3sdG/SsBv49G8es2wG0rDd0/s2fBVvXd4qUoXzKJAjYk1MFQxnGHomlt67SBrr2QLh+m2VHg+mkdi6yrdm9B9ylF8V55Vl82pPZXxphIRgqdos5YWeALS7dr5dSw9s5smFBxyy8IfCQMxagfNC59w22w2ULC/J7au/oP8ylusuxncxizdR/+5UazzAlOWtkjzaABzzBWM4hEK</ds:X509Certificate>


### PR DESCRIPTION
This fixes parsing of our generated XML with some remote entities, notably ADFS. This was present in the old metadata (pre-twig) and is also present in e.g. the signed Responses we send and in metadata generated by other products.

XML before:

```xml
<ds:Reference URI="#EB...">
    <ds:Transforms>
        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
    </ds:Transforms>
    <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
    <ds:DigestValue>...</ds:DigestValue>
</ds:Reference>
```

XML after:
```xml
<ds:Reference URI="#EB...">
    <ds:Transforms>
        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
    </ds:Transforms>
    <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
    <ds:DigestValue>...</ds:DigestValue>
</ds:Reference>
```

Other users do the same, see e.g. https://github.com/simplesamlphp/simplesamlphp/blob/d6d30c87235c3dc3c9690753d7da487b02613972/lib/SimpleSAML/Metadata/Signer.php#L284

Thanks @tvdijen for finding an analyzing the issue.