### PR TITLE
Remove the remaining eduGAIN metadafields

### DIFF
--- a/database/DoctrineMigrations/Version20191011132428.php
+++ b/database/DoctrineMigrations/Version20191011132428.php
@@ -15,6 +15,11 @@ final class Version20191011132428 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
+        $this->skipIf(
+            !$schema->getTable('sso_provider_roles_eb5')->hasColumn('response_processing_service_binding'),
+            'Skipping because `response_processing_service_binding` did not exist to begin with'
+        );
+
         $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP response_processing_service_binding');
     }
 

--- a/database/DoctrineMigrations/Version20200226103409.php
+++ b/database/DoctrineMigrations/Version20200226103409.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200226103409 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX idx_sso_provider_roles_publish_in_edugain ON sso_provider_roles_eb5');
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP publish_in_edugain, DROP publish_in_edu_gain_date');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD publish_in_edugain TINYINT(1) NOT NULL, ADD publish_in_edu_gain_date DATE DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_sso_provider_roles_publish_in_edugain ON sso_provider_roles_eb5 (publish_in_edugain)');
+    }
+}

--- a/database/DoctrineMigrations/Version20201005161700.php
+++ b/database/DoctrineMigrations/Version20201005161700.php
@@ -14,9 +14,15 @@ final class Version20201005161700 extends AbstractMigration
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
-        $this->addSql('DROP INDEX idx_sso_provider_roles_publish_in_edugain ON sso_provider_roles_eb5');
-        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP publish_in_edugain, DROP publish_in_edu_gain_date');
+        if ($schema->getTable('sso_provider_roles_eb5')->hasIndex('idx_sso_provider_roles_publish_in_edugain')) {
+            $this->addSql('DROP INDEX idx_sso_provider_roles_publish_in_edugain ON sso_provider_roles_eb5');
+        }
+        if ($schema->getTable('sso_provider_roles_eb5')->hasColumn('publish_in_edugain')) {
+            $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP publish_in_edugain');
+        }
+        if ($schema->getTable('sso_provider_roles_eb5')->hasColumn('publish_in_edu_gain_date')) {
+            $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP publish_in_edu_gain_date');
+        }
     }
 
     public function down(Schema $schema) : void

--- a/database/DoctrineMigrations/Version20201005161700.php
+++ b/database/DoctrineMigrations/Version20201005161700.php
@@ -8,7 +8,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20200226103409 extends AbstractMigration
+final class Version20201005161700 extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {


### PR DESCRIPTION
This PR consists of a migration that drops the last database table related eduGAIN references.

The commit warns: `To be released post EngineBlock 6.2 for rollbackability` Now that we are in the 6.3 tier, this can be merged now.