### PR TITLE
Ensure informational is big enough for icon

### DIFF
--- a/theme/base/stylesheets/pages/wayf/remainingIdps.scss
+++ b/theme/base/stylesheets/pages/wayf/remainingIdps.scss
@@ -84,6 +84,7 @@
     > .remainingIdps__defaultIdp {
         @include informational;
         margin: 1.25rem 0 1.25rem;
+        min-height: 3rem;
 
         > .wayf__defaultIdpLink {
             color: $black;


### PR DESCRIPTION
On tablets the design sometimes uses elements of the mobile design.  For the informational that means the icon isn't shown entirely as the padding is the mobile one and the text is single-line.  

This pr solves that by adding a min-height to the informational.