### PR TITLE
Fix undefined index error

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/ContinueToIdp.php
+++ b/library/EngineBlock/Corto/Module/Service/ContinueToIdp.php
@@ -64,15 +64,19 @@ class EngineBlock_Corto_Module_Service_ContinueToIdp implements EngineBlock_Cort
      */
     public function serve($serviceName, Request $httpRequest)
     {
-        $selectedIdp = urldecode($_REQUEST['idp']);
-        if (!$selectedIdp) {
+        $selectedIdp = null;
+        if (array_key_exists('idp', $_REQUEST)) {
+            $selectedIdp = urldecode($_REQUEST['idp']);
+        }
+
+        if ($selectedIdp !== null) {
             throw new EngineBlock_Corto_Module_Services_Exception(
                 'No IdP selected after WAYF'
             );
         }
 
         // Retrieve the request from the session.
-        $id      = $_POST['ID'];
+        $id = $_POST['ID'];
         if (!$id) {
             throw new EngineBlock_Exception(
                 'Missing ID for AuthnRequest after WAYF',

--- a/library/EngineBlock/Corto/Module/Service/ContinueToIdp.php
+++ b/library/EngineBlock/Corto/Module/Service/ContinueToIdp.php
@@ -69,7 +69,7 @@ class EngineBlock_Corto_Module_Service_ContinueToIdp implements EngineBlock_Cort
             $selectedIdp = urldecode($_REQUEST['idp']);
         }
 
-        if ($selectedIdp !== null) {
+        if ($selectedIdp === null) {
             throw new EngineBlock_Corto_Module_Services_Exception(
                 'No IdP selected after WAYF'
             );


### PR DESCRIPTION
Oct 30 19:14:34 sv2010010 EBLOG-FIN[21532]: [2020-10-30 19:14:34] app.ERROR: Undefined index: idp [/apps/installation/OpenConext-engineblock/engine.broker.fin.rijksdienst.nl/OpenConext-engineblock-6.3.6/library/EngineBlock/Corto/Module/Service/ContinueToIdp.php:67]

This should never happen in the first place, but it could happen if a session is lost.. The undefined index error can be prevented