### PR TITLE
Repair the quirky behavior whilst theme switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,25 @@ See the [UPGRADING.md][upgrading] file
 
 Please see the [wiki][eb-wiki-theme-development] for information on how to get started with developing themes for OpenConext EngineBlock
 In short, themes require front-end resource compilation which can be done by running the following commands:
+
+First set the desired theme name in the parameters.yml. This will load the correct Twig templates as they are a part of the Symfony config.
+
+```
+parameters:
+    # Other parameters have been left out for brevity
+    theme.name: skeune
+```
+
+Next build the front-end assets for the selected theme.
+
 ```
     (cd theme && npm ci && npm run build)
+```
+
+Finally, when not in an environment with the debug flag enabled, you need to clear the cache. This will ensure the translations and templates are swapped out for the ones found in the new theme.
+
+```
+$ php72 ./app/console cache:clear --env=prod
 ```
 
 To setup the required tooling on the VM, the following steps might be useful:

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -8,6 +8,13 @@ parameters:
     asset_version: "dev"
 
 framework:
+    translator:
+        enabled: true
+        fallbacks: [ "%locale%" ]
+        paths:
+            - '%kernel.root_dir%/../languages'
+            - '%kernel.root_dir%/../theme/base/translations'
+            - '%kernel.root_dir%/../theme/%theme.name%/translations'
     router:
         resource: "%kernel.root_dir%/config/routing_dev.yml"
         strict_requirements: true
@@ -19,3 +26,13 @@ web_profiler:
 
 twig:
     cache: false
+    auto_reload: true
+    debug: true
+    strict_variables: false
+    paths:
+        "%kernel.root_dir%/../theme/%theme.name%/templates/modules": theme
+        "%kernel.root_dir%/../theme/%theme.name%/templates/layouts": themeLayouts
+        "%kernel.root_dir%/../theme/%theme.name%/images": images
+        "%kernel.root_dir%/../theme/base/templates/modules": theme
+        "%kernel.root_dir%/../theme/base/templates/layouts": themeLayouts
+        "%kernel.root_dir%/../theme/base/images": images

--- a/app/config/functional_testing.yml.dist
+++ b/app/config/functional_testing.yml.dist
@@ -5,5 +5,3 @@ parameters:
     # Where must we store the writable state of the Mock IdP and Mock SP?
     idp_fixture_file:   "%kernel.root_dir%/../tmp/fixtures/db/idp.states.php.serialized"
     sp_fixture_file:    "%kernel.root_dir%/../tmp/fixtures/db/sp.states.php.serialized"
-
-    theme.name: "skeune"


### PR DESCRIPTION
Additional SF config was required to ensure the twig templates where loaded for the new theme.

Also updated the instructions on how to switch themes in the README.md