### PR TITLE
Change default isMinimalConsent behavior

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/ConsentSettings.php
+++ b/src/OpenConext/EngineBlock/Metadata/ConsentSettings.php
@@ -95,7 +95,7 @@ class ConsentSettings implements JsonSerializable
             return $settings->type === self::CONSENT_MINIMAL;
         }
 
-        return false;
+        return true;
     }
 
     public function hasConsentExplanation($entityId)

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Consent.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Consent.feature
@@ -34,12 +34,13 @@ Feature:
     Given I log in at "Dummy-SP"
       And I pass through EngineBlock
       And I pass through the IdP
-     Then the response should contain "Do you agree with sharing this data?"
-     Then the response should contain "Yes, proceed to Dummy-SP"
-     Then the response should contain "No, I do not agree"
-     Then the response should contain "Dummy-SP needs your information before logging in"
-     Then the response should contain "support@openconext.org"
-     Then the response should contain "+31612345678"
+     Then the response should not contain "Do you agree with sharing this data?"
+      And the response should not contain "Yes, proceed to Dummy-SP"
+      And the response should contain "Proceed to Dummy-SP"
+      And the response should not contain "No, I do not agree"
+      And the response should contain "Cancel"
+      And the response should contain "support@openconext.org"
+      And the response should contain "+31612345678"
      When I give my consent
      Then I pass through EngineBlock
 
@@ -92,9 +93,9 @@ Feature:
     Given I log in at "Dummy-SP"
      And I pass through EngineBlock
      And I pass through the IdP
-    Then the response should contain "Do you agree with sharing this data?"
+    Then the response should contain "Proceed to Dummy-SP"
     When I reload the page
-    Then the response should contain "Do you agree with sharing this data?"
+    Then the response should contain "Proceed to Dummy-SP"
 
   Scenario: The user sees the identifier section when nameid is persistent
     Given SP "Dummy-SP" uses the Persistent NameID format

--- a/tests/unit/OpenConext/EngineBlock/Metadata/ConsentSettingsTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/ConsentSettingsTest.php
@@ -46,7 +46,7 @@ class ConsentSettingsTest extends TestCase
     {
         $settings = new ConsentSettings([]);
 
-        $this->assertFalse($settings->isMinimal('test'));
+        $this->assertTrue($settings->isMinimal('test'));
     }
 
     public function testCanReadAllServiceProviderEntityIds()

--- a/theme/cypress/integration/skeune/consent/consent.skeune.spec.js
+++ b/theme/cypress/integration/skeune/consent/consent.skeune.spec.js
@@ -77,7 +77,7 @@ context('Consent on Skeune theme', () => {
     });
 
     it('Should show the decline consent modal after selection', () => {
-      cy.contains('label', 'No, I do not agree')
+      cy.contains('label', 'Cancel')
         .click({force: true});
       cy.get('.ctas .modal__value')
         .should('be.visible');


### PR DESCRIPTION
By default when no idp/sp configuration is available the consent style
is set to be minimal.