### PR TITLE
Ensure all cypress commands are theme agnostic

### DIFF
--- a/theme/cypress/support/commands.js
+++ b/theme/cypress/support/commands.js
@@ -1,5 +1,5 @@
-Cypress.Commands.add('countIdps', (expectedCount) => {
-  cy.get('#idp-picker h3')
+Cypress.Commands.add('countIdps', (expectedCount, idpSelector = '#idp-picker h3') => {
+  cy.get(idpSelector)
   .should('have.length', expectedCount);
 });
 


### PR DESCRIPTION
Ensure all custom cypress commands can be used by other themes as well