### PR TITLE
Remove HttpOnly flag from `lang` cookie

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -141,7 +141,7 @@ parameters:
     cookie.secure: true
     cookie.locale.domain: .vm.openconext.org
     cookie.locale.expiry: 5184000
-    cookie.locale.http_only: true
+    cookie.locale.http_only: false
     cookie.locale.secure: true
 
     ## UI settings

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
@@ -26,6 +26,7 @@ use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RuntimeException;
 use SAML2\XML\mdui\Common;
 use SAML2\XML\shibmd\Scope;
+use function count;
 
 /**
  * Mink-enabled context.
@@ -168,8 +169,9 @@ class MinkContext extends BaseMinkContext
         if (count($anchors) != $expectedNumberOfLinks) {
             throw new ExpectationException(
                 sprintf(
-                    'The expected amount (%d) of metadata links could not be found on the page',
-                    $expectedNumberOfLinks
+                    'The expected amount (%d) of metadata links could not be found on the page, actually found "%d"',
+                    $expectedNumberOfLinks,
+                    count($anchors)
                 ),
                 $this->getSession()
             );


### PR DESCRIPTION
Other non-PHP components use the lang cookie in their Javascript,
setting the flag on this global cookie would mess up their operations.

Thanks @tveijen voor pointing this out!

See: https://github.com/OpenConext/OpenConext-deploy/pull/320#issuecomment-756109327
See: https://github.com/OpenConext/OpenConext-engineblock/pull/1056