### PR TITLE
Only show default IdP when available

### DIFF
--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -260,7 +260,7 @@ class EngineBlock_Application_DiContainer extends Pimple
 
     public function getDefaultIdPEntityId()
     {
-        if ($this->container->has('wayf.default_idp_entity_id')) {
+        if ($this->container->hasParameter('wayf.default_idp_entity_id')) {
             return $this->container->getParameter('wayf.default_idp_entity_id');
         }
         return null;


### PR DESCRIPTION
Only show default IdP when available and when the feature is enabled. Testing this feature showed an error in the way this feature was created. The di container checked for the existence of a config setting, and not for the existence of a the wayf parameter. This was also fixed in this commit