### PR TITLE
Introduce display_default_idp_banner_on_wayf feature flag

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -166,6 +166,9 @@ parameters:
     ## Allow users to save their selected IdP and then auto-select it on returning visits.
     wayf.remember_choice: false
 
+    ## Toggle the default IdP quick link banner on the WAYF.
+    wayf.display_default_idp_banner_on_wayf: true
+
     ## Settings for detecting whether the user is stuck in a authentication loop within his session
     time_frame_for_authentication_loop_in_seconds: 60
     maximum_authentication_procedures_allowed: 5

--- a/docs/js_testing.md
+++ b/docs/js_testing.md
@@ -44,6 +44,7 @@ parameters can be used to manipulate the behaviour of the wayf that is rendered.
 | displayUnconnectedIdpsWayf | (bool) false | Type: boolean. Display unconnected IdPs on the WAYF. |
 | rememberChoiceFeature | (bool) false | Type: boolean. Display the remember choice feature. |
 | cutoffPointForShowingUnfilteredIdps | (int) 100 | Type: integer. The number of IdPs to display on the WAYF before cutting them off. |
+| showIdpBanner | (bool) true | Type: boolean. Show the EduId (default IdP) banner on the WAYF or not |
 | connectedIdps | (int) 5 | Type: integer. The number of IdPs to display on the WAYF. |
 | unconnectedIdps | (int) 0 | Type: integer. The number of unconnected IdPs to display on the WAYF. |
 | backLink | (bool) false | Type: boolean. Display the back link on the WAYF. |

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -253,6 +253,11 @@ class EngineBlock_Application_DiContainer extends Pimple
         return $this->container->getParameter('wayf.cutoff_point_for_showing_unfiltered_idps');
     }
 
+    public function shouldDisplayDefaultIdpBannerOnWayf()
+    {
+        return $this->container->getParameter('wayf.display_default_idp_banner_on_wayf');
+    }
+
     public function getRememberChoice()
     {
         return $this->container->getParameter('wayf.remember_choice');

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -437,6 +437,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
                 'helpLink' => '/authentication/idp/help-discover?lang=' . $currentLocale,
                 'backLink' => $container->isUiOptionReturnToSpActive(),
                 'cutoffPointForShowingUnfilteredIdps' => $container->getCutoffPointForShowingUnfilteredIdps(),
+                'showIdPBanner' => (bool) $container->shouldDisplayDefaultIdpBannerOnWayf(),
                 'rememberChoiceFeature' => $rememberChoiceFeature,
                 'showRequestAccess' => $serviceProvider->getCoins()->displayUnconnectedIdpsWayf(),
                 'requestId' => $request->getId(),

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
@@ -46,6 +46,8 @@ class WayfController extends Controller
         $rememberChoiceFeature = (bool) $request->get('rememberChoiceFeature', false);
         $cutoffPointForShowingUnfilteredIdps = $request->get('cutoffPointForShowingUnfilteredIdps', 100);
         $showIdPBanner = $request->get('showIdPBanner', true);
+        // Casting a string 'true' or 'false' using filter_var (bool) does not work here
+        $showIdPBanner = filter_var($showIdPBanner, FILTER_VALIDATE_BOOLEAN);
 
         $connectedIdps = (int) $request->get('connectedIdps', 5);
         $unconnectedIdps = (int) $request->get('unconnectedIdps', 0);

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
@@ -45,6 +45,7 @@ class WayfController extends Controller
         $displayUnconnectedIdpsWayf = (bool) $request->get('displayUnconnectedIdpsWayf', false);
         $rememberChoiceFeature = (bool) $request->get('rememberChoiceFeature', false);
         $cutoffPointForShowingUnfilteredIdps = $request->get('cutoffPointForShowingUnfilteredIdps', 100);
+        $showIdPBanner = $request->get('showIdPBanner', true);
 
         $connectedIdps = (int) $request->get('connectedIdps', 5);
         $unconnectedIdps = (int) $request->get('unconnectedIdps', 0);
@@ -57,6 +58,7 @@ class WayfController extends Controller
                 'helpLink' => '/authentication/idp/help-discover?lang='.$currentLocale,
                 'backLink' => $backLink,
                 'cutoffPointForShowingUnfilteredIdps' => $cutoffPointForShowingUnfilteredIdps,
+                'showIdPBanner' => $showIdPBanner,
                 'rememberChoiceFeature' => $rememberChoiceFeature,
                 'showRequestAccess' => $displayUnconnectedIdpsWayf,
                 'requestId' => 'bogus-request-id',

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/remainingIdps.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/remainingIdps.html.twig
@@ -7,12 +7,13 @@
         {% endif %}
     </h2>
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/search.html.twig' %}
-    {# todo make this hide behind a feature flag #}
-    {# todo get right link for eduId #}
-    {% include '@theme/Default/Partials/informational.html.twig' with {
-        class: 'remainingIdps__eduId',
-        text: 'wayf_eduId'|trans({ '%eduIdLink%': 'https://something.com/eduId'})
-    } %}
+
+    {% if showIdPBanner %}
+        {% include '@theme/Default/Partials/informational.html.twig' with {
+            class: 'remainingIdps__eduId',
+            text: 'wayf_eduId'|trans({ '%eduIdLink%': 'https://something.com/eduId'})
+        } %}
+    {% endif %}
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/rememberChoice.html.twig' %}
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig' with { idpList: connectedIdps.formattedIdpList, delete: false, listName: 'remaining' } %}
 </section>

--- a/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
+++ b/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
@@ -115,6 +115,11 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
     it('Check if the eduId is present', () => {
       cy.contains('.remainingIdps__eduId', 'eduID is available as an alternative');
     });
+
+    it('Ensure the CTA is not present when the feature flag is disabled', () => {
+      cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?showIdpBanner=0');
+      cy.get('.remainingIdps__eduId').should('not.exist');;
+    });
   });
 
   describe('Should show the remember my choice option', () => {


### PR DESCRIPTION
This feature flag toggles the default IdP banner on the WAYF in the preselection twig template.

By default this feature is enabled and can be set in the parameters.yml