### PR TITLE
Add the default IdP EntityID configuration parameter

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -168,6 +168,7 @@ parameters:
 
     ## Toggle the default IdP quick link banner on the WAYF.
     wayf.display_default_idp_banner_on_wayf: true
+    wayf.default_idp_entity_id: https://default-idp.vm.openconext.org
 
     ## Settings for detecting whether the user is stuck in a authentication loop within his session
     time_frame_for_authentication_loop_in_seconds: 60

--- a/docs/js_testing.md
+++ b/docs/js_testing.md
@@ -45,6 +45,7 @@ parameters can be used to manipulate the behaviour of the wayf that is rendered.
 | rememberChoiceFeature | (bool) false | Type: boolean. Display the remember choice feature. |
 | cutoffPointForShowingUnfilteredIdps | (int) 100 | Type: integer. The number of IdPs to display on the WAYF before cutting them off. |
 | showIdpBanner | (bool) true | Type: boolean. Show the EduId (default IdP) banner on the WAYF or not |
+| defaultIdpEntityId | (string) null | Type: string. The entityId of the default IdP (EduId) |
 | connectedIdps | (int) 5 | Type: integer. The number of IdPs to display on the WAYF. |
 | unconnectedIdps | (int) 0 | Type: integer. The number of unconnected IdPs to display on the WAYF. |
 | backLink | (bool) false | Type: boolean. Display the back link on the WAYF. |

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -258,6 +258,14 @@ class EngineBlock_Application_DiContainer extends Pimple
         return $this->container->getParameter('wayf.display_default_idp_banner_on_wayf');
     }
 
+    public function getDefaultIdPEntityId()
+    {
+        if ($this->container->has('wayf.default_idp_entity_id')) {
+            return $this->container->getParameter('wayf.default_idp_entity_id');
+        }
+        return null;
+    }
+
     public function getRememberChoice()
     {
         return $this->container->getParameter('wayf.remember_choice');

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
@@ -93,6 +93,7 @@ class Wayf extends Twig_Extension
                         'title' => strtolower($idp['Name_' . $locale]),
                         'keywords' => strtolower(join('|', $idpKeywords)),
                         'logo' => $idp['Logo'],
+                        'isDefaultIdp' => (bool) $idp['isDefaultIdp'],
                     ]
                 );
                 continue;
@@ -105,6 +106,7 @@ class Wayf extends Twig_Extension
                 'title' => strtolower($idp['Name_'.$locale]),
                 'keywords' => strtolower(join('|', $idpKeywords)),
                 'logo' => $idp['Logo'],
+                'isDefaultIdp' => (bool) $idp['isDefaultIdp'],
             ];
         }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
@@ -46,6 +46,7 @@ class WayfController extends Controller
         $rememberChoiceFeature = (bool) $request->get('rememberChoiceFeature', false);
         $cutoffPointForShowingUnfilteredIdps = $request->get('cutoffPointForShowingUnfilteredIdps', 100);
         $showIdPBanner = $request->get('showIdPBanner', true);
+        $defaultIdpEntityId = $request->get('defaultIdpEntityId', null);
         // Casting a string 'true' or 'false' using filter_var (bool) does not work here
         $showIdPBanner = filter_var($showIdPBanner, FILTER_VALIDATE_BOOLEAN);
 
@@ -65,7 +66,7 @@ class WayfController extends Controller
                 'showRequestAccess' => $displayUnconnectedIdpsWayf,
                 'requestId' => 'bogus-request-id',
                 'serviceProvider' => TestEntitySeeder::buildSp(),
-                'idpList' => TestEntitySeeder::buildIdps($connectedIdps, $unconnectedIdps, $currentLocale),
+                'idpList' => TestEntitySeeder::buildIdps($connectedIdps, $unconnectedIdps, $currentLocale, $defaultIdpEntityId),
                 'beforeScriptHtml' => '<div id="request-access-scroller"><div id="request-access-container">' .
                     '<div id="request-access"></div></div></div>',
             ]

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
@@ -37,7 +37,7 @@ class TestEntitySeeder
      * @param string $locale
      * @return array[]
      */
-    public static function buildIdps($numberOfIdps, $numberOfUnconnectedIdps, $locale)
+    public static function buildIdps($numberOfIdps, $numberOfUnconnectedIdps, $locale, $defaultIdpEntityId)
     {
         Assert::integer($numberOfIdps);
         Assert::integer($numberOfUnconnectedIdps);
@@ -52,14 +52,22 @@ class TestEntitySeeder
         for ($i=1; $i < (int) ($numberOfIdps - $numberOfUnconnectedIdps) + 1; $i++) {
             $entityId = sprintf("https://example.com/entityId/%d", $i);
             $name = sprintf("%s IdP %d %s", 'Connected', $i, $locale);
-            $idps[$entityId] = ['name' => $name, 'enabled' => true];
+            $isDefaultIdp = false;
+            if ($defaultIdpEntityId === $entityId) {
+                $isDefaultIdp = true;
+            }
+            $idps[$entityId] = ['name' => $name, 'enabled' => true, 'isDefaultIdp' => $isDefaultIdp];
         }
 
         if ($numberOfUnconnectedIdps > 0) {
             for ($i=1; $i < (int) $numberOfUnconnectedIdps + 1; $i++) {
                 $entityId = sprintf("https://unconnected.example.com/entityId/%d", $i);
                 $name = sprintf("%s IdP %d %s", 'Disconnected', $i, $locale);
-                $idps[$entityId] = ['name' => $name, 'enabled' => false];
+                $isDefaultIdp = false;
+                if ($defaultIdpEntityId === $entityId) {
+                    $isDefaultIdp = true;
+                }
+                $idps[$entityId] = ['name' => $name, 'enabled' => false, 'isDefaultIdp' => $isDefaultIdp];
             }
         }
 
@@ -86,6 +94,7 @@ class TestEntitySeeder
                 'Access' => ($identityProvider->enabledInWayf) ? '1' : '0',
                 'ID' => md5($identityProvider->entityId),
                 'EntityID' => $identityProvider->entityId,
+                'isDefaultIdp' => $idpEntityIds[$identityProvider->entityId]['isDefaultIdp']
             );
             $wayfIdps[] = $wayfIdp;
         }

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
@@ -6,6 +6,7 @@
     data-index="{{ loop.index }}"
     data-keywords="{{ idp['keywords']|lower }}"
     data-title="{{ idp['displayTitle']|lower }}"
+    data-is-default-idp="{{ idp['isDefaultIdp'] ? 'true' : 'false' }}"
     tabindex="0"
 >
     <picture class="idp__logo">

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
@@ -6,7 +6,7 @@
     data-index="{{ loop.index }}"
     data-keywords="{{ idp['keywords']|lower }}"
     data-title="{{ idp['displayTitle']|lower }}"
-    data-is-default-idp="{{ idp['isDefaultIdp'] ? 'true' : 'false' }}"
+    {% if idp['isDefaultIdp'] %}id="defaultIdp"{% endif %}
     tabindex="0"
 >
     <picture class="idp__logo">

--- a/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
+++ b/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
@@ -148,6 +148,12 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?showIdpBanner=0');
       cy.get('.remainingIdps__eduId').should('not.exist');
     });
+
+    it('Ensure the default IdP has the correct data attribute', () => {
+      cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?defaultIdpEntityId=https://example.com/entityId/3');
+      cy.get('article[data-entityid="https://example.com/entityid/3"]')
+        .should('have.attr', 'data-is-default-idp', 'true');
+    });
   });
 
   describe('Should show the remember my choice option', () => {

--- a/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
+++ b/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
@@ -152,7 +152,7 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
     it('Ensure the default IdP has the correct data attribute', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?defaultIdpEntityId=https://example.com/entityId/3');
       cy.get('article[data-entityid="https://example.com/entityid/3"]')
-        .should('have.attr', 'data-is-default-idp', 'true');
+        .should('have.id', 'defaultIdp');
     });
   });
 


### PR DESCRIPTION
Allow configuration of the default IdP entity ID. This id is then used to mark the default IdP in the wayf list. Or at least to easily select it when the link in the banner is clicked.

To test this feature, use this qurey param in the function testing wayf

https://engine.vm.openconext.org/functional-testing/wayf?defaultIdpEntityId=https://example.com/entityId/3