### PR TITLE
Ensure links don't overflow on mobile

### DIFF
--- a/theme/base/stylesheets/front-page/base/_page.sass
+++ b/theme/base/stylesheets/front-page/base/_page.sass
@@ -7,6 +7,7 @@ body
   font-size: $fNormal
   line-height: 20px
   margin: 0
+  overflow-wrap: break-word
 
 *, *:before, *:after
   box-sizing: border-box


### PR DESCRIPTION
On the index page, links don't break nicely on mobile.  This pr resolves that in a generic way