### PR TITLE
Ensure hitting reset shows default idp

### DIFF
--- a/theme/base/javascripts/wayf/search/toggleSearchAndResetButton.js
+++ b/theme/base/javascripts/wayf/search/toggleSearchAndResetButton.js
@@ -2,6 +2,7 @@ import {hideElement} from "../../utility/hideElement";
 import {showElement} from "../../utility/showElement";
 import {searchAndSortIdps} from "./searchAndSortIdps";
 import {searchResetSelector, searchSubmitSelector} from '../../selectors';
+import {toggleDefaultIdPLinkVisibility} from './toggleDefaultIdPLinkVisibility';
 
 export const toggleSearchAndResetButton = (idpArray, searchTerm) => {
   const searchButton = document.querySelector(searchSubmitSelector);
@@ -16,6 +17,7 @@ export const toggleSearchAndResetButton = (idpArray, searchTerm) => {
   } else {
     // Reset the list/search results
     searchAndSortIdps(idpArray, searchTerm);
+    toggleDefaultIdPLinkVisibility('');
     showElement(searchButton, true);
     hideElement(resetButton, true);
   }

--- a/theme/cypress/integration/skeune/wayf/wayf.general.spec.js
+++ b/theme/cypress/integration/skeune/wayf/wayf.general.spec.js
@@ -41,22 +41,9 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
       cy.get('.wayf__idp--noAccess')
         .should('not.exist');
     });
-
-    it('Should show 5 disconnected IdPs', () => {
-      cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?displayUnconnectedIdpsWayf=1&unconnectedIdps=5');
-      cy.get('.wayf__idp--noAccess')
-        .should('have.length', 5)
-        .should('be.visible');
-    });
-
-    it('Should show no disconnected IdPs when the flag is false', () => {
-      cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?displayUnconnectedIdpsWayf=0&unconnectedIdps=5');
-      cy.get('.wayf__idp--noAccess')
-        .should('not.exist');
-    });
   });
 
-  describe.only('Test if search works as it should', () => {
+  describe('Test if search works as it should', () => {
     it('Should show no results when no IdPs are found', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
       cy.get('.wayf__search').type('OllekebollekeKnol');
@@ -128,12 +115,13 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
         .should('have.length', 5);
     });
 
-    it('Should reset the search text when clicking the reset button', () => {
+    it.only('Should reset the search text when clicking the reset button', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
       cy.get('.wayf__search').type('con 1');
       cy.get('.search__reset').click({force:true});
       cy.get('.search__submit').should('be.visible');
       cy.get('.search__reset').should('have.class', 'visually-hidden');
+      cy.get('.remainingIdps__defaultIdp').should('be.visible');
       cy.get('.wayf__remainingIdps .wayf__idp')
         .should('have.length', 5);
     });


### PR DESCRIPTION
Prior to this change, when the user pressed the reset button whilst searching; the default idp remained hidden.

This change ensures the default idp is shown in the above scenario.  It also adds the visibility of the default idp to the test, so if it fails it'll get detected.

[Issue brought up as part of the feedback round](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam)