### PR TITLE
Sort unconnected idps after connected idps on load

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
@@ -53,6 +53,11 @@ class WayfController extends Controller
 
         $connectedIdps = (int) $request->get('connectedIdps', 5);
         $unconnectedIdps = (int) $request->get('unconnectedIdps', 0);
+        $randomIdps = (int) $request->get('randomIdps', 0);
+
+        $idpList = $randomIdps === 0
+            ? TestEntitySeeder::buildIdps($connectedIdps, $unconnectedIdps, $currentLocale, $defaultIdpEntityId)
+            : TestEntitySeeder::buildRandomIdps($randomIdps, $currentLocale, $defaultIdpEntityId);
 
         return new Response($this->twig->render(
             '@theme/Authentication/View/Proxy/wayf.html.twig',
@@ -67,7 +72,7 @@ class WayfController extends Controller
                 'showRequestAccess' => $displayUnconnectedIdpsWayf,
                 'requestId' => 'bogus-request-id',
                 'serviceProvider' => TestEntitySeeder::buildSp(),
-                'idpList' => TestEntitySeeder::buildIdps($connectedIdps, $unconnectedIdps, $currentLocale, $defaultIdpEntityId),
+                'idpList' => $idpList,
                 'beforeScriptHtml' => '<div id="request-access-scroller"><div id="request-access-container">' .
                     '<div id="request-access"></div></div></div>',
             ]

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
@@ -75,6 +75,74 @@ class TestEntitySeeder
     }
 
     /**
+     * Build a random collection of (unconnected) IdPs
+     *
+     * This is not an array of IdentityProvider value objects, but a derivative that can be used for showing IdPs on
+     * the WAYF.
+     *
+     * @param int $numberOfIdps
+     * @param int $numberOfUnconnectedIdps
+     * @param string $locale
+     * @return array[]
+     */
+    public static function buildRandomIdps($numberOfIdps, $locale, $defaultIdpEntityId)
+    {
+        Assert::integer($numberOfIdps);
+        Assert::stringNotEmpty($locale);
+        $idpNames = [
+            'Academisch Medisch Centrum (AMC)',
+            'AMOLF',
+            'Amphia Hospital',
+            'Breda University of Applied Sciences',
+            'Centraal Planbureau',
+            'Centrum Wiskunde & Informatica',
+            'Cito',
+            'Delft University of Technology',
+            'Drenthe College',
+            'eduID (NL)',
+            'Erasmus MC',
+            'Fontys University of Applied Sciences',
+            'Friesland College',
+            'Graafschap College',
+            'GÉANT Staff Identity Provider',
+            'HAN University of Applied Sciences',
+            'Hotelschool The Hague',
+            'IHE Delft Institute for Water Education',
+            'KNMI',
+            'Koninklijke Nederlandse Akademie van Wetenschappen (KNAW)',
+            'Leids Universitair Medisch Centrum',
+            'Maastricht University',
+            'Netherlands eScience Center',
+            'SURF bv',
+            'Thomas More Hogeschool',
+            'VSNU',
+        ];
+        $randomIdpNames = $numberOfIdps < count($idpNames) ? array_rand($idpNames, $numberOfIdps) : array_keys($idpNames);
+
+        $idps = [];
+
+        for ($i=1; $i < (int) $numberOfIdps + 1; $i++) {
+            $connected = rand(0, 1) === 1;
+            $entityId = $connected ? sprintf("https://example.com/entityId/%d", $i) : sprintf("https://unconnected.example.com/entityId/%d", $i);
+
+            if ($i < 25) {
+                $name = sprintf("%s %d %s", $idpNames[$randomIdpNames[$i - 1]], $i, $locale);
+            } else {
+                $variableString = $connected ? 'Connected' : 'Disconnected';
+                $name = sprintf("%s IdP %d %s", $variableString, $i, $locale);
+            }
+
+            $isDefaultIdp = false;
+            if ($defaultIdpEntityId === $entityId) {
+                $isDefaultIdp = true;
+            }
+            $idps[$entityId] = ['name' => $name, 'enabled' => $connected, 'isDefaultIdp' => $isDefaultIdp];
+        }
+
+        return self::transformIdpsForWayf($idps, $locale);
+    }
+
+    /**
      * @param array $idpEntityIds
      * @param string $currentLocale
      * @return array[]

--- a/theme/README.md
+++ b/theme/README.md
@@ -162,7 +162,7 @@ Below you'll find a list of the "entry points" for each page with corresponding 
 - redirect page: `templates > modules > authentication > view > proxy > redirect.html.twig`.
 - index.html.twig: `templates > modules > authentication > view > index > index.html.twig`.  You can use `https://engine.vm.openconext.org/` to develop the page.
 
-#### Supported feature flags
+#### Supported feature / testing flags
 
 There are a number of feature flags which need to be supported by a theme in order to distribute it to the wider community.  These toggle certain features on or off.
 
@@ -173,6 +173,14 @@ There are a number of feature flags which need to be supported by a theme in ord
 - backLink: display a link which, when clicked, allows you to go back two pages.  In essence the equivalent of clicking the back button twice.  You can test this by going to `/functional-testing/wayf?backLink=1`.
 - cutoffPointForShowingUnfilteredIdps: unlike the previous flags which were booleans, this one is an integer.  When this flag is present & the user is not searching (so no value in the search field): there should only be idps shown when there are no more than the cutoff point.  So as an example: if there are 100 idps that would be shown normally, and the cutoff point is 50: the user should see no idps at all (so only the empty search field is shown).  You can test this by going to `/functional-testing/wayf?cutoffPointForShowingUnfilteredIdps=50`.
 - showConsentExplanation: whether to show a special explanation on the consent page.  There is currently no test endpoint for this.
+
+There is currently one flag which allows for testing a more realistic scenario.  The number of such flags might be expanded in the future.
+
+**The following test flag exist (name of query param):**
+- randomIdps: whether to use random Idp names (taken from a selection of real IDP names) with random connected status.  Example usage:
+`https://engine.vm.openconext.org/functional-testing/wayf?randomIdps=20&displayUnconnectedIdpsWayf=true`
+There are only 25 random names to choose from.  If you enter a number larger than 25, number 26 & greater will receive names as normal for the FT idps.
+**Note:** these idps are randomly assigned connected / unconnected status.
 
 [babel]: https://babeljs.io/
 [cypress]: https://www.cypress.io/

--- a/theme/base/javascripts/utility/hideElement.js
+++ b/theme/base/javascripts/utility/hideElement.js
@@ -1,8 +1,14 @@
 /**
  * Hide an element by adding the hidden class.
  *
- * @param element   HTML Element    the element to hide.
+ * @param element       HTML Element    the element to hide.
+ * @param visuallyOnly  boolean         whether to hide visually only or not
  */
-export const hideElement = (element) => {
+export const hideElement = (element, visuallyOnly = false) => {
+  if (visuallyOnly) {
+    element.classList.add('visually-hidden');
+    return;
+  }
+
   element.classList.add('hidden');
 };

--- a/theme/base/javascripts/utility/showElement.js
+++ b/theme/base/javascripts/utility/showElement.js
@@ -1,8 +1,14 @@
 /**
  * Show an element by removing the hidden class.
  *
- * @param element   HTML Element    the element to show.
+ * @param element       HTML Element    the element to show.
+ * @param visuallyOnly  boolean         whether to show visually only or not
  */
-export const showElement = (element) => {
+export const showElement = (element, visuallyOnly = false) => {
+  if (visuallyOnly) {
+    element.classList.remove('visually-hidden');
+    return;
+  }
+
   element.classList.remove('hidden');
 };

--- a/theme/base/javascripts/wayf/idpFocus/arrowDown.js
+++ b/theme/base/javascripts/wayf/idpFocus/arrowDown.js
@@ -11,13 +11,8 @@ import {isFocusOn} from '../../utility/isFocusOn';
  */
 import {focusOnNextIdp} from './focusOnNextIdp';
 
-export const arrowDown = () => {
-  const searchBar = document.querySelector('.search__field');
-  const defaultIdp = document.querySelector('.wayf__defaultIdpLink');
-  const firstIdp = document.querySelector('.wayf__remainingIdps li:first-of-type > .wayf__idp');
-  const lastIdp = document.querySelector('.wayf__remainingIdps li:last-of-type > .wayf__idp');
-
-  if (isFocusOn(searchBar)) {
+export const arrowDown = (searchBar, resetButton, defaultIdp, firstIdp, lastIdp) => {
+  if (isFocusOn(searchBar) || isFocusOn(resetButton)) {
     try {
       defaultIdp.focus();
     } catch (e) {

--- a/theme/base/javascripts/wayf/idpFocus/arrowUp.js
+++ b/theme/base/javascripts/wayf/idpFocus/arrowUp.js
@@ -10,13 +10,8 @@ import {focusOnPreviousIdp} from './focusOnPreviousIdp';
  * - to go to the searchbar if we are on the defaultIdp notification
  * - to go to the last idp if we are on the searchbar
  */
-export const arrowUp = () => {
-  const searchBar = document.querySelector('.search__field');
-  const defaultIdp = document.querySelector('.wayf__defaultIdpLink');
-  const firstIdp = document.querySelector('.wayf__remainingIdps li:first-of-type > .wayf__idp');
-  const lastIdp = document.querySelector('.wayf__remainingIdps li:last-of-type > .wayf__idp');
-
-  if (isFocusOn(searchBar)) {
+export const arrowUp = (searchBar, resetButton, defaultIdp, firstIdp, lastIdp) => {
+  if (isFocusOn(searchBar) || isFocusOn(resetButton)) {
     lastIdp.focus();
     return;
   } else if (isFocusOn(firstIdp)) {

--- a/theme/base/javascripts/wayf/idpFocus/focusOnNextIdp.js
+++ b/theme/base/javascripts/wayf/idpFocus/focusOnNextIdp.js
@@ -1,11 +1,7 @@
 export const focusOnNextIdp = () => {
-  const element = document.activeElement;
-  const index = Number(element.getAttribute('data-index'));
+  const nextSibling = document.activeElement.parentElement.nextElementSibling;
 
-  try {
-    element
-      .closest('.wayf__idpList')
-      .querySelector(`.wayf__idp[data-index="${index + 1}"]`).focus();
-  } catch(e) {
+  if (!!nextSibling) {
+    nextSibling.firstElementChild.focus();
   }
 };

--- a/theme/base/javascripts/wayf/idpFocus/focusOnPreviousIdp.js
+++ b/theme/base/javascripts/wayf/idpFocus/focusOnPreviousIdp.js
@@ -1,9 +1,7 @@
 export const focusOnPreviousIdp = () => {
-  const element = document.activeElement;
-  const index = Number(element.getAttribute('data-index'));
+  const previousSibling = document.activeElement.parentElement.previousElementSibling;
 
-  try {
-    element.closest('.wayf__idpList').querySelector(`.wayf__idp[data-index="${index - 1}"]`).focus();
-  } catch(e) {
+  if (!!previousSibling) {
+    previousSibling.firstElementChild.focus();
   }
 };

--- a/theme/base/javascripts/wayf/keyboardBehaviour.js
+++ b/theme/base/javascripts/wayf/keyboardBehaviour.js
@@ -10,6 +10,12 @@ export const keyboardBehaviour = (previouslySelectedIdps) => {
   const ENTER      = 13;
   const ARROW_UP   = 38;
   const ARROW_DOWN = 40;
+  const searchBar = document.querySelector('.search__field');
+  const resetButton = document.querySelector('.search__reset');
+  const defaultIdp = document.querySelector('.wayf__defaultIdpLink');
+  const firstIdp = document.querySelector('.wayf__remainingIdps li:first-of-type > .wayf__idp');
+  const lastIdp = document.querySelector('.wayf__remainingIdps li:last-of-type > .wayf__idp');
+
 
   document.querySelector('body').addEventListener('keydown', function(e) {
     if (e.keyCode === ENTER) {
@@ -18,12 +24,12 @@ export const keyboardBehaviour = (previouslySelectedIdps) => {
     }
 
     if (e.keyCode === ARROW_DOWN) {
-      arrowDown();
+      arrowDown(searchBar, resetButton, defaultIdp, firstIdp, lastIdp);
       return;
     }
 
     if (e.keyCode === ARROW_UP) {
-      arrowUp();
+      arrowUp(searchBar, resetButton, defaultIdp, firstIdp, lastIdp);
       return;
     }
   });

--- a/theme/base/javascripts/wayf/search/toggleSearchAndResetButton.js
+++ b/theme/base/javascripts/wayf/search/toggleSearchAndResetButton.js
@@ -6,16 +6,16 @@ export const toggleSearchAndResetButton = (idpArray, searchTerm) => {
   const searchButton = document.querySelector('.search__submit');
   const resetButton = document.querySelector('.search__reset');
   if (resetButton.classList.contains('visually-hidden')) {
-    resetButton.classList.remove('visually-hidden');
+    showElement(resetButton, true);
   }
 
   if (searchTerm !== '') {
-    hideElement(searchButton);
-    showElement(resetButton);
+    hideElement(searchButton, true);
+    showElement(resetButton, true);
   } else {
     // Reset the list/search results
     searchAndSortIdps(idpArray, searchTerm);
-    showElement(searchButton);
-    hideElement(resetButton);
+    showElement(searchButton, true);
+    hideElement(resetButton, true);
   }
 };

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig
@@ -1,6 +1,16 @@
 <ul class="wayf__idpList{% if cutoffPointForShowingUnfilteredIdps < idpList|length %} wayf__idpList--cutoffMet{% endif %}">
+    {# First show all connected Idps #}
     {% for idp in idpList %}
-        {% if showRequestAccess or (not showRequestAccess and idp['connected'] is defined and idp['connected']) %}
+        {% if idp['connected'] is defined and idp['connected'] %}
+            <li>
+                {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig' with { idp: idp }
+                %}
+            </li>
+        {% endif %}
+    {% endfor %}
+    {# Next show all unconnnected Idps #}
+    {% for idp in idpList %}
+        {% if showRequestAccess and idp['connected'] is defined and not idp['connected'] %}
             <li>
                 {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig' with { idp: idp }
                 %}

--- a/theme/cypress/integration/skeune/wayf/wayf.general.spec.js
+++ b/theme/cypress/integration/skeune/wayf/wayf.general.spec.js
@@ -56,12 +56,12 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
     });
   });
 
-  describe('Test if search works as it should', () => {
+  describe.only('Test if search works as it should', () => {
     it('Should show no results when no IdPs are found', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
       cy.get('.wayf__search').type('OllekebollekeKnol');
       cy.get('.wayf__noResults').should('be.visible');
-      cy.get('.search__submit').should('not.be.visible');
+      cy.get('.search__submit').should('have.class', 'visually-hidden');
       cy.get('.search__reset').should('be.visible');
     });
 
@@ -69,7 +69,7 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
       cy.get('.wayf__search').type('4');
       // When the user starts typing, the reset (x) button should appear, replacing the search icon
-      cy.get('.search__submit').should('not.be.visible');
+      cy.get('.search__submit').should('have.class', 'visually-hidden');
       cy.get('.search__reset').should('be.visible');
 
       // After filtering the search results, verify one result is visible
@@ -133,7 +133,7 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
       cy.get('.wayf__search').type('con 1');
       cy.get('.search__reset').click({force:true});
       cy.get('.search__submit').should('be.visible');
-      cy.get('.search__reset').should('not.be.visible');
+      cy.get('.search__reset').should('have.class', 'visually-hidden');
       cy.get('.wayf__remainingIdps .wayf__idp')
         .should('have.length', 5);
     });


### PR DESCRIPTION
- The sort works once searching has commenced, but not on load.  Fixed that in this PR.
- Also added a way to test this & the sort with more realistic data.
- The search navigation by arrow didn't work with the new sorting so fixed that.
- Noticed the submit button was hidden when the reset button was visible, so ensured it stays accessible to aural UI.