### PR TITLE
Sort previously selected idps by count

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/ConnectedIdps.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/ConnectedIdps.php
@@ -30,7 +30,7 @@ class ConnectedIdps
 
     public function __construct(array $formattedPreviousSelectionList, array $formattedIdpList)
     {
-        $this->formattedPreviousSelectionList = $formattedPreviousSelectionList;
+        $this->formattedPreviousSelectionList = $this->sortPreviousSelection($formattedPreviousSelectionList);
         $this->formattedIdpList = $formattedIdpList;
     }
 
@@ -76,5 +76,14 @@ class ConnectedIdps
             }
         }
         return '';
+    }
+
+    private function sortPreviousSelection($formattedPreviousSelectionList)
+    {
+        usort($formattedPreviousSelectionList, function ($first, $second) {
+            return $first['count'] <=> $second['count'];
+        });
+
+        return array_reverse($formattedPreviousSelectionList);
     }
 }

--- a/theme/base/javascripts/wayf/utility/sortAndReindex.js
+++ b/theme/base/javascripts/wayf/utility/sortAndReindex.js
@@ -31,7 +31,7 @@ export const sortAndReindex = (list = REMAINING, sortBy = 'title', focus = false
   }
 
   // sort
-  const idpArray = sortIdpList(idpList);
+  const idpArray = sortIdpList(idpList, list);
 
   // reindex
   idpArray.forEach((idp, index) => {

--- a/theme/base/javascripts/wayf/utility/sortIdpList.js
+++ b/theme/base/javascripts/wayf/utility/sortIdpList.js
@@ -1,4 +1,4 @@
-import {sortByTitle} from './sortIdpMethods';
+import {sortByCount, sortByTitle} from './sortIdpMethods';
 import {nodeListToArray} from '../../utility/nodeListToArray';
 import {sortArrayList} from './sortArrayList';
 
@@ -7,12 +7,16 @@ import {sortArrayList} from './sortArrayList';
  * No other sorts exist atm, but this is anticipated once the search is implemented.
  *
  * @param idpList   NodeList    the list to sort
- *
+ * @param list      string      the list to be sorted
  * @returns   Node[]
  */
-export const sortIdpList = (idpList) => {
+export const sortIdpList = (idpList, list) => {
   // so we can sort it easily
   const idpArray = nodeListToArray(idpList);
+
+  if (list === 'previous') {
+    return sortArrayList(idpArray, sortByCount);
+  }
 
   return sortArrayList(idpArray, sortByTitle);
 };

--- a/theme/base/javascripts/wayf/utility/sortIdpMethods.js
+++ b/theme/base/javascripts/wayf/utility/sortIdpMethods.js
@@ -17,17 +17,61 @@ export const sortByTitle = (firstElement, secondElement) => {
   return titleOne.localeCompare(titleTwo, lang);
 };
 
+/**
+ * Helper function for sortByTitle
+ * @param element
+ * @returns {number|string}
+ */
 function getTitle(element) {
   return getData(element, 'title');
 }
 
-export const sortByWeight = (firstElement, secondElement) => {
-  const weightOne = Number(getData(firstElement.children[0], 'weight'));
-  const weightTwo = Number(getData(secondElement.children[0], 'weight'));
+/**
+ * Determine which of two li elements has a number attribute that is greater than the other.
+ * Sorts in descending order
+ * Numbers are taken from data-attributes
+ * @param firstElement
+ * @param secondElement
+ * @param attributeName
+ * @returns {number}
+ */
+export const sortByNumber = (firstElement, secondElement, attributeName) => {
+  const numberOne = getNumberAttribute(firstElement.children[0], attributeName);
+  const numberTwo = getNumberAttribute(secondElement.children[0], attributeName);
 
-  if (weightOne > weightTwo) return -1;
-  if (weightOne < weightTwo) return 1;
+  if (numberOne > numberTwo) return -1;
+  if (numberOne < numberTwo) return 1;
 
   // if weights are equal sort them by title
   return sortByTitle(firstElement , secondElement);
+};
+
+/**
+ * Helper function for sortByNumber
+ * @param element
+ * @param attributeName
+ * @returns {number}
+ */
+function getNumberAttribute(element, attributeName) {
+  return Number(getData(element, attributeName));
+}
+
+/**
+ * Sort li elements by how well the idps in it match the current search query.
+ * @param firstElement
+ * @param secondElement
+ * @returns {number}
+ */
+export const sortByWeight = (firstElement, secondElement) => {
+  return sortByNumber(firstElement, secondElement, 'weight');
+};
+
+/**
+ * Sort li elements by the amount of times the idps in them have been clicked.
+ * @param firstElement
+ * @param secondElement
+ * @returns {number}
+ */
+export const sortByCount = (firstElement, secondElement) => {
+  return sortByNumber(firstElement, secondElement, 'count');
 };

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
@@ -1,4 +1,5 @@
-<section class="wayf__previousSelection {% if connectedIdps.formattedPreviousSelectionList is empty %}hidden{% endif %}">
+{% set previousSelectionList = connectedIdps.formattedPreviousSelectionList %}
+<section class="wayf__previousSelection {% if previousSelectionList is empty %}hidden{% endif %}">
     <h2 class="previousSelection__title">
         {{ 'wayf_your_accounts'|trans }}
     </h2>
@@ -11,7 +12,7 @@
         </label>
     </div>
     {% endspaceless %}
-    {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig' with { idpList: connectedIdps.formattedPreviousSelectionList, delete: true, listName: 'preselection' } %}
+    {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig' with { idpList: previousSelectionList, delete: true, listName: 'preselection' } %}
     <button type="button" class="previousSelection__addAccount">
         <span>{{ 'wayf_add_account'|trans }}</span>
     </button>


### PR DESCRIPTION
The previously selected idps should be ordered descending by the amount of times they were used to log in before.  