### PR TITLE
Remove weird transition in safari

### DIFF
--- a/theme/base/stylesheets/pages/wayf/previousSelection.scss
+++ b/theme/base/stylesheets/pages/wayf/previousSelection.scss
@@ -2,25 +2,8 @@
     @include display-grid;
     @include grid-template-columns(calc(100% - 7rem) 7rem);
     @include grid-template-rows(min-content min-content min-content);
-    @include motion {
-        max-height: fit-content;
-        overflow: unset;
-        transition: max-height 2s linear;
-    }
-
-    &.hidden {
-        // if this is absent, Safari uses the height despite it being visually hidden
-        > * {
-            display: none;
-        }
-
-        @include motion {
-            display: block !important;
-            max-height: 0;
-            overflow: hidden;
-            transition: max-height 2s linear;
-        }
-    }
+    display: block;
+    max-height: fit-content;
 
     > .previousSelection__title {
         @include grid-position(1, 2, 1, 2);

--- a/theme/base/stylesheets/pages/wayf/remainingIdps.scss
+++ b/theme/base/stylesheets/pages/wayf/remainingIdps.scss
@@ -1,23 +1,5 @@
 .wayf__remainingIdps {
-    @include motion {
-        max-height: fit-content;
-        overflow: unset;
-        transition: max-height 2s linear;
-    }
-
-    &.hidden {
-        // if this is absent, Safari uses the height despite it being visually hidden
-        > * {
-            display: none;
-        }
-
-        @include motion {
-            display: block !important;
-            max-height: 0;
-            overflow: hidden;
-            transition: max-height 2s linear;
-        }
-    }
+    display: block;
 
     > .wayf__search {
         @include relative;


### PR DESCRIPTION
Prior to this change, when on the wayf and hitting the "use another account" button (one needs to have previously selected accounts to do so) there was a weird transition effect.

This change removes the transition animation, thereby also removing the weird transition effect.

[Issue brought up as part of the feedback round](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam)