### PR TITLE
Ensure logo height never grows too big

### DIFF
--- a/theme/base/stylesheets/pages/wayf.scss
+++ b/theme/base/stylesheets/pages/wayf.scss
@@ -92,6 +92,7 @@
                         > svg {
                             height: auto;
                             margin: auto 0;
+                            max-height: 100%;
                             width: 100%;
                         }
                     }


### PR DESCRIPTION
You can test this by using the following code to replace line 14 in idp.html.twig & and using the logo that triggered the bug report ![conext_logo](https://user-images.githubusercontent.com/4058016/99978217-f482d200-2da5-11eb-9451-8aaff67b679c.png)
 (or something similar):

```
           {% if loop.index == 1 %}
                {% set logoUrl = '/images/temp/conext_logo.png' %}
            {% else %}
                {% set logoUrl = idp.logo %}
            {% endif %}
```