### PR TITLE
Style index page in material theme

### DIFF
--- a/theme/openconext/stylesheets/front-page.scss
+++ b/theme/openconext/stylesheets/front-page.scss
@@ -1,1 +1,13 @@
-@import '../../base/stylesheets/front-page';
+@import "shared/utilities/reset.css.sass";
+@import "shared/vars.css.sass";
+@import "../../base/stylesheets/mixins";
+@import "shared/utilities/placeholders.css.sass";
+@import "application/utilities/dynamic.css.sass";
+@import "shared/components/language.css.sass";
+@import "application/components/links.css.sass";
+@import "application/modules/content.css.sass";
+@import "application/base/page.css.sass";
+@import "shared/base/layout.css.sass";
+@import "shared/base/type.css.sass";
+@import 'shared/modules/header.css.sass';
+@import "shared/modules/footer.css.sass";


### PR DESCRIPTION
The burger and some other small points in the material theme weren't styled properly.  This PR reverts that page to it's old state in the material theme.

The issue was reported [on the wiki](https://wiki.surfnet.nl/pages/viewpage.action?spaceKey=coininfra&title=Bevindingen+januari+2021)