### PR TITLE
Leave the previously selected IdPs in the 'select another IdP' list

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
@@ -96,7 +96,6 @@ class Wayf extends Twig_Extension
                         'isDefaultIdp' => (bool) $idp['isDefaultIdp'],
                     ]
                 );
-                continue;
             }
 
             $formattedIdpList[] = [


### PR DESCRIPTION
In the previous situation the previously selected IdPs where only shown in the shortlist. This is not very intuitive when clicking the 'select a different IdP' link from the short list. As the IdPs you used before are no longer available for selection.