### PR TITLE
Tighten cookie security

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -141,7 +141,7 @@ parameters:
     cookie.secure: true
     cookie.locale.domain: .vm.openconext.org
     cookie.locale.expiry: 5184000
-    cookie.locale.http_only: false
+    cookie.locale.http_only: true
     cookie.locale.secure: true
 
     ## UI settings

--- a/theme/.babelrc
+++ b/theme/.babelrc
@@ -5,7 +5,7 @@
         ["@babel/preset-env", {
           "useBuiltIns": "usage",
           "corejs": 3,
-          "debug": true,
+          "debug": false,
           "targets": {
               "browsers": [ ">0.25%"]
           }

--- a/theme/base/javascripts/wayf/deleteDisable/savePreviousSelection.js
+++ b/theme/base/javascripts/wayf/deleteDisable/savePreviousSelection.js
@@ -14,5 +14,5 @@ export const savePreviousSelection = (previousSelection, cookieName) => {
     };
   });
 
-  setCookie(simplifiedPreviousSelection, cookieName);
+  setCookie(simplifiedPreviousSelection, cookieName, 365, '/', true);
 };

--- a/theme/base/javascripts/wayf/rememberChoice.js
+++ b/theme/base/javascripts/wayf/rememberChoice.js
@@ -7,5 +7,5 @@ export const rememberChoice = (entityId) => {
   if (!checkbox.checked) return;
 
   const cookieName = JSON.parse(document.getElementById(configurationId).innerHTML).rememberChoiceCookieName;
-  setCookie(entityId, cookieName);
+  setCookie(entityId, cookieName, 365, '/', true);
 };


### PR DESCRIPTION
Several cookie changes:

1. The `http_only` flag was set on the `lang` cookie
2. The rememberchoice and previousSelection cookies where set to be `secure`

:deciduous_tree: To reduce JavaScript build output polution, the babel config was updated to no longer spit very verbose debug output.

See: https://www.pivotaltracker.com/story/show/176287495
See: https://github.com/OpenConext/OpenConext-deploy/pull/320