### PR TITLE
Show search icon on page load

### DIFF
--- a/theme/base/javascripts/wayf/search/toggleSearchAndResetButton.js
+++ b/theme/base/javascripts/wayf/search/toggleSearchAndResetButton.js
@@ -4,6 +4,9 @@ import {showElement} from "../../utility/showElement";
 export const toggleSearchAndResetButton = (searchTerm) => {
   const searchButton = document.querySelector('.search__submit');
   const resetButton = document.querySelector('.search__reset');
+  if (resetButton.classList.contains('visually-hidden')) {
+    resetButton.classList.remove('visually-hidden');
+  }
 
   if (searchTerm !== '') {
     hideElement(searchButton);

--- a/theme/base/stylesheets/pages/wayf.scss
+++ b/theme/base/stylesheets/pages/wayf.scss
@@ -405,6 +405,7 @@
                     @include absolute(top 3px right 3px);
                     @include button-reset($white);
                     @include poirot;
+                    background-color: transparent;
                     background-position: center center;
                     background-size: 1.5rem 1.5rem;
                     border-radius: 6px;

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/search.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/search.html.twig
@@ -10,6 +10,6 @@
         placeholder="{{ 'wayf_search_placeholder'|trans }}"
         type="search"
     />
+    <button type="reset" class="search__reset visually-hidden"><span class="visually-hidden">{{ 'reset'|trans }}</span></button>
     <button type="submit" class="search__submit"><span class="visually-hidden">{{ 'search'|trans }}</span></button>
-    <button type="reset" class="search__reset"><span class="visually-hidden">{{ 'reset'|trans }}</span></button>
 </form>


### PR DESCRIPTION
And hide the reset button visually. When typing, show the reset button (remove the class).

The background has also been removed from the poirot element. This prevents setting extra logic to color with the parent elements focus style. E.g. when the search bar is focussed, you want the poirot to be focussed too