### PR TITLE
Differentiate noAccess form when unconnectable

### DIFF
--- a/theme/base/javascripts/wayf/deleteDisable/setConnectability.js
+++ b/theme/base/javascripts/wayf/deleteDisable/setConnectability.js
@@ -1,0 +1,17 @@
+/**
+ * Ensures the right content/texts are shown for the noAccess form, depending on whether or not the clicked Idp is connectable or not.
+ *
+ * @param noAccess          the noAccess section element
+ * @param isConnectable     whether the clicked idp is connectable
+ */
+export const setConnectablity = (noAccess, isConnectable) => {
+  const isUnconnectable = noAccess.classList.contains('wayf__noAccess--unconnectable');
+
+  if (isUnconnectable && isConnectable) {
+    noAccess.classList.replace('wayf__noAccess--unconnectable', 'wayf__noAccess--connectable', );
+  }
+
+  if (!isConnectable && !isUnconnectable) {
+    noAccess.classList.replace('wayf__noAccess--connectable', 'wayf__noAccess--unconnectable');
+  }
+};

--- a/theme/base/javascripts/wayf/deleteDisable/setConnectability.js
+++ b/theme/base/javascripts/wayf/deleteDisable/setConnectability.js
@@ -1,17 +1,17 @@
 /**
  * Ensures the right content/texts are shown for the noAccess form, depending on whether or not the clicked Idp is connectable or not.
  *
- * @param noAccess          the noAccess section element
- * @param isConnectable     whether the clicked idp is connectable
+ * @param noAccess        the noAccess section element
+ * @param connectable     whether the clicked idp is connectable
  */
-export const setConnectablity = (noAccess, isConnectable) => {
-  const isUnconnectable = noAccess.classList.contains('wayf__noAccess--unconnectable');
+export const setConnectability = (noAccess, connectable) => {
+  const currentState = noAccess.classList.contains('wayf__noAccess--unconnectable');
 
-  if (isUnconnectable && isConnectable) {
+  if (currentState !== connectable) {
     noAccess.classList.replace('wayf__noAccess--unconnectable', 'wayf__noAccess--connectable', );
   }
 
-  if (!isConnectable && !isUnconnectable) {
+  if (!currentState && !connectable) {
     noAccess.classList.replace('wayf__noAccess--connectable', 'wayf__noAccess--unconnectable');
   }
 };

--- a/theme/base/javascripts/wayf/handleClickingDisabledIdp.js
+++ b/theme/base/javascripts/wayf/handleClickingDisabledIdp.js
@@ -4,7 +4,7 @@ import {setHiddenFieldValues} from './noAccess/setHiddenFieldValues';
 import {cloneIdp} from './noAccess/cloneIdp';
 import {hideSuccessMessage} from './noAccess/hideSuccessMessage';
 import {attachClickHandlerToRequestButton} from './noAccess/attachClickHandlerToRequestButton';
-import {setConnectablity} from './deleteDisable/setConnectability';
+import {setConnectability} from './deleteDisable/setConnectability';
 import {getData} from '../utility/getData';
 
 export const handleClickingDisabledIdp = (element) => {
@@ -13,9 +13,9 @@ export const handleClickingDisabledIdp = (element) => {
   const form = noAccess.querySelector('.noAccess__requestForm');
   const parentSection = element.closest('section');
   const cloneOfIdp = cloneIdp(element);
-  const isConnectable = getData(element, 'connectable') === 'true';
+  const connectable = getData(element, 'connectable') === 'true';
 
-  setConnectablity(noAccess, isConnectable);
+  setConnectability(noAccess, connectable);
   toggleVisibility(parentSection);
   toggleVisibility(noAccess);
 

--- a/theme/base/javascripts/wayf/handleClickingDisabledIdp.js
+++ b/theme/base/javascripts/wayf/handleClickingDisabledIdp.js
@@ -4,6 +4,8 @@ import {setHiddenFieldValues} from './noAccess/setHiddenFieldValues';
 import {cloneIdp} from './noAccess/cloneIdp';
 import {hideSuccessMessage} from './noAccess/hideSuccessMessage';
 import {attachClickHandlerToRequestButton} from './noAccess/attachClickHandlerToRequestButton';
+import {setConnectablity} from './deleteDisable/setConnectability';
+import {getData} from '../utility/getData';
 
 export const handleClickingDisabledIdp = (element) => {
   const noAccess = document.querySelector('.wayf__noAccess');
@@ -11,7 +13,9 @@ export const handleClickingDisabledIdp = (element) => {
   const form = noAccess.querySelector('.noAccess__requestForm');
   const parentSection = element.closest('section');
   const cloneOfIdp = cloneIdp(element);
+  const isConnectable = getData(element, 'connectable') === 'true';
 
+  setConnectablity(noAccess, isConnectable);
   toggleVisibility(parentSection);
   toggleVisibility(noAccess);
 

--- a/theme/base/javascripts/wayf/noAccess/attachClickHandlerToRequestButton.js
+++ b/theme/base/javascripts/wayf/noAccess/attachClickHandlerToRequestButton.js
@@ -15,19 +15,22 @@ import {toggleFormFieldsAndButton} from './toggleFormFieldsAndButton';
  */
 export const attachClickHandlerToRequestButton = (parentSection, noAccess, form) => {
   const requestButton = document.querySelector('.cta__showForm');
-  const hasClickHandler = getData(requestButton, 'clickhandled');
 
-  // if clickHandler's already been attached, do not attach it again
-  if (hasClickHandler) {
-    return;
+  if (!!requestButton) {
+    const hasClickHandler = getData(requestButton, 'clickhandled');
+
+    // if clickHandler's already been attached, do not attach it again
+    if (hasClickHandler) {
+      return;
+    }
+
+    // attach clickHandler to request button
+    requestButton.addEventListener('click', () => {
+      toggleFormFieldsAndButton();
+    });
+    requestButton.setAttribute('data-clickhandled', true);
+
+    // attach clickHandler for form
+    attachClickHandlerToForm(form, parentSection, noAccess);
   }
-
-  // attach clickHandler to request button
-  requestButton.addEventListener('click', () => {
-    toggleFormFieldsAndButton();
-  });
-  requestButton.setAttribute('data-clickhandled', true);
-
-  // attach clickHandler for form
-  attachClickHandlerToForm(form, parentSection, noAccess);
 };

--- a/theme/base/stylesheets/pages/wayf/noAccess.scss
+++ b/theme/base/stylesheets/pages/wayf/noAccess.scss
@@ -1,4 +1,17 @@
 .wayf__noAccess {
+    &.wayf__noAccess--connectable {
+        .noAccess__unconnectable {
+            display: none;
+        }
+    }
+
+    &.wayf__noAccess--unconnectable {
+        .noAccess__connectable,
+        .noAccess__ctas > .cta__showForm.noAccess__connectable {
+            display: none;
+        }
+    }
+
     > .wayf__idp.wayf__idp--noAccess {
         > .idp__content {
             > .idp__deleteDisable {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
@@ -1,6 +1,13 @@
+{% if idp['connected'] is defined %}
+    {% set connectable = 'true' %}
+{% else %}
+    {% set connectable = 'false' %}
+{% endif %}
+
 <article
     aria-describedby="idp__title{{ listName }}{{ loop.index }}"
     class="wayf__idp{% if idp['connected'] is defined and not idp['connected'] %} wayf__idp--noAccess{% endif %}"
+    data-connectable="{{ connectable }}"
     data-count="{% if idp['count'] is defined %}{{ idp['count'] }}{% else %}0{% endif %}"
     data-entityid="{{ idp['entityId'] }}"
     data-index="{{ loop.index }}"

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/ctas.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/ctas.html.twig
@@ -1,6 +1,9 @@
 <div class="noAccess__ctas">
-    <button type="button" class="cta__cancel">{{ 'cancel'|trans }}</button>
-    <button type="button" class="cta__showForm">{{ 'request_access'|trans }}</button>
+    <button type="button" class="cta__cancel">
+        <span class="noAccess__connectable">{{ 'cancel'|trans }}</span>
+        <span class="noAccess__unconnectable">{{ 'back'|trans }}</span>
+    </button>
+    <button type="button" class="cta__showForm noAccess__connectable">{{ 'request_access'|trans }}</button>
     <a href="#top" class="cta__request hidden">{{ 'send_request'|trans }}</a>
     <button type="submit" class="hidden">{{ 'send_request'|trans }}</button>
 </div>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/helpdesk.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/helpdesk.html.twig
@@ -1,1 +1,4 @@
-<p class="noAccess__helpdesk">{{ 'wayf_no_access_helpdesk'|trans({ '%orgNoun%': 'organisation_noun'|trans }) }}</p>
+<p class="noAccess__helpdesk">
+    <span class="noAccess__connectable">{{ 'wayf_no_access_helpdesk'|trans({ '%orgNoun%': 'organisation_noun'|trans }) }}</span>
+    <span class="noAccess__unconnectable">{{ 'wayf_no_access_helpdesk_not_connected'|trans({ '%buttonText%': 'wayf_add_account'|trans }) }}</span>
+</p>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/noAccess.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/noAccess.html.twig
@@ -1,4 +1,4 @@
-<section class="wayf__noAccess hidden">
+<section class="wayf__noAccess wayf__noAccess--connectable hidden">
     <h2 class="noAccess__title">{{ 'wayf_no_access'|trans }}</h2>
     <ul class="wayf__idpList">
         <li>

--- a/theme/skeune/translations/messages.en.php
+++ b/theme/skeune/translations/messages.en.php
@@ -32,6 +32,7 @@ return [
     'wayf_no_access'            => 'Sorry, no access for this account',
     'wayf_no_access_account'    => 'No access with this account',
     'wayf_no_access_helpdesk'   => 'If you want, you can request access to this service. We will send the request to the helpdesk of your %orgNoun%.',
+    'wayf_no_access_helpdesk_not_connected'     =>  "Go back to the previous page and click '%buttonText%'.",
     'wayf_noaccess_name'        => 'Your name',
     'wayf_noaccess_email'       => 'Your emailaddress',
     'wayf_noaccess_motivation'  => 'Motivation',

--- a/theme/skeune/translations/messages.nl.php
+++ b/theme/skeune/translations/messages.nl.php
@@ -32,6 +32,7 @@ return [
     'wayf_no_access'            => 'Sorry, geen toegang voor deze account',
     'wayf_no_access_account'    => 'Geen toegang met deze account',
     'wayf_no_access_helpdesk'   => 'U kan toegang vragen tot deze dienst.  We sturen deze aanvraag door naar de helpdesk van uw %orgNoun%.',
+    'wayf_no_access_helpdesk_not_connected'     =>  "Ga terug naar de vorige pagina en klik op '%buttonText%'.",
     'wayf_noaccess_name'        => 'Uw naam',
     'wayf_noaccess_email'       => 'Uw e-mailadres',
     'wayf_noaccess_motivation'  => 'Motivatie',

--- a/theme/skeune/translations/messages.pt.php
+++ b/theme/skeune/translations/messages.pt.php
@@ -32,6 +32,7 @@ return [
     'wayf_no_access'            => 'Sorry, no access for this account',
     'wayf_no_access_account'    => 'No access with this account',
     'wayf_no_access_helpdesk'   => 'If you want, you can request access to this service. We will send the request to the helpdesk of your %orgNoun%.',
+    'wayf_no_access_helpdesk_not_connected'     =>  "Go back to the previous page and click '%buttonText%'.",
     'wayf_noaccess_name'        => 'Your name',
     'wayf_noaccess_email'       => 'Your emailaddress',
     'wayf_noaccess_motivation'  => 'Motivation',


### PR DESCRIPTION
When an idp cannot request access a different form needs to be shown when clicking the no-access button.  This PR fixes that.