### PR TITLE
Fix sequence / schema violation

### DIFF
--- a/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
+++ b/theme/material/templates/modules/Authentication/View/Metadata/partial/organization.xml.twig
@@ -10,7 +10,15 @@
     {% for locale in locales %}
         {% if metadata.hasCompleteOrganizationData(locale) %}
             <md:OrganizationName xml:lang="{{ locale }}">{{ metadata.organizationName(locale) }}</md:OrganizationName>
+        {% endif %}
+    {% endfor %}
+    {% for locale in locales %}
+        {% if metadata.hasCompleteOrganizationData(locale) %}
             <md:OrganizationDisplayName xml:lang="{{ locale }}">{{ metadata.organizationDisplayName(locale) }}</md:OrganizationDisplayName>
+        {% endif %}
+    {% endfor %}
+    {% for locale in locales %}
+        {% if metadata.hasCompleteOrganizationData(locale) %}
             <md:OrganizationURL xml:lang="{{ locale }}">{{ metadata.organizationUrl(locale) }}</md:OrganizationURL>
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
As per Slack-discussion, the recent changes in https://github.com/OpenConext/OpenConext-engineblock/pull/878 cause a schema violation, because a specific order of elements is demanded.

Also see par [2.3.2.1](https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf) of the specs