### PR TITLE
Only show default idp when connected

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -478,12 +478,20 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
                 continue;
             }
 
+            $isAccessible = $identityProvider->enabledInWayf || $isDebugRequest;
             $isDefaultIdP = false;
             if ($defaultIdpEntityId === $identityProvider->entityId) {
                 $isDefaultIdP = true;
             }
 
+            // Do not show the default IdP in the disconnected IdPs section.
+            if (!$isAccessible && $isDefaultIdP) {
+                continue;
+            }
+
             $additionalInfo = AdditionalInfo::create()->setIdp($identityProvider->entityId);
+
+            $isAccessible = $identityProvider->enabledInWayf || $isDebugRequest;
 
             $wayfIdp = array(
                 'Name_nl'   => $this->getNameNl($identityProvider, $additionalInfo),
@@ -491,7 +499,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
                 'Name_pt'   => $this->getNamePt($identityProvider, $additionalInfo),
                 'Logo'      => $identityProvider->logo ? $identityProvider->logo->url : '/images/placeholder.png',
                 'Keywords'  => $this->getKeywords($identityProvider),
-                'Access'    => $identityProvider->enabledInWayf || $isDebugRequest ? '1' : '0',
+                'Access'    => $isAccessible ? '1' : '0',
                 'ID'        => md5($identityProvider->entityId),
                 'EntityID'  => $identityProvider->entityId,
                 self::IS_DEFAULT_IDP_KEY => $isDefaultIdP

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/ConnectedIdps.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/ConnectedIdps.php
@@ -67,4 +67,14 @@ class ConnectedIdps
     {
         return $this->formattedPreviousSelectionList;
     }
+
+    public function getDefaultIdPTitle()
+    {
+        foreach ($this->formattedIdpList as $idp) {
+            if ($idp['isDefaultIdp']) {
+                return $idp['displayTitle'];
+            }
+        }
+        return '';
+    }
 }

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/remainingIdps.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/remainingIdps.html.twig
@@ -19,7 +19,7 @@
         {% set organisationNoun = 'organisation_noun'|trans %}
         {% include '@theme/Default/Partials/informational.html.twig' with {
             class: 'remainingIdps__defaultIdp',
-            text: 'wayf_defaultIdp'|trans({ '%defaultIdpLink%': requestUri, '%organisation_noun%': organisationNoun })
+            text: 'wayf_defaultIdp'|trans({ '%defaultIdpLink%': requestUri, '%organisation_noun%': organisationNoun, '%defaultIdpName%': connectedIdps.defaultIdPTitle })
         } %}
     {% endif %}
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/rememberChoice.html.twig' %}

--- a/theme/skeune/translations/messages.en.php
+++ b/theme/skeune/translations/messages.en.php
@@ -30,7 +30,7 @@ return [
     'wayf_noaccess_email'       => 'Your emailaddress',
     'wayf_noaccess_motivation'  => 'Motivation',
     'wayf_noaccess_success'     => 'Your request for access has been sent.',
-    'wayf_defaultIdp'                => 'If your %organisation_noun% is not listed, <a href="%defaultIdpLink%" class="wayf__defaultIdpLink">eduID is available as an alternative.</a>',
+    'wayf_defaultIdp'                => 'If your %organisation_noun% is not listed, <a href="%defaultIdpLink%" class="wayf__defaultIdpLink">%defaultIdpName% is available as an alternative.</a>',
     'wayf_idp_title_screenreader' => 'Login with ',
     'log_in_to'                 => 'Select an %organisationNoun% to login to %arg1%',
 

--- a/theme/skeune/translations/messages.nl.php
+++ b/theme/skeune/translations/messages.nl.php
@@ -30,7 +30,7 @@ return [
     'wayf_noaccess_email'       => 'Uw e-mailadres',
     'wayf_noaccess_motivation'  => 'Motivatie',
     'wayf_noaccess_success'     => 'Je aanvraag tot toegang werd verstuurd.',
-    'wayf_defaultIdp'                => '<a href="%defaultIdpLink%" class="wayf__defaultIdpLink">eduID is beschikbaar als alternatief</a> indien uw %organisation_noun% niet in de lijst staat.',
+    'wayf_defaultIdp'                => '<a href="%defaultIdpLink%" class="wayf__defaultIdpLink">%defaultIdpName% is beschikbaar als alternatief</a> indien uw %organisation_noun% niet in de lijst staat.',
     'wayf_idp_title_screenreader' => 'Inloggen met ',
     'log_in_to'                 => 'Selecteer een %organisationNoun% en login bij %arg1%',
 

--- a/theme/skeune/translations/messages.pt.php
+++ b/theme/skeune/translations/messages.pt.php
@@ -30,7 +30,7 @@ return [
     'wayf_noaccess_email'       => 'Your emailaddress',
     'wayf_noaccess_motivation'  => 'Motivation',
     'wayf_noaccess_success'     => 'Your request for access has been sent.',
-    'wayf_defaultIdp'                => 'If your %organisation_noun% is not listed, <a href="%defaultIdpLink%" class="wayf__defaultIdpLink">eduID is available as an alternative.</a>',
+    'wayf_defaultIdp'                => 'If your %organisation_noun% is not listed, <a href="%defaultIdpLink%" class="wayf__defaultIdpLink">%defaultIdpName% is available as an alternative.</a>',
     'wayf_idp_title_screenreader' => 'Login with ',
     'log_in_to'                 => 'Select an %organisationNoun% to login to %arg1%',
 


### PR DESCRIPTION
Only show the defautl IdP when it is connected. This makes more sense from an user perspective. 
And we now show the actual IdP title instead of always rendering eduID as the default IdP name.