### PR TITLE
Show and hide default IdP when searching

### DIFF
--- a/theme/base/javascripts/wayf/search/toggleDefaultIdPLinkVisibility.js
+++ b/theme/base/javascripts/wayf/search/toggleDefaultIdPLinkVisibility.js
@@ -1,0 +1,16 @@
+import {showElement} from '../../utility/showElement';
+import {hideElement} from '../../utility/hideElement';
+
+/**
+ * Shows / hides the default IdP link section
+ *
+ * @param searchTerm
+ */
+export const toggleDefaultIdPLinkVisibility = (searchTerm) => {
+  const idpLink = document.querySelector('.remainingIdps__defaultIdp');
+  if (searchTerm.length > 0 ) {
+    hideElement(idpLink);
+  } else {
+    showElement(idpLink);
+  }
+};

--- a/theme/base/javascripts/wayf/searchBehaviour.js
+++ b/theme/base/javascripts/wayf/searchBehaviour.js
@@ -1,6 +1,7 @@
 import {throttle} from '../utility/throttle';
 import {nodeListToArray} from '../utility/nodeListToArray';
 import {searchAndSortIdps} from './search/searchAndSortIdps';
+import {toggleDefaultIdPLinkVisibility} from "./search/toggleDefaultIdPLinkVisibility";
 
 export const searchBehaviour = () => {
   const idpList = document.querySelectorAll('.wayf__remainingIdps .wayf__idpList > li');
@@ -9,6 +10,7 @@ export const searchBehaviour = () => {
 
   // attach handler to search field
   searchBar.addEventListener('keyup', throttle(event => searchAndSortIdps(idpArray, event.target.value), 250));
+  searchBar.addEventListener('keyup', event => toggleDefaultIdPLinkVisibility(event.target.value));
   searchBar.addEventListener('click', event => searchAndSortIdps(idpArray, event.target.value));
   searchBar.addEventListener('input', event => searchAndSortIdps(idpArray, event.target.value));
 

--- a/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
+++ b/theme/cypress/integration/skeune/wayf/WayfGeneralBehaviour.js
@@ -182,4 +182,18 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
           .should('have.text', 'Return to Service Provider');
       });
   });
+
+  describe('Test hides and shows IdP list', () => {
+    it('Should hide the IdP link when search term is provided', () => {
+      cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
+      cy.get('.search__field').type('search-term');
+      cy.notOnPage('If your organisation is not listed').should('not.exist');
+    });
+
+    it('Should show the IdP link when search term is provided', () => {
+      cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
+      cy.get('.search__field').type('');
+      cy.onPage('If your organisation is not listed');
+    });
+  });
 });


### PR DESCRIPTION
When searching, the default IdP should be hidden. When the search bar is
empty, the idp banner should re-appear.