### PR TITLE
Support cutoff point feature flag

### DIFF
--- a/theme/base/javascripts/wayf/noAccess/handleCancelNoAccess.js
+++ b/theme/base/javascripts/wayf/noAccess/handleCancelNoAccess.js
@@ -1,7 +1,0 @@
-import {toggleVisibility} from '../../utility/toggleVisibility';
-
-export const handleCancelNoAccess = (parentSection, noAccessSection) => {
-  toggleVisibility(noAccessSection);
-  toggleVisibility(parentSection);
-  // todo show banner
-};

--- a/theme/base/javascripts/wayf/noAccess/handleCancelNoAccess.js
+++ b/theme/base/javascripts/wayf/noAccess/handleCancelNoAccess.js
@@ -1,0 +1,7 @@
+import {toggleVisibility} from '../../utility/toggleVisibility';
+
+export const handleCancelNoAccess = (parentSection, noAccessSection) => {
+  toggleVisibility(noAccessSection);
+  toggleVisibility(parentSection);
+  // todo show banner
+};

--- a/theme/base/javascripts/wayf/search/hideIdpsWhenCutoffNoSearch.js
+++ b/theme/base/javascripts/wayf/search/hideIdpsWhenCutoffNoSearch.js
@@ -1,0 +1,10 @@
+/**
+ * When the feature flag "cuttoffPointForShowingUnfilteredIdps" is set: hide idps when not searching.
+ *
+ * @param list    The ul element for the remaining idps.
+ */
+export const hideIdpsWhenCutoffNoSearch = (list) => {
+  if (!!list) {
+    list.classList.remove('wayf__idpList--searching');
+  }
+};

--- a/theme/base/javascripts/wayf/search/searchAndSortIdps.js
+++ b/theme/base/javascripts/wayf/search/searchAndSortIdps.js
@@ -3,6 +3,8 @@ import {assignWeight} from './assignWeight';
 import {clearWeight} from './clearWeight';
 import {showOrHideNoResultsSection} from './showOrHideNoResultsSection';
 import {reinsertIdpList} from '../utility/reinsertIdpList';
+import {showFoundIdpsWhenCutoff} from './showFoundIdpsWhenCutoff';
+import {hideIdpsWhenCutoffNoSearch} from './hideIdpsWhenCutoffNoSearch';
 
 /**
  * Searches an array of idps for a given searchTerm.
@@ -23,14 +25,18 @@ import {reinsertIdpList} from '../utility/reinsertIdpList';
  * @returns   node[]
  */
 export const searchAndSortIdps = (idpArray, searchTerm) => {
+  const list = document.querySelector('.wayf__remainingIdps .wayf__idpList--cutoffMet');
+
   // reset weights by removing them
   clearWeight(idpArray);
 
   if (typeof searchTerm !== 'undefined' && searchTerm.length) {
     assignWeight(idpArray, searchTerm.toLowerCase());
     idpArray.sort(sortByWeight);
+    showFoundIdpsWhenCutoff(list);
   } else {
     idpArray.sort(sortByTitle);
+    hideIdpsWhenCutoffNoSearch(list);
   }
 
   // add the sorted items to the dom, replacing the previous ones

--- a/theme/base/javascripts/wayf/search/showFoundIdpsWhenCutoff.js
+++ b/theme/base/javascripts/wayf/search/showFoundIdpsWhenCutoff.js
@@ -1,0 +1,10 @@
+/**
+ * When the feature flag "cuttoffPointForShowingUnfilteredIdps" is set: show the search results.
+ *
+ * @param list    The ul element for the remaining idps.
+ */
+export const showFoundIdpsWhenCutoff = (list) => {
+  if (!!list) {
+    list.classList.add('wayf__idpList--searching');
+  }
+};

--- a/theme/base/stylesheets/pages/wayf.scss
+++ b/theme/base/stylesheets/pages/wayf.scss
@@ -452,6 +452,20 @@
                         border: 1px solid $red;
                         background-color: $errorRed;
                     }
+
+                    &:hover {
+                        background-color: $hoverBlue;
+                    }
+
+                    &:focus {
+                        box-shadow: 0 0 0 3px $lightBlue;
+                        outline: none;
+                    }
+
+                    &:not(:valid) {
+                        border: 1px solid $red;
+                        background-color: $errorRed;
+                    }
                 }
 
                 input {

--- a/theme/base/stylesheets/pages/wayf.scss
+++ b/theme/base/stylesheets/pages/wayf.scss
@@ -42,6 +42,12 @@
             list-style: none;
             padding: 0;
 
+            &.wayf__idpList--cutoffMet:not(.wayf__idpList--searching) {
+                .wayf__idp {
+                    display: none;
+                }
+            }
+
             > li {
                 margin-bottom: calculateRem(19px);
 
@@ -437,15 +443,6 @@
                     &:invalid {
                         border: 1px solid $red;
                         background-color: $errorRed;
-                    }
-
-                    &:hover {
-                        background-color: $hoverBlue;
-                    }
-
-                    &:focus {
-                        box-shadow: 0 0 0 3px $lightBlue;
-                        outline: none;
                     }
 
                     &:not(:valid) {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig
@@ -1,4 +1,4 @@
-<ul class="wayf__idpList">
+<ul class="wayf__idpList{% if cutoffPointForShowingUnfilteredIdps < idpList|length %} wayf__idpList--cutoffMet{% endif %}">
     {% for idp in idpList %}
         {% if showRequestAccess or (not showRequestAccess and idp['connected'] is defined and idp['connected']) %}
             <li>

--- a/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
+++ b/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
@@ -16,15 +16,17 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
         .should('have.length', 10);
     });
 
-    // todo: test after cutoff point is configured
-    it.skip('Should show no connected IdPs when cutoff point is configured', () => {
+    it('Should show no connected IdPs when cutoff point is configured', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=6&cutoffPointForShowingUnfilteredIdps=5');
-      cy.get('.wayf__idp h3')
-        .should('have.length', 0);
+      cy.get('.wayf__remainingIdps .wayf__idp')
+        .should('not.be.visible');
+    });
 
-      cy.get('#wayf__search').type('IdP');
-      cy.get('.wayf__idp h3')
-        .should('have.length', 6);
+    it('Should show found IdPs when cutoff point is configured and user searched', () => {
+      cy.get('.search__field').type('IdP');
+      cy.get('.wayf__idp')
+        .should('have.length', 6)
+        .should('be.visible');
     });
 
     it('Should show 5 disconnected IdPs', () => {
@@ -34,7 +36,7 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
         .should('be.visible');
     });
 
-    it.only('Should show no disconnected IdPs when the flag is false', () => {
+    it('Should show no disconnected IdPs when the flag is false', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?displayUnconnectedIdpsWayf=0&unconnectedIdps=5');
       cy.get('.wayf__idp--noAccess')
         .should('not.exist');
@@ -131,7 +133,7 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
 
     it('Ensure the CTA is not present when the feature flag is disabled', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?showIdpBanner=0');
-      cy.get('.remainingIdps__eduId').should('not.exist');;
+      cy.get('.remainingIdps__eduId').should('not.exist');
     });
   });
 


### PR DESCRIPTION
Support the cutoff point feature flag.  This means hiding all remaining Idps on the page when there would be more, unless the user is searching.