### PR TITLE
Run the Behat acceptance tests against the skeune theme

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -83,7 +83,9 @@ jobs:
                       echo -e "\nInstalling database fixtures...\n" && \
                       ./app/console doctrine:schema:drop --force --env=ci && \
                       ./app/console doctrine:schema:create --env=ci && \
-                      echo -e "\nBehat tests\n" && \
+                      echo -e "\nPreparing frontend assets\n" && \
+                      EB_THEME=skeune ./theme/scripts/prepare-test.js > /dev/null && \
+                      echo -e "\nRun the Behat tests\n" && \
                       ./vendor/bin/behat -c ./tests/behat-ci.yml --suite default -vv --format progress --strict && \
                       echo -e "\nBehat tests (with selenium and headless Chrome)\n" && \
                       ./vendor/bin/behat -c ./tests/behat-ci.yml --suite selenium -vv --format progress --strict

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -11,8 +11,11 @@ services:
 framework:
     test: ~
     translator:
+        fallbacks: ["%locale%"]
         paths:
             - '%kernel.root_dir%/../languages'
+            - '%kernel.root_dir%/../theme/base/translations'
+            - '%kernel.root_dir%/../theme/%theme.name%/translations'
             - '%kernel.root_dir%/../src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/languages'
     session:
         storage_id: session.storage.mock_file

--- a/app/config/functional_testing.yml.dist
+++ b/app/config/functional_testing.yml.dist
@@ -6,4 +6,4 @@ parameters:
     idp_fixture_file:   "%kernel.root_dir%/../tmp/fixtures/db/idp.states.php.serialized"
     sp_fixture_file:    "%kernel.root_dir%/../tmp/fixtures/db/sp.states.php.serialized"
 
-    theme.name: skeune
+    theme.name: "skeune"

--- a/app/config/functional_testing.yml.dist
+++ b/app/config/functional_testing.yml.dist
@@ -5,3 +5,5 @@ parameters:
     # Where must we store the writable state of the Mock IdP and Mock SP?
     idp_fixture_file:   "%kernel.root_dir%/../tmp/fixtures/db/idp.states.php.serialized"
     sp_fixture_file:    "%kernel.root_dir%/../tmp/fixtures/db/sp.states.php.serialized"
+
+    theme.name: skeune

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Consent.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Consent.feature
@@ -36,8 +36,8 @@ Feature:
       And I pass through the IdP
      Then the response should not contain "Do you agree with sharing this data?"
       And the response should not contain "Yes, proceed to Dummy-SP"
-      And the response should contain "Yes, I agree"
-      And the response should contain "No, I do not agree"
+      And the response should contain "Proceed to Dummy-SP"
+      And the response should contain "Cancel"
       And the response should contain "support@openconext.org"
       And the response should contain "+31612345678"
      When I give my consent
@@ -58,27 +58,26 @@ Feature:
     And I pass through the IdP
     Then the response should not contain "Do you agree with sharing this data?"
     Then the response should not contain "Yes, proceed to Dummy-SP"
-    Then the response should contain "Proceed to Dummy-SP"
-    Then the response should contain "Cancel"
+    And the response should contain "Proceed to Dummy-SP"
+    And the response should contain "Cancel"
 
   Scenario: The user is asked for default consent
     Given I log in at "Dummy-SP"
     And the IdP "Dummy-IdP" requires default consent for SP "Dummy-SP"
     And I pass through EngineBlock
     And I pass through the IdP
-    Then the response should contain "Do you agree with sharing this data?"
-    Then the response should contain "Yes, I agree"
-    Then the response should contain "No, I do not agree"
-    Then the response should not contain "Cancel"
+    Then the response should contain "Review your information that will be shared."
+    And the response should contain "Proceed to Dummy-SP"
 
   Scenario: The user is can read why the service providers requires an attribute
     Given I log in at "Dummy-SP"
     And I pass through EngineBlock
     And I pass through the IdP
-    Then the response should contain "Motivation for cn"
-    Then the response should contain "Motivation for dn"
-    Then the response should contain "Motivation for affiliation"
-    Then the response should contain "Motivation for orcid"
+    Then the response should contain "Review your information that will be shared."
+     And the response should contain "Motivation for cn"
+     And the response should contain "Motivation for dn"
+     And the response should contain "Motivation for affiliation"
+     And the response should contain "Motivation for orcid"
 
   Scenario: The user presented with an institution provided consent text
     Given I log in at "Dummy-SP"
@@ -91,8 +90,9 @@ Feature:
     Given I log in at "Dummy-SP"
      And I pass through EngineBlock
      And I pass through the IdP
-    Then the response should contain "Yes, I agree"
+    Then the response should contain "Proceed to Dummy-SP"
     When I reload the page
+    Then the response should contain "Proceed to Dummy-SP"
 
   Scenario: The user sees the identifier section when nameid is persistent
     Given SP "Dummy-SP" uses the Persistent NameID format

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Consent.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Consent.feature
@@ -36,6 +36,7 @@ Feature:
       And I pass through the IdP
      Then the response should not contain "Do you agree with sharing this data?"
       And the response should not contain "Yes, proceed to Dummy-SP"
+      And the response should contain "Dummy-SP will receive"
       And the response should contain "Proceed to Dummy-SP"
       And the response should contain "Cancel"
       And the response should contain "support@openconext.org"
@@ -57,7 +58,7 @@ Feature:
     And I pass through EngineBlock
     And I pass through the IdP
     Then the response should not contain "Do you agree with sharing this data?"
-    Then the response should not contain "Yes, proceed to Dummy-SP"
+    And the response should not contain "Yes, proceed to Dummy-SP"
     And the response should contain "Proceed to Dummy-SP"
     And the response should contain "Cancel"
 
@@ -66,14 +67,13 @@ Feature:
     And the IdP "Dummy-IdP" requires default consent for SP "Dummy-SP"
     And I pass through EngineBlock
     And I pass through the IdP
-    Then the response should contain "Review your information that will be shared."
-    And the response should contain "Proceed to Dummy-SP"
+    Then the response should contain "Dummy-SP will receive"
 
   Scenario: The user is can read why the service providers requires an attribute
     Given I log in at "Dummy-SP"
     And I pass through EngineBlock
     And I pass through the IdP
-    Then the response should contain "Review your information that will be shared."
+    Then the response should contain "Dummy-SP will receive"
      And the response should contain "Motivation for cn"
      And the response should contain "Motivation for dn"
      And the response should contain "Motivation for affiliation"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Debug.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Debug.feature
@@ -11,7 +11,7 @@ Feature:
 
   Scenario: When a user opens the debug endpoint the wayf should be presented
     When I go to Engineblock URL "/authentication/sp/debug"
-    Then I should see "Selecteer een organisatie en login bij OpenConext EngineBlock"
+    Then I should see "Selecteer een organisatie om in te loggen bij OpenConext EngineBlock"
 
   Scenario: A user should be able to test a login
     When I go to Engineblock URL "/authentication/sp/debug"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
@@ -72,7 +72,7 @@ Feature:
       And I select "AlwaysAuth" on the WAYF
       And I pass through EngineBlock
       And I pass through the IdP
-     Then I should see "needs your information"
+     Then I should see "needs this information to function properly"
       And I should see "Step Up"
       And I should not see "Loa SP"
 
@@ -81,11 +81,11 @@ Feature:
       And SP "Step Up" is a trusted proxy
       And SP "Step Up" signs its requests
      When I log in at "Step Up"
-     Then I should see "Select an organisation to login to the service Loa SP"
+     Then I should see "Select an organisation to login to Loa SP"
       And I select "AlwaysAuth" on the WAYF
       And I pass through EngineBlock
       And I pass through the IdP
-     Then I should see "needs your information"
+     Then I should see "needs this information to function properly"
       And I should see "Loa SP"
       And I should not see "Step Up"
 
@@ -97,7 +97,7 @@ Feature:
      When I log in at "Step Up"
       And I pass through EngineBlock
       And I pass through the IdP
-     Then I should see "needs your information"
+     Then I should see "needs this information to function properly"
       And I should not see "Far SP"
       And I should not see "Step Up"
       And I should see "Loa SP"
@@ -111,7 +111,7 @@ Feature:
       And I select "AlwaysAuth" on the WAYF
       And I pass through EngineBlock
       And I pass through the IdP
-     Then I should not see "needs your information"
+     Then I should not see "needs this information to function properly"
 
   Scenario: User logs in via trusted proxy and sees no consent as the destination has it disabled
     Given SP "Step Up" is authenticating for SP "Loa SP"
@@ -122,7 +122,7 @@ Feature:
       And I select "AlwaysAuth" on the WAYF
       And I pass through EngineBlock
       And I pass through the IdP
-     Then I should not see "needs your information"
+     Then I should not see "needs this information to function properly"
 
   Scenario: User logs in via trusted proxy and attribute release policy for destination is executed
     Given SP "Step Up" is authenticating for SP "Loa SP"
@@ -236,7 +236,7 @@ Feature:
          # Bug report: https://www.pivotaltracker.com/story/show/164069793
     Then I should not see "Error - No organisations found"
          # The WAYF should be visible
-     And I should see "Select an organisation to login to the service"
+     And I should see "Select an organisation to login to"
 
   Scenario: Trusted proxy not signing requests results in an error
     Given SP "Step Up" is authenticating for SP "Loa SP"

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/list.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/list.html.twig
@@ -5,7 +5,7 @@
     }
     %}
 {% endif %}
-<ul class="consent__attributes">
+<ul id="attribute-source-{{ attributeSource }}" class="consent__attributes">
     {% for attributeIdentifier, attributeValues in attributes %}
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/includeAttribute.html.twig' %}
         {% if loop.last and loop.index >= 6 %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/ctas.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/ctas.html.twig
@@ -16,6 +16,7 @@
         {% include '@theme/Default/Partials/button.html.twig' with
             {
                 buttonClass: 'cta_consent_ok',
+                name: 'accept_terms_button',
                 text: text_ok
             }
         %}

--- a/theme/base/templates/modules/Default/Partials/button.html.twig
+++ b/theme/base/templates/modules/Default/Partials/button.html.twig
@@ -1,4 +1,8 @@
-<button type="{{ buttonType|default('submit') }}" {% if buttonClass is defined %} class="{{ buttonClass }}"{% endif %}>
+<button
+    type="{{ buttonType|default('submit') }}"
+    {% if buttonClass is defined %} class="{{ buttonClass }}"{% endif %}
+    {% if name is defined %} name="{{ name }}"{% endif %}
+>
     <span class="secondaryBorder">
         {{ text }}
     </span>

--- a/theme/scripts/build.js
+++ b/theme/scripts/build.js
@@ -18,7 +18,7 @@ try {
     const fileContents = fs.readFileSync(config, 'utf8');
     const parameters = yaml.safeLoadAll(fileContents);
 
-    let theme = process.env.EB_THEME || parameters[0].parameters['theme.name'] || 'openconext';
+    let theme = process.env.EB_THEME || parameters[0].parameters['theme.name'] || 'skeune';
 
     if (process.env.EB_THEME) {
         theme = process.env.EB_THEME;


### PR DESCRIPTION
The aim of this PR is to run the acceptance tests against the Skeune theme in al its glory. Including translations, and theme specific settings and optimizations.

This allows us to create new tests carelessly in the future. As the new theme should become the new default in the near future. 