### PR TITLE
Change algorithm for SP displayname & refactor algorithm for organization name

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlock\Metadata\Entity;
 
+use Doctrine\ORM\Mapping as ORM;
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
@@ -31,7 +32,6 @@ use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Constants;
-use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @package OpenConext\EngineBlock\Metadata\Entity
@@ -335,58 +335,52 @@ class ServiceProvider extends AbstractRole
     }
 
     /**
-     * @param string $preferredLocale
-     * @return string
+     * Algorithm for display name is:
+     * 1. Display name in preferred locale
+     * 2. Name in preferred locale
+     * 3. Display name in English
+     * 4. Name in English
+     * 5. EntityID (should never happen)
      */
-    public function getDisplayName($preferredLocale = '')
+    public function getDisplayName(string $preferredLocale = 'en'): string
     {
-        $spName = '';
-        if ($preferredLocale === 'nl') {
-            $spName = $this->displayNameNl;
-            if (empty($spName)) {
-                $spName = $this->nameNl;
-            }
-        } elseif ($preferredLocale === 'en') {
-            $spName = $this->displayNameEn;
-            if (empty($spName)) {
-                $spName = $this->nameEn;
-            }
-        } elseif ($preferredLocale === 'pt') {
-            $spName = $this->displayNamePt;
-            if (empty($spName)) {
-                $spName = $this->namePt;
-            }
+        $preferredName = 'displayName' . ucfirst($preferredLocale);
+        $fallback = 'name' . ucfirst($preferredLocale);
+        $spName = !empty($this->$preferredName) ? $this->$preferredName : $this->$fallback;
+
+        if ($preferredLocale !== 'en' & empty($spName)) {
+            $spName = !empty($this->displayNameEn) ? $this->displayNameEn : $this->nameEn;
         }
 
         if (empty($spName)) {
             $spName = $this->entityId;
         }
+
         return $spName;
     }
 
-    public function getOrganizationName(string $preferredLocale = ''): string
+    /**
+     * Algorithm for organization name is
+     * 1. Organization display name in preferred locale
+     * 2. Organization name in preferred locale
+     * 3. English organization display name
+     * 4. English organization name
+     * 5. Empty string (will be set to the locale-specific variant of 'unknown' in the template)
+     */
+    public function getOrganizationName(string $preferredLocale = 'en'): string
     {
-        $orgName = '';
+        $orgLocale = 'organization' . ucfirst($preferredLocale);
+        // Load the preferred locale org. display name, falling back on org. name
+        $orgName = !empty($this->$orgLocale->displayName)
+            ? $this->$orgLocale->displayName
+            : $this->$orgLocale->name;
 
-        if ($preferredLocale === 'nl') {
-            $orgName = $this->organizationNl->displayName;
-            if (empty($orgName)) {
-                $orgName = $this->organizationNl->name;
-            }
-        } elseif ($preferredLocale === 'pt') {
-            $orgName = $this->organizationPt->displayName;
-            if (empty($orgName)) {
-                $orgName = $this->organizationPt->name;
-            }
+        // Fallback to EN naming preferences when the preferred locale was not set or yielded no value
+        if (($preferredLocale !== 'en' && empty($orgName)) || empty($orgName)) {
+            $orgName = !empty($this->organizationEn->displayName) ? $this->organizationEn->displayName : $this->organizationEn->name;
         }
 
-        if ($preferredLocale === 'en' || empty($orgName)) {
-            $orgName = $this->organizationEn->displayName;
-            if (empty($orgName)) {
-                $orgName = $this->organizationEn->name;
-            }
-        }
-
+        // Show empty string when no translation was found (virtually impossible)
         if (empty($orgName)) {
             $orgName = '';
         }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Entity/ServiceProviderTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Entity/ServiceProviderTest.php
@@ -19,6 +19,7 @@
 namespace OpenConext\EngineBlock\Metadata\Entity;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Organization;
 use PHPUnit\Framework\TestCase;
 
 class ServiceProviderTest extends TestCase
@@ -30,5 +31,135 @@ class ServiceProviderTest extends TestCase
         $entityId = 'https://sp.example.edu';
         $sp = new ServiceProvider($entityId);
         $this->assertEquals($entityId, $sp->entityId);
+    }
+
+    /**
+     * Expected behavior for display name retrieval is:
+     * 1. display name in preferred locale
+     * 2. name in preferred locale
+     * 3. display name in english
+     * 4. name in english
+     * 5. entityID (should never happen)
+     *
+     * @dataProvider displayNameProvider
+     */
+    public function testGetDisplayName(string $entityId, ?string $displayNameEn, ?string $nameEn, ?string $displayNameLocale, ?string $nameLocale, string $locale, $outcome)
+    {
+        $sp = $this->createServiceProvider(
+            $entityId,
+            null,
+            null,
+            $displayNameEn,
+            $displayNameLocale,
+            $nameEn,
+            $nameLocale
+        );
+
+        $this->assertEquals($outcome, $sp->getDisplayName($locale));
+    }
+
+    /**
+     * Algorithm for organization name is
+     * 1. organization display name in preferred locale
+     * 2. organization name in preferred locale
+     * 3. english organization display name
+     * 4. english organization name
+     * 5. empty string (will be set to the locale-specific variant of 'unknown' in the template)
+     *
+     * @dataProvider organizationNameProvider
+     */
+    public function testGetOrganizationName(string $entityId, ?string $orgDisplayNameEn, ?string $orgNameEn, ?string $orgDisplayNameNl, ?string $orgNameNl, string $locale, $outcome)
+    {
+        $orgEn = new Organization($orgNameEn, $orgDisplayNameEn, $entityId);
+        $orgNl = new Organization($orgNameNl, $orgDisplayNameNl, $entityId);
+
+        $sp = $this->createServiceProvider(
+            $entityId,
+            $orgEn,
+            $orgNl
+        );
+
+        $this->assertEquals($outcome, $sp->getOrganizationName($locale));
+    }
+
+    /**
+     * First item in array = entityId
+     * Second item in array = English display name
+     * Third item in array = English name
+     * Fourth item in array = display name in Dutch locale
+     * Fifth item in array = name in Dutch locale
+     * Sixth item in array = preferred locale
+     * Seventh item in array = normative outcome
+     *
+     * @return string[][]
+     */
+    public function displayNameProvider()
+    {
+        return [
+            ['https://entityId.fake', 'JohnnyEnglish', 'English', 'JohnnyEnglish', 'English', 'en', 'JohnnyEnglish'],
+            ['https://entityId.fake', null, 'English', null, 'English', 'en', 'English'],
+            ['https://entityId.fake', null, null, null, null, 'en', 'https://entityId.fake'],
+            ['https://entityId.fake', 'JohnnyEnglish', 'English', 'TijlUilenspiegel', 'Dutch', 'nl', 'TijlUilenspiegel'],
+            ['https://entityId.fake', 'JohnnyEnglish', 'English', null, 'Dutch', 'nl', 'Dutch'],
+            ['https://entityId.fake', 'JohnnyEnglish', 'English', null, null, 'nl', 'JohnnyEnglish'],
+            ['https://entityId.fake', null, 'English', null, null, 'nl', 'English'],
+            ['https://entityId.fake', null, null, null, null, 'nl', 'https://entityId.fake'],
+        ];
+    }
+
+    /**
+     * First item in array = entityId
+     * Second item in array = English organization display name
+     * Third item in array = English organization name
+     * Fourth item in array = organization display name in Dutch locale
+     * Fifth item in array = organization name in Dutch locale
+     * Sixth item in array = preferred locale
+     * Seventh item in array = normative outcome
+     *
+     * @return string[][]
+     */
+    public function organizationNameProvider()
+    {
+        return [
+            ['https://entityId.fake', 'JohnnyEnglish', 'English', 'JohnnyDutch', 'Dutch', 'en', 'JohnnyEnglish'],
+            ['https://entityId.fake', 'JohnnyEnglish', 'English', 'TijlUilenspiegel', 'Dutch', 'nl', 'TijlUilenspiegel'],
+            ['https://entityId.fake', null, 'English', 'TijlUilenspiegel', 'Dutch', 'nl', 'TijlUilenspiegel'],
+            ['https://entityId.fake', null, 'English', 'TijlUilenspiegel', null, 'nl', 'TijlUilenspiegel'],
+            ['https://entityId.fake', null, 'English', null, 'Dutch', 'en', 'English'],
+            ['https://entityId.fake', null, 'English', null, 'Dutch', 'nl', 'Dutch'],
+            ['https://entityId.fake', 'JohnnyEnglish', 'English', null, 'Dutch', 'nl', 'Dutch'], // follows locale preference even if a preferable org displayname is available
+            ['https://entityId.fake', null, null, null, null, 'en', ''],
+            ['https://entityId.fake', null, null, 'TijlUilenspiegel', null, 'en', ''], // Even if a preferable dutch translation is available, show the empty English fallback value: ''
+            ['https://entityId.fake', 'JohnnyEnglish', 'English', null, null, 'nl', 'JohnnyEnglish'],
+            ['https://entityId.fake', null, 'English', null, null, 'nl', 'English'],
+            ['https://entityId.fake', null, null, null, null, 'nl', ''],
+        ];
+    }
+
+    private function createServiceProvider(string $entityId, ?Organization $orgEn = null, ?Organization $orgLocale = null, ?string $displayNameEn = null, ?string $displayNameLocale = null, ?string $nameEn = null, ?string $nameLocale = null)
+    {
+        return new ServiceProvider(
+            $entityId,
+            $orgEn,
+            $orgLocale,
+            null,
+            null,
+            false,
+            array(),
+            array(),
+            '',
+            '',
+            '',
+            false,
+            $displayNameEn,
+            $displayNameLocale,
+            '',
+            '',
+            '',
+            '',
+            null,
+            $nameEn,
+            $nameLocale
+        );
     }
 }


### PR DESCRIPTION
As one of the [feedback items](https://wiki.surfnet.nl/display/coininfra/Bevindingen+december+2020) it was requested that we [change the algorithm for the SP displayname](https://www.pivotaltracker.com/n/projects/1425900) to:
1. displayname in preferred locale
2. name in preferred locale
3. displayname in english
4. name in english
5. entityID (should never happen as an english name is mandatory)

I took advantage of the opportunity to refactor the organizationName method as well.  This to address the remarks in the previous PRs that dealt with this method: [one by me](https://github.com/OpenConext/OpenConext-engineblock/pull/980#discussion_r529379926) and [one by martin](https://github.com/OpenConext/OpenConext-engineblock/pull/1022/files#r543128672).  The refactor ensures both methods still have the same code-structure.