### PR TITLE
Ensure build installs npm

### DIFF
--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -79,7 +79,7 @@ fi
 # can be removed when we stop doing that
 echo "Build assets"
 cd ${PROJECT_DIR}/theme &&
-npm ci --unsafe-perm &&
+npm ci --unsafe-perm && npm install &&
 npm run release
 
 if [ $? -eq 0 ]; then

--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -79,7 +79,7 @@ fi
 # can be removed when we stop doing that
 echo "Build assets"
 cd ${PROJECT_DIR}/theme &&
-npm ci --unsafe-perm && npm install &&
+npm ci --unsafe-perm &&
 npm run release
 
 if [ $? -eq 0 ]; then

--- a/theme/scripts/build.js
+++ b/theme/scripts/build.js
@@ -17,12 +17,7 @@ try {
     console.log('Reading contents of parameters.yml.\n');
     const fileContents = fs.readFileSync(config, 'utf8');
     const parameters = yaml.safeLoadAll(fileContents);
-
-    let theme = process.env.EB_THEME || parameters[0].parameters['theme.name'] || 'skeune';
-
-    if (process.env.EB_THEME) {
-        theme = process.env.EB_THEME;
-    }
+    const theme = process.env.EB_THEME || parameters[0].parameters['theme.name'] || 'skeune';
 
     console.log(`Using theme ${theme} to run the build.\nOutput will be printed once the build is finished.\n`);
     executeShellCommand(`cd ${__dirname}/.. && EB_THEME=${theme} npm run buildtheme`);


### PR DESCRIPTION
~The current makeRelease does not install npm packages.  While there is a build script, this script assumes `npm install` has already run.  Fixed that in this version.~

The script uses `npm ci` to ensure a cleanly installed `node_modules` is composed. In this ticket we also investigated other possible causes for the failing switch between themes. See individual commit messages for more details.