### PR TITLE
Align IdP titles between connected and disconnected variaties

### DIFF
--- a/theme/base/stylesheets/pages/wayf.scss
+++ b/theme/base/stylesheets/pages/wayf.scss
@@ -100,7 +100,6 @@
                         align-items: center;
                         box-sizing: content-box;
                         display: flex;
-                        justify-content: space-between;
                         width: calc(100% - 6.25rem);
 
                         @include screen('mobile') {


### PR DESCRIPTION
By removing the justification layout directive from the stylesheet, the texts are now aligned similarly between the connected and disconnected IdPs.

See screenshots for a concept of what I'm on about.

*Full width browser*
![Screenshot_2020-11-17 OpenConext - Select an organisation to login to DisplayName](https://user-images.githubusercontent.com/28252948/99379296-c5152680-28c8-11eb-946c-166a78248aec.png)

*Mobile*
![Screenshot_2020-11-17 OpenConext - Select an organisation to login to DisplayName(1)](https://user-images.githubusercontent.com/28252948/99379290-c3e3f980-28c8-11eb-90c2-331f0b6f2720.png)

PS. Only consider the last commit of this PR (this branch was based on the fix cypress tests PR)