### PR TITLE
Increase room for tooltipless attribute values

### DIFF
--- a/theme/base/stylesheets/pages/consent/attribute.scss
+++ b/theme/base/stylesheets/pages/consent/attribute.scss
@@ -7,6 +7,14 @@
     border-bottom: 1px solid $softBorderGray;
     line-height: 1.63;
 
+    &.consent__attribute--noTooltip {
+        @include grid-template-columns(33% 1% 65% 1%);
+
+        @include screen('mobile') {
+            @include grid-template-columns(100%);
+        }
+    }
+
     &:nth-child(n+6) {
         display: none;
     }
@@ -22,7 +30,7 @@
     @include screen('mobile') {
         @include grid-template-columns(100%);
         @include grid-template-rows(min-content min-content);
-        padding: 10px;
+        padding: 10px 6px;
     }
 
     &:nth-child(-n + 4) {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
@@ -1,6 +1,6 @@
-<li class="consent__attribute">
-    {# in case a tooltip needs to be shown set the id #}
-    {% if attributeMotivations[attributeIdentifier] is defined %}
+{% set addTooltip = attributeMotivations[attributeIdentifier] is defined %}
+<li class="consent__attribute{% if not addTooltip %} consent__attribute--noTooltip{% endif %}">
+    {% if addTooltip %}
         {% set id %}
             tooltip{{ loop.index }}{{ orgId }}
         {% endset %}
@@ -12,7 +12,7 @@
     {# Single attribute value #}
     {% if attributeValues|length == 1 %}
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: attributeValues|first } %}
-        {% if attributeMotivations[attributeIdentifier] is defined %}
+        {% if addTooltip %}
             {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with { tooltipValue: attributeMotivations[attributeIdentifier] } %}
         {% endif %}
     {# Multiple attribute values #}
@@ -29,7 +29,7 @@
             {% for value in attributeValues %}
                 <li>
                     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: value } %}
-                    {% if attributeMotivations[attributeIdentifier] is defined %}
+                    {% if addTooltip %}
                         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with { tooltipValue: attributeMotivations[attributeIdentifier] } %}
                     {% endif %}
                 </li>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/engineBlockAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/engineBlockAttribute.html.twig
@@ -1,5 +1,6 @@
-<li class="consent__attribute">
-    {% if nameIdIsPersistent %}
+{% set addTooltip = nameIdIsPersistent %}
+<li class="consent__attribute{% if not addTooltip %} consent__attribute--noTooltip{% endif %}">
+    {% if addTooltip %}
         {% set id %}
             tooltip{{ loop.index }}{{ orgId }}
         {% endset %}
@@ -9,7 +10,7 @@
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/name.html.twig' with { attributeName: 'consent_name_id_label'|trans } %}
     {% endif %}
     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: attributeValues } %}
-    {% if nameIdIsPersistent %}
+    {% if addTooltip %}
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with {
             tooltipValue: 'consent_name_id_value_tooltip'|trans({'%arg1%': 'suite_name'|trans })
         } %}


### PR DESCRIPTION
The idea here is to allow enough room for at least a 40-character attribute value, both on all screen sizes.  The reason being that we want to ensure that the identifier fits 95% of the time.  Because identifiers tend to be persistent nameids, which are a sh1-hash, that means 40 characters.