### PR TITLE
Add accessibility support for aria-pressed attribute on labels in the WAYF

### DIFF
--- a/theme/base/javascripts/consent/addA11ySupport.js
+++ b/theme/base/javascripts/consent/addA11ySupport.js
@@ -1,4 +1,5 @@
 import {fireClickEvent} from '../utility/fireClickEvent';
+import {handleAriaPressed} from '../utility/handleAriaPressed';
 
 export const addAccessibilitySupport = () => {
   /**
@@ -19,16 +20,6 @@ export const addAccessibilitySupport = () => {
    * Ensure that for people with a screenreader the aria-pressed status is updated.
    * This ensures content in a tooltip / modal is actually announced to them upon opening the tooltip / modal.
    */
-  var labels = document.querySelectorAll('label[aria-pressed]');
-  for (var i = 0; i < labels.length; i++) {
-    labels[i].addEventListener('click', function(e) {
-      var label = e.target;
-      var ariaPressed = label.getAttribute('aria-pressed');
-      var newValue = {
-        false: true,
-        true: false,
-      };
-      label.setAttribute('aria-pressed', newValue[ariaPressed]);
-    });
-  }
+  const labels = document.querySelectorAll('label[aria-pressed]');
+  handleAriaPressed(labels);
 };

--- a/theme/base/javascripts/utility/handleAriaPressed.js
+++ b/theme/base/javascripts/utility/handleAriaPressed.js
@@ -1,0 +1,22 @@
+/**
+ * Add aria-pressed support to elements with that attribute.
+ *
+ * @param elements
+ */
+export const handleAriaPressed = (elements) => {
+  for (let i = 0; i < elements.length; i++) {
+    elements[i].addEventListener('click', function(e) {
+      const element = e.target;
+      const ariaPressed = element.getAttribute('aria-pressed');
+      const newValue = {
+        false: true,
+        true: false,
+      };
+
+      // We use the newValue object because ariaPressed is a string containing either "true" or "false".
+      // Casting that to a boolean will, in both instances, give us true.
+      // By using an object we can use array notation to access the right value based on what we get back from the attribute.
+      element.setAttribute('aria-pressed', newValue[ariaPressed]);
+    });
+  }
+};

--- a/theme/base/javascripts/wayf/handleDeleteDisable.js
+++ b/theme/base/javascripts/wayf/handleDeleteDisable.js
@@ -8,7 +8,7 @@ import {sortPrevious, sortRemaining} from './utility/sortIdps';
 import {getListSelector} from './utility/getListSelector';
 
 /**
- * Handle what happens if a user clicks on either the delete button, or the disabled button.
+ * Handle what happens if a user clicks on either the delete button, or the disabled button in an Idp.
  *
  * @param e
  * @param previouslySelectedIdps

--- a/theme/base/javascripts/wayf/mouseBehaviour.js
+++ b/theme/base/javascripts/wayf/mouseBehaviour.js
@@ -1,10 +1,15 @@
 import {submitForm} from './submitForm';
+import {handleAriaPressed} from '../utility/handleAriaPressed';
 
 export const mouseBehaviour = (previouslySelectedIdps) => {
-// allow chosing an idp to login
+  // allow chosing an idp to login
   const idpLists = document
     .querySelectorAll('.wayf__idpList');
   idpLists.forEach(list => list.addEventListener('click', (e) => {
     submitForm(e, previouslySelectedIdps);
   }));
+
+  // add a11y support for all labels with an aria-pressed attribute.
+  const labels = document.querySelectorAll('label[aria-pressed]');
+  handleAriaPressed(labels);
 };

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
@@ -2,9 +2,9 @@
     <h2 class="previousSelection__title">
         {{ 'wayf_your_accounts'|trans }}
     </h2>
-    <input type="checkbox" name="previousSelectionToggle" id="previousSelectionToggle" class="visually-hidden previousSelection__toggle" tabindex="-1" role="button" aria-pressed="false" /> {# todo add js for aria #}
+    <input type="checkbox" name="previousSelectionToggle" id="previousSelectionToggle" class="visually-hidden previousSelection__toggle" tabindex="-1" role="button" aria-pressed="false" />
     <div class="ie11__label">
-        <label for="previousSelectionToggle" tabindex="0" class="previousSelection__toggleLabel">
+        <label for="previousSelectionToggle" tabindex="0" class="previousSelection__toggleLabel" aria-pressed="false">
             <span class="previousSelection__edit">
                 {{ 'edit'|trans }}
             </span>


### PR DESCRIPTION
Refactored it to be more general in consent, then added it in the WAYF.