### PR TITLE
Hide spinner & associated text on nojs for form

### DIFF
--- a/theme/base/stylesheets/classes.scss
+++ b/theme/base/stylesheets/classes.scss
@@ -37,6 +37,7 @@
     }
 }
 
-.hidden {
+.hidden,
+.hideNoJS {
     display: none !important;
 }

--- a/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
@@ -31,9 +31,11 @@
                 <h2 class="form__subHeader">{{ 'processing_waiting'|trans }}</h2>
             </header>
 
-            <p>{{ 'processing_long'|trans }}</p>
+            <div class="hideNoJS">
+                <p>{{ 'processing_long'|trans }}</p>
 
-            {% include '@theme/Authentication/View/Proxy/Partials/Shared/spinner.html.twig' %}
+                {% include '@theme/Authentication/View/Proxy/Partials/Shared/spinner.html.twig' %}
+            </div>
 
             <form id="ProcessForm" method="post" action="{{ action }}">
                 <input type="hidden" name="{{ name }}" value="{{ message }}"/>
@@ -49,6 +51,11 @@
         </main>
     </div>
 
+    <script>
+        window.addEventListener('load', () => {
+            document.querySelector('.hideNoJS').classList.remove('hideNoJS');
+        });
+    </script>
     </body>
     </html>
 {% endblock %}


### PR DESCRIPTION
The spinner on the form page serves no purpose when the user has JS disabled.  As such, it and the associated text are now hidden when that is the case.