### PR TITLE
Use organizationName in consent h2 title

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/consentContent.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/consentContent.html.twig
@@ -1,5 +1,5 @@
 <section class="consent__content">
-    <h2>{{ 'consent_privacy_header'|trans({'%target%': spName}) }}</h2>
+    <h2>{{ 'consent_privacy_header'|trans({'%target%': organizationName}) }}</h2>
 
     <div class="consent__content-body">
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/attributes.html.twig' %}


### PR DESCRIPTION
The name used in the h2 did not fit with the designs.  As such when the same name was used in the disclaimer list, it "came out of nowhere".  