### PR TITLE
Remove stray space from consent screen disclaimer

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/disclaimerList.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/disclaimerList.html.twig
@@ -4,11 +4,9 @@
             {% include '@theme/Authentication/View/Proxy/Partials/Consent/SVG/file_info.svg' %}
             <div>
                 <div>
-                    <strong>{{ spName }}</strong> {{ 'consent_disclaimer_privacy_statement'|trans({ '%org%': organizationName }) }}
-                    {% if sp.coins.termsOfServiceUrl is not null %}
+                    <strong>{{ spName }}</strong> {{ 'consent_disclaimer_privacy_statement'|trans({ '%org%': organizationName }) }}{% if sp.coins.termsOfServiceUrl is not null %}
                         ({{ 'consent_disclaimer_privacy_read'|trans }} <a href="{{ sp.coins.termsOfServiceUrl }}" target="_blank" rel="noreferrer noopener">{{ 'consent_disclaimer_privacy_policy'|trans }}</a>)
-                    {% endif %}
-                    .
+                    {% endif %}.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
As reported by Thijs, there is a stray space after "heeft deze informatie nodig om te kunnen werken" in the first item of the disclaimerlist.  It was caused by formatting of the code.  This PR removes that.

![image](https://user-images.githubusercontent.com/4058016/102686952-9fdb4700-41eb-11eb-9224-396679879319.png)
