### PR TITLE
Repair the previously selected feature in test

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
@@ -174,13 +174,19 @@ class Wayf extends Twig_Extension
     {
         $request = $requestStack->getCurrentRequest();
         $previousSelection = null;
+        $previousSelectionIndexed = [];
         if ($request) {
             $previousSelection = json_decode(
                 $request->cookies->get(self::PREVIOUS_SELECTION_COOKIE_NAME, null),
                 true
             );
+            if ($previousSelection) {
+                // And index the previous selection on IdP entity ID
+                foreach ($previousSelection as $item) {
+                    $previousSelectionIndexed[$item['idp']] = $item;
+                }
+            }
         }
-
-        return $previousSelection;
+        return $previousSelectionIndexed;
     }
 }

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
@@ -2,7 +2,7 @@
     aria-describedby="idp__title{{ listName }}{{ loop.index }}"
     class="wayf__idp{% if idp['connected'] is defined and not idp['connected'] %} wayf__idp--noAccess{% endif %}"
     data-count="{% if idp['count'] is defined %}{{ idp['count'] }}{% else %}0{% endif %}"
-    data-entityid="{{ idp['entityId']|lower }}"
+    data-entityid="{{ idp['entityId'] }}"
     data-index="{{ loop.index }}"
     data-keywords="{{ idp['keywords']|lower }}"
     data-title="{{ idp['displayTitle']|lower }}"

--- a/web/app.php
+++ b/web/app.php
@@ -8,7 +8,6 @@ require_once __DIR__.'/../app/AppKernel.php';
 $symfonyEnvironment = getenv('SYMFONY_ENV') ?: 'prod';
 
 $request = Request::createFromGlobals();
-
 $kernel = new AppKernel($symfonyEnvironment, false);
 $kernel->boot();
 


### PR DESCRIPTION
The test WAYF did not function as intened. It did not show the previously selected IdP's as the cookie could not be used by the Twig Function:

1. The TWIG function compared the EnittyID of the IDP in a case sensitive manner (good thing) but the EntityId was lower cased in the Twig template (no bueno).
2. The cookie for previous selection was no longer indexed on entityID, making the matching logic in the Twig function impossible. This was also fixed by re-indexing the values once they where loaded in the function.