### PR TITLE
Ensure the id of a tooltip is unique

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
@@ -2,7 +2,7 @@
     {# in case a tooltip needs to be shown set the id #}
     {% if attributeMotivations[attributeIdentifier] is defined %}
         {% set id %}
-            tooltip{{ loop.index }}
+            tooltip{{ loop.index }}{{ orgId }}
         {% endset %}
         <input type="checkbox" tabindex="-1" aria-hidden="true" class="tooltip visually-hidden" id="{{ id|trim }}" name="{{ id|trim }}" />
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/name.html.twig' with { attributeName: attributeShortName(attributeIdentifier, locale()), id: id|trim } %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/engineBlockAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/engineBlockAttribute.html.twig
@@ -1,7 +1,7 @@
 <li class="consent__attribute">
     {% if nameIdIsPersistent %}
         {% set id %}
-            tooltip{{ loop.index }}
+            tooltip{{ loop.index }}{{ orgId }}
         {% endset %}
         <input type="checkbox" tabindex="-1" class="tooltip visually-hidden" aria-hidden="true" id="{{ id|trim }}" name="{{ id|trim }}" />
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/name.html.twig' with { attributeName: 'consent_name_id_label'|trans, id: id|trim } %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig
@@ -1,6 +1,6 @@
 {% if tooltipValue %}
     {% set id %}
-        tooltip{{ loop.index }}
+        tooltip{{ loop.index }}{{ orgId }}
     {% endset %}
     {% include '@theme/Default/Partials/label.html.twig' with
         {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/attributes.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/attributes.html.twig
@@ -1,4 +1,5 @@
 {% for attributeSource, attributes in attributesBySource %}
+    {% set orgId = attributeSourceDisplayName(attributeSource)|trim|split(' ')|join %}
     {% if attributes|length == 0 %}
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/noAttributes.html.twig' %}
     {% else %}

--- a/theme/cypress/integration/skeune/consent/consent.general.spec.js
+++ b/theme/cypress/integration/skeune/consent/consent.general.spec.js
@@ -22,7 +22,7 @@ context('Consent on Skeune theme', () => {
 
   describe('Hides the correct content on load', () => {
     it('Hides the tooltip on load', () => {
-      cy.get('label.tooltip[for="tooltip3"]:not(:first-child)')
+      cy.get('label.tooltip[for="tooltip3consent_attribute_source_idp"]:not(:first-child)')
         .next()
         .should('not.be.visible');
     });

--- a/theme/cypress/integration/skeune/consent/consent.keyboard.spec.js
+++ b/theme/cypress/integration/skeune/consent/consent.keyboard.spec.js
@@ -31,18 +31,18 @@ context('Consent when using the keyboard', () => {
 
   describe('Shows / hides the tooltips on enter', () => {
     it('Shows the tooltip', () => {
-      cy.focusAndEnter('label.tooltip[for="tooltip3"]:not(:first-child)')
+      cy.focusAndEnter('label.tooltip[for="tooltip3consent_attribute_source_idp"]:not(:first-child)')
         .next()
         .should('be.visible');
     });
 
     it('Hides the tooltip', () => {
       // Make it visible
-      cy.focusAndEnter('label.tooltip[for="tooltip3"]:not(:first-child)')
+      cy.focusAndEnter('label.tooltip[for="tooltip3consent_attribute_source_idp"]:not(:first-child)')
         .next();
 
       // Hide and check if it worked
-      cy.focusAndEnter('label.tooltip[for="tooltip3"]:not(:first-child)')
+      cy.focusAndEnter('label.tooltip[for="tooltip3consent_attribute_source_idp"]:not(:first-child)')
         .next()
         .should('not.be.visible');
     });

--- a/theme/cypress/integration/skeune/consent/consent.mouse.spec.js
+++ b/theme/cypress/integration/skeune/consent/consent.mouse.spec.js
@@ -31,7 +31,7 @@ context('Consent when using the mouse', () => {
 
   describe('Shows / hides the tooltips on click', () => {
     it('Shows the tooltip', () => {
-      cy.get('label.tooltip[for="tooltip3"]:not(:first-child)')
+      cy.get('label.tooltip[for="tooltip3consent_attribute_source_idp"]:not(:first-child)')
         .click({force: true})
         .next()
         .should('be.visible');
@@ -39,12 +39,12 @@ context('Consent when using the mouse', () => {
 
     it('Hides the tooltip', () => {
       // Make it visible
-      cy.get('label.tooltip[for="tooltip3"]:not(:first-child)')
+      cy.get('label.tooltip[for="tooltip3consent_attribute_source_idp"]:not(:first-child)')
         .click({force: true})
         .next();
 
       // Hide and check if it worked
-      cy.get('label.tooltip[for="tooltip3"]:not(:first-child)')
+      cy.get('label.tooltip[for="tooltip3consent_attribute_source_idp"]:not(:first-child)')
         .click({force: true})
         .next()
         .should('not.be.visible');


### PR DESCRIPTION
Given that there are potentially different attribute-lists, we need to ensure that the id for a tooltip is unique.  In this PR i've added the attributeSource (SP) name as part of the id, so that each attribute source is guaranteed to have a unique id.