### PR TITLE
Prevent undefined access in Assembler

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -336,11 +336,19 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
 
     private function assembleOrganization(stdClass $connection, $langCode)
     {
-        return array('organization' . ucfirst($langCode) => new Organization(
-            $connection->metadata->OrganizationName->$langCode,
-            $connection->metadata->OrganizationDisplayName->$langCode,
-            $connection->metadata->OrganizationURL->$langCode
-        ));
+        $name = null;
+        $displayName = null;
+        $url = null;
+        if (isset($connection->metadata->OrganizationName) && isset($connection->metadata->OrganizationName->$langCode)) {
+            $name = $connection->metadata->OrganizationName->$langCode;
+        }
+        if (isset($connection->metadata->OrganizationDisplayName) && isset($connection->metadata->OrganizationDisplayName->$langCode)) {
+            $displayName = $connection->metadata->OrganizationDisplayName->$langCode;
+        }
+        if (isset($connection->metadata->OrganizationURL) && isset($connection->metadata->OrganizationURL->$langCode)) {
+            $url = $connection->metadata->OrganizationURL->$langCode;
+        }
+        return array('organization' . ucfirst($langCode) => new Organization($name, $displayName, $url));
     }
 
     private function assembleCertificates(stdClass $connection)


### PR DESCRIPTION
The assembly of the organization value objects would read possibly
undefined properties from the metadata 'connections' stdClass.

This would result in notices in the log, and even errors. As these
metadata values are not required, a safeguard was added to the import
logic

See point 3 of:
https://github.com/OpenConext/OpenConext-engineblock/issues/920#issue-714118630