### PR TITLE
Increase whitespace between consent title and text

### DIFF
--- a/theme/base/stylesheets/pages/consent.scss
+++ b/theme/base/stylesheets/pages/consent.scss
@@ -172,11 +172,13 @@
 
                 > .attribute__name {
                     @include grid-position(1, 2, 1, 2);
+                    margin-right: 0.5rem;
                     text-align: right;
 
                     @include screen('mobile') {
-                        text-align: left;
                         display: inline-block;
+                        text-align: left;
+                        margin-right: 0;
                     }
 
                     > label.tooltip {


### PR DESCRIPTION
The whitespace needed to be a bit more roomy. By setting a margin-right on the title, this should not interfere with other viewports as they render title and text beneath each other.