### PR TITLE
Use organization name for SP in disclaimer text

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -42,6 +42,7 @@ return $overrides + [
     'go_back'               => '&lt;&lt; Go back',
     'note'                  => 'Note',
     'note_no_script'        => 'Since your browser does not support JavaScript, you must press the button below to proceed.',
+    'unknown_organization_name' => 'Unknown',
 
     // Feedback
     'requestId'             => 'UR ID',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -42,6 +42,7 @@ return $overrides + [
     'go_back'               => '&lt;&lt; Ga terug',
     'note'                  => 'Mededeling',
     'note_no_script'        => 'Jouw browser ondersteunt geen JavaScript. Je moet op de onderstaande knop drukken om door te gaan.',
+    'unknown_organization_name' => 'Onbekend',
 
      // Feedback
     'requestId'             => 'UR ID',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -42,6 +42,7 @@ return $overrides + [
     'go_back'               => '&lt;&lt; Volte atrás',
     'note'                  => 'Nota',
     'note_no_script'        => 'Visto que o seu browser não suporta JavaScript, deve pressionar no botão em baixo para prosseguir.',
+    'unknown_organization_name' => 'Unknown',
 
     // Feedback
     'requestId'             => 'UR ID',

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -364,6 +364,32 @@ class ServiceProvider extends AbstractRole
         return $spName;
     }
 
+    public function getOrganizationName(string $preferredLocale = ''): string
+    {
+        $orgName = '';
+        if ($preferredLocale === 'nl') {
+            $orgName = $this->organizationNl->displayName;
+            if (empty($orgName)) {
+                $orgName = $this->organizationNl->name;
+            }
+        } elseif ($preferredLocale === 'en') {
+            $orgName = $this->organizationEn->displayName;
+            if (empty($orgName)) {
+                $orgName = $this->organizationEn->name;
+            }
+        } elseif ($preferredLocale === 'pt') {
+            $orgName = $this->organizationPt->displayName;
+            if (empty($orgName)) {
+                $orgName = $this->organizationPt->name;
+            }
+        }
+
+        if (empty($orgName)) {
+            $orgName = '';
+        }
+        return $orgName;
+    }
+
     /**
      * @return bool
      */

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
@@ -219,6 +219,7 @@ abstract class AbstractEntityTest extends TestCase
         $skipMethods = [
             'accept',
             'getDisplayName',
+            'getOrganizationName',
             'toggleWorkflowState',
         ];
 

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Adapter/ServiceProviderEntityTest.php
@@ -72,6 +72,7 @@ class ServiceProviderEntityTest extends AbstractEntityTest
             'attributeAggregationRequired' => $ormEntity->isAttributeAggregationRequired(),
             'allowed' => $ormEntity->isAllowed('entity-id'),
             'displayName' => $ormEntity->getDisplayName('EN'),
+            'organization' => $ormEntity->getOrganizationName('EN'),
         ];
 
         $this->runServiceProviderAssertions($adapter, $adapter, $assertions);

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/disclaimerList.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/disclaimerList.html.twig
@@ -8,9 +8,9 @@
             {% include '@theme/Authentication/View/Proxy/Partials/Consent/SVG/file_info.svg' %}
             <div>
                 {% if sp.coins.termsOfServiceUrl is not null %}
-                    {{ 'consent_disclaimer_privacy'|trans({'%org%': spName, '%privacy_url%': sp.coins.termsOfServiceUrl})|raw }}
+                    {{ 'consent_disclaimer_privacy'|trans({'%org%': organizationName, '%privacy_url%': sp.coins.termsOfServiceUrl})|raw }}
                 {% else %}
-                    {{ 'consent_disclaimer_privacy_nolink'|trans({ '%org%': spName })|raw }}
+                    {{ 'consent_disclaimer_privacy_nolink'|trans({ '%org%': organizationName })|raw }}
                 {% endif %}
             </div>
         </div>

--- a/theme/base/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -2,6 +2,7 @@
 
 {# SP and IdP name are stored in a local variable for convenience #}
 {% set spName = sp.displayName(locale()) %}
+{% set organizationName = sp.organizationName(locale())|default('unknown_organization_name'|trans) %}
 {% set idpName = idp.displayName(locale()) %}
 
 {# Prepare the page title #}


### PR DESCRIPTION
The following fallback sequence was implemented.

Show:
1. Organization Display Name
2. Organization Name when 1 is not available
3. 'Unknown' when 1 and 2 are not available