### PR TITLE
Resolve smaller a11y bugs

### DIFF
--- a/theme/base/stylesheets/pages/wayf/idpList.scss
+++ b/theme/base/stylesheets/pages/wayf/idpList.scss
@@ -96,6 +96,7 @@
                     border-bottom-right-radius: 8px;
                     border-top-right-radius: 8px;
                     display: flex;
+                    height: 4rem;
                     justify-content: center;
                     margin: 3px 0;
                     width: 4rem;

--- a/theme/base/stylesheets/pages/wayf/previousSelection.scss
+++ b/theme/base/stylesheets/pages/wayf/previousSelection.scss
@@ -95,6 +95,16 @@
         }
     }
 
+    > .previousSelection__toggle:not(:checked) ~ .wayf__idpList {
+        > li {
+            > .wayf__idp:not(.wayf__idp--noAccess) {
+                .idp__deleteDisable {
+                    display: none;
+                }
+            }
+        }
+    }
+
     > .previousSelection__toggle:checked ~ .wayf__idpList {
         > li {
             > .wayf__idp {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
@@ -6,8 +6,8 @@
     {% spaceless %}
     <div class="ie11__label">
         <label for="previousSelectionToggle" tabindex="0" class="previousSelection__toggleLabel" aria-pressed="false">
-            <span class="previousSelection__edit" tabindex="0">{{ 'edit'|trans }}</span>
-            <span class="previousSelection__done" tabindex="0">{{ 'done'|trans }}</span>
+            <span class="previousSelection__edit">{{ 'edit'|trans }}</span>
+            <span class="previousSelection__done">{{ 'done'|trans }}</span>
         </label>
     </div>
     {% endspaceless %}

--- a/theme/cypress/support/commands.js
+++ b/theme/cypress/support/commands.js
@@ -75,7 +75,7 @@ Cypress.Commands.add('selectFirstIdpAndReturn', (click = true, url = 'https://en
   });
 });
 
-Cypress.Commands.add('toggleEditButton', (click = true, buttonSelector = '.previousSelection__edit') => {
+Cypress.Commands.add('toggleEditButton', (click = true, buttonSelector = '.previousSelection__toggleLabel') => {
   if (click) {
     cy.get(buttonSelector).click({force: true });
     return;


### PR DESCRIPTION
- remove double focus for edit button on wayf
- hide deleteDisable button (and it's outline) when there is no content
- enlarge touch surface of delete button