### PR TITLE
Ensure clicking the defaultIdp works correctly

### DIFF
--- a/theme/base/javascripts/selectors.js
+++ b/theme/base/javascripts/selectors.js
@@ -81,6 +81,7 @@ export const defaultIdpSelector = `.${defaultIdpClass}`;
 export const defaultIdpInformational = '.remainingIdps__defaultIdp';
 export const remainingIdpCutoffMetSelector = '.wayf__remainingIdps .wayf__idpList--cutoffMet';
 export const remainingIdpLiSelector = '.wayf__remainingIdps .wayf__idpList > li';
+export const remainingIdpArticleSelector = `${remainingIdpListSelector} > li > .wayf__idp`;
 export const firstRemainingIdpSelector = '.wayf__remainingIdps li:first-of-type > .wayf__idp';
 export const firstRemainingIdpAfterSearchSelector = '.wayf__remainingIdps .wayf__idpList > li:first-child > .wayf__idp:not([data-weight="0"])';
 export const lastRemainingIdpSelector = '.wayf__remainingIdps li:last-of-type > .wayf__idp';

--- a/theme/base/javascripts/utility/fireClickEvent.js
+++ b/theme/base/javascripts/utility/fireClickEvent.js
@@ -3,7 +3,7 @@
  *
  *  @param element
  */
-export const fireClickEvent = (element) => {
+export const fireClickEvent = async (element) => {
   const clickEvent = new MouseEvent('click');
   element.dispatchEvent(clickEvent);
 };

--- a/theme/base/javascripts/wayf/handleIdpBanner.js
+++ b/theme/base/javascripts/wayf/handleIdpBanner.js
@@ -1,9 +1,31 @@
-import {defaultIdpId} from '../selectors';
+import {
+  defaultIdpId,
+  remainingIdpArticleSelector,
+  searchFieldSelector,
+  searchResetSelector,
+  searchSubmitSelector
+} from '../selectors';
+import {getData} from '../utility/getData';
+import {hideElement} from '../utility/hideElement';
+import {showElement} from '../utility/showElement';
 
-export const handleIdpBanner = (event) => {
+export const handleIdpBanner = async (event) => {
   event.preventDefault();
 
+  const searchField = document.querySelector(searchFieldSelector);
   const defaultIdp = document.getElementById(defaultIdpId);
-  defaultIdp.scrollIntoView(true);
+  const defaultIdpTitle = getData(defaultIdp, 'title');
+  const remainingIdps = document.querySelectorAll(remainingIdpArticleSelector);
+  const searchButton = document.querySelector(searchSubmitSelector);
+  const resetButton = document.querySelector(searchResetSelector);
+
+  for (const idp of remainingIdps) {
+    if(getData(idp, 'title').localeCompare(defaultIdpTitle) !== 0) {
+      idp.setAttribute('data-weight', '0');
+    }
+  }
+  searchField.value = defaultIdpTitle;
   defaultIdp.focus();
+  hideElement(searchButton, true);
+  showElement(resetButton, true);
 };


### PR DESCRIPTION
Prior to this change, when the user clicked the defaultIdp it focused into view.  Other idps remained visible however.

This change ensures the default idp receives focus and other idps are hidden.

[Issue brought up as part of the feedback round](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam)