### PR TITLE
Fix Safari repaint bug

### DIFF
--- a/theme/base/stylesheets/pages/wayf/idpList.scss
+++ b/theme/base/stylesheets/pages/wayf/idpList.scss
@@ -139,9 +139,11 @@
                             border: 3px solid $white;
                         }
 
-                        // if this is absent, Safari uses the height despite it being visually hidden
                         &.visually-hidden {
+                            // if this is absent, Safari uses the height despite it being visually hidden
                             height: 0;
+                            // if this is absent, Safari adds a bar next to the body after a repaint
+                            width: 0;
                         }
                     }
                 }


### PR DESCRIPTION
Safari took the width of the submit button into account after a repaint (it shouldn't as visually hidden).  Fixed it and added a comment for clarification.