### PR TITLE
Use english name as backup of locale-specific name

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -367,15 +367,11 @@ class ServiceProvider extends AbstractRole
     public function getOrganizationName(string $preferredLocale = ''): string
     {
         $orgName = '';
+
         if ($preferredLocale === 'nl') {
             $orgName = $this->organizationNl->displayName;
             if (empty($orgName)) {
                 $orgName = $this->organizationNl->name;
-            }
-        } elseif ($preferredLocale === 'en') {
-            $orgName = $this->organizationEn->displayName;
-            if (empty($orgName)) {
-                $orgName = $this->organizationEn->name;
             }
         } elseif ($preferredLocale === 'pt') {
             $orgName = $this->organizationPt->displayName;
@@ -384,9 +380,17 @@ class ServiceProvider extends AbstractRole
             }
         }
 
+        if ($preferredLocale === 'en' || empty($orgName)) {
+            $orgName = $this->organizationEn->displayName;
+            if (empty($orgName)) {
+                $orgName = $this->organizationEn->name;
+            }
+        }
+
         if (empty($orgName)) {
             $orgName = '';
         }
+
         return $orgName;
     }
 


### PR DESCRIPTION
The algorithm for specifying a name is now:
If OrgDisplayName:TAAL is set: OrgDisplayname:TAAL;
Elseif OrgName:TAAL is set: OrgName:TAAL
Elseif OrgDisplayName:en is set: OrgDisplayname:en
Elseif OrgName:en is set: OrgName:en
Else "Onbekend"