### PR TITLE
Hide label in idprow when unchecked

### DIFF
--- a/theme/base/stylesheets/pages/consent/idpRow.scss
+++ b/theme/base/stylesheets/pages/consent/idpRow.scss
@@ -56,9 +56,7 @@
         }
 
         > label.modal {
-            @include screen('tabletAndBigger') {
-                display: none;
-            }
+            display: none;
         }
 
         > .idpRow__providedBy-content {


### PR DESCRIPTION
Fix the label in the paragraph of the idpRow getting focus on mobile when it's empty (aka, when the input is unchecked).  Issue reported by @MKodde [here](https://github.com/OpenConext/OpenConext-engineblock/pull/1031#issuecomment-747327699)