### PR TITLE
Ensure content of idprow is aligned correctly on Safari & accross source-type

### DIFF
--- a/theme/base/stylesheets/pages/consent/idpRow.scss
+++ b/theme/base/stylesheets/pages/consent/idpRow.scss
@@ -11,6 +11,12 @@
     line-height: 1.63;
     text-align: left;
 
+    @include screen('mobile') {
+        @include grid-template-columns(10% 6% 83% 1%);
+        @include grid-template-rows(min-content min-content);
+        padding: 10px;
+    }
+
     > * {
         padding: 1rem 0;
 
@@ -19,17 +25,19 @@
         }
     }
 
-    @include screen('mobile') {
-        @include grid-template-columns(10% 6% 83% 1%);
-        @include grid-template-rows(min-content min-content);
-        padding: 10px;
-    }
-
     > img {
         @include grid-position(1, 2, 1, 2);
         box-sizing: content-box;
         max-height: calculateRem(30px);
         margin-left: 9px;
+    }
+
+    label.modal {
+        color: $brownishGray;
+        padding: 10px 25px 10px 5px;
+        text-align: right;
+        text-decoration: underline;
+        background-image: unset;
     }
 
     > p {
@@ -44,8 +52,6 @@
         }
 
         > label.modal {
-            background-image: unset;
-
             @include screen('tabletAndBigger') {
                 display: none;
             }
@@ -79,11 +85,6 @@
         }
 
         > label.modal {
-            color: $brownishGray;
-            padding: 10px 25px 10px 5px;
-            text-decoration: underline;
-            background-image: unset;
-
             @include screen('mobile') {
                 display: block;
                 background-position: right 18px center;

--- a/theme/base/stylesheets/pages/consent/idpRow.scss
+++ b/theme/base/stylesheets/pages/consent/idpRow.scss
@@ -45,6 +45,10 @@
 
         > label.modal {
             background-image: unset;
+
+            @include screen('tabletAndBigger') {
+                display: none;
+            }
         }
 
         > .idpRow__providedBy-content {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
@@ -11,6 +11,7 @@
         incorrect_{{ attributeSource }}
     {% endset %}
     <input type="checkbox" tabindex="-1" aria-hidden="true" class="modal visually-hidden" id="{{ id|trim }}" name="{{ id|trim }}" />
+    {# note: the empty label is for display on mobile #}
     <p>{{ text|raw }}<label tabindex="0" for="{{ id|trim }}" class="modal"></label>
     </p>
     {# note: the div is here only for IE11, as soon as IE11 support is scrapped, this can be removed along with the CSS/JS for it  #}


### PR DESCRIPTION
On Safari there are two bugs:
- the label for mobile throws off the alignment of the paragraph under certain fringe conditions
- on MacOS Big Sur 14.0.1 the text-alignment of the labels is left instead of the set value of right.

Aside from that the label for the second row is in blue rather than in dark gray.