### PR TITLE
Use Composer 1 while not Composer 2 compatible

### DIFF
--- a/docker/php-fpm/Dockerfile-php72
+++ b/docker/php-fpm/Dockerfile-php72
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-enable xdebug
 
 # Composer
-RUN curl -sL https://getcomposer.org/installer | php -- --install-dir /usr/bin --filename composer
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 
 # Fix npm
 RUN mkdir /.npm && chown -R "${NPM_UID}:${NPM_GID}" "/.npm"

--- a/docker/php-fpm/Dockerfile-php74
+++ b/docker/php-fpm/Dockerfile-php74
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-enable xdebug
 
 # Composer
-RUN curl -sL https://getcomposer.org/installer | php -- --install-dir /usr/bin --filename composer
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 
 # Fix npm
 RUN mkdir /.npm && chown -R "${NPM_UID}:${NPM_GID}" "/.npm"


### PR DESCRIPTION
Download the composer 1 installer instead of using the latest and greatest. This should enable the dependencies to install without error on the GitHub Actions pipelines.