### PR TITLE
Redesign the spinner page

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -163,6 +163,7 @@ Below you'll find a list of the "entry points" for each page with corresponding 
 - wayf: `templates > modules > authentication > view > proxy > wayf.html.twig `.  You can use `https://engine.vm.openconext.org/functional-testing/wayf` to develop the page.
 - error: `templates > modules > default > view > error > error.html.twig`.  You can use `https://engine.vm.openconext.org/feedback/unknown-error` to develop the page.
 - redirect page: `templates > modules > authentication > view > proxy > redirect.html.twig`.
+- spinner page: `templates > modules > authentication > view > proxy > form.html.twig`.  To test it disable the onload handler on the body-tag and go to your profile (or load the page without JS).
 - index.html.twig: `templates > modules > authentication > view > index > index.html.twig`.  You can use `https://engine.vm.openconext.org/` to develop the page.
 - cookie removal page: `templates > modules > authentication > view > identityprovider > remove-cookies.html.twig`.  You can use `https://engine.vm.openconext.org/authentication/idp/remove-cookies` to develop the page.
 - debug page: `templates > modules > authentication > view > proxy > debug-idp-response.html.twig`.  You can use `https://engine.vm.openconext.org/authentication/sp/debug` to develop the page.

--- a/theme/base/stylesheets/components.scss
+++ b/theme/base/stylesheets/components.scss
@@ -1,4 +1,5 @@
 @import 'components/footer';
 @import 'components/noscript';
+@import 'components/spinner';
 @import 'components/success';
 @import 'components/warning';

--- a/theme/base/stylesheets/components/spinner.scss
+++ b/theme/base/stylesheets/components/spinner.scss
@@ -1,0 +1,25 @@
+/**
+ * Spinner created by buzinas & modified for this project
+ * Repo @ https://github.com/buzinas/tiny-spinner.
+ */
+.spinner {
+    @include motion {
+        animation: spin 1s linear infinite;
+    }
+
+    border: 0.25rem solid $white;
+    border-bottom: 0.25rem solid $yellow;
+    border-radius: 50%;
+    height: 3rem;
+    width: 3rem;
+}
+
+.spinner--hidden {
+    display: none;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/theme/base/stylesheets/pages/form.scss
+++ b/theme/base/stylesheets/pages/form.scss
@@ -2,39 +2,43 @@
     CSS specific to the form page (auto submitted page that sends
     SAML response to SP
  ******************************************************************/
+.redirect {
+    height: 100%;
+    width: 100%;
+}
 
 .form {
-    > main {
-        background-color: $gray;
-        color: $black;
-        font-size: $f-normal;
-        padding: 0 2rem 2.5rem;
-        @include screen('mobile') {
-            padding: 0 1rem 1.25rem;
-        }
+    box-sizing: border-box;
+    height: 100%;
+    width: 100%;
+}
 
-        > header {
-            h2.form__subHeader {
-                padding: 1.5rem 2rem 2.125rem 0;
-            }
-        }
+.redirect__content {
+    color: $white;
+    margin: auto auto;
+    padding: 0 2rem 2.5rem;
+    text-align: center;
 
-        > div.logo {
-            > img.rotate-img {
-                width: 20%;
-                margin: 2em auto 0 auto;
-                display:block;
-            }
-        }
+    @include screen('mobile') {
+        padding: 0 1rem 1.25rem;
+    }
+}
 
-        > form {
-            > noscript {
-                input.form__noJsSubmit {
-                    @include button-primary($buttonBlue);
-                    text-align: center;
-                    width: 100%;
-                }
-            }
-        }
+.redirect__title {
+    font-size: $f-h5;
+}
+
+.redirect__spinner {
+    margin: 1.5rem auto;
+}
+
+.redirect__noJsSubmit {
+    @include button-primary($buttonBlue);
+    padding: 1rem;
+    width: 100%;
+
+    &:hover {
+        box-shadow: 0 0 0 3px $lightBlue;
+        text-decoration: underline;
     }
 }

--- a/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
@@ -1,61 +1,49 @@
 {% extends '@themeLayouts/scripts/empty.html.twig' %}
 
 {% block content %}
-    <!DOCTYPE html>
-    <html lang="{{ locale()|escape('html_attr') }}">
-    <head>
-        <title>{{ defaultTitle }} - {{ 'post_data'|trans }}</title>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-        <meta name="robots" content="noindex, nofollow"/>
-        <meta content="IE=edge" http-equiv="x-ua-compatible">
-        <meta content="initial-scale=1.0,width=device-width" name="viewport">
-        <meta content="yes" name="apple-mobile-web-app-capable">
-        <meta content="translucent-black" name="apple-mobile-web-app-status-bar-style">
-        <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon">
+<!DOCTYPE html>
+<html lang="{{ locale()|escape('html_attr') }}" class="redirect">
+<head>
+    <title>{{ defaultTitle }} - {{ 'post_data'|trans }}</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta name="robots" content="noindex, nofollow"/>
+    <meta content="IE=edge" http-equiv="x-ua-compatible">
+    <meta content="initial-scale=1.0,width=device-width" name="viewport">
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="translucent-black" name="apple-mobile-web-app-status-bar-style">
+    <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon">
 
-        {% block stylesheets %}{% spaceless %}
-            <link href="/stylesheets/application.css?v={{ assetsVersion }}" rel="stylesheet" type="text/css"/>
-        {% endspaceless %}{% endblock %}
-    </head>
-    <body class="index" {% if preventAutoSubmit is not defined %} onload="document.forms[0].submit()" {% endif %}>
-
-    <div class="container form">
-
-        <header>
-            <h1 class="redirectBar">{{ 'processing'|trans }}</h1>
-        </header>
-
-
-        <main>
-            <header>
-                <h2 class="form__subHeader">{{ 'processing_waiting'|trans }}</h2>
-            </header>
-
-            <div class="hideNoJS">
-                <p>{{ 'processing_long'|trans }}</p>
-
-                {% include '@theme/Authentication/View/Proxy/Partials/Shared/spinner.html.twig' %}
-            </div>
-
-            <form id="ProcessForm" method="post" action="{{ action }}">
-                <input type="hidden" name="{{ name }}" value="{{ message }}"/>
-                {{ xtra|raw }}
-                <noscript>
-                    <p>
-                        <strong>{{ 'note'|trans }}:</strong>
-                        {{ 'note_no_script'|trans }}
-                    </p>
-                    <input type="submit" value="Submit" class="form__noJsSubmit"/>
-                </noscript>
-            </form>
-        </main>
-    </div>
+    {% block stylesheets %}{% spaceless %}
+        <link href="/stylesheets/application.css?v={{ assetsVersion }}" rel="stylesheet" type="text/css"/>
+    {% endspaceless %}{% endblock %}
+</head>
+<body class="index form" {% if preventAutoSubmit is not defined %} onload="document.forms[0].submit()" {% endif %}>
+    <main class="redirect__content">
+        <h1 class="redirect__title">{{ 'processing'|trans }}</h1>
+        <div class="spinner redirect__spinner"></div>
+        <p class="redirect_message hideNoJS">
+            {{ 'processing_waiting'|trans }}
+            <br />
+            {{ 'processing_long'|trans }}
+        </p>
+        <form id="ProcessForm" method="post" action="{{ action }}">
+            <input type="hidden" name="{{ name }}" value="{{ message }}"/>
+            {{ xtra|raw }}
+            <noscript>
+                <p>
+                    <strong>{{ 'note'|trans }}:</strong>
+                    {{ 'note_no_script'|trans }}
+                </p>
+                <input type="submit" value="Submit" class="redirect__noJsSubmit"/>
+            </noscript>
+        </form>
+    </main>
 
     <script>
         window.addEventListener('load', () => {
             document.querySelector('.hideNoJS').classList.remove('hideNoJS');
         });
     </script>
-    </body>
-    </html>
+</body>
+</html>
 {% endblock %}

--- a/theme/skeune/translations/messages.en.php
+++ b/theme/skeune/translations/messages.en.php
@@ -19,6 +19,9 @@ return [
     'form_error_name'       =>  'Your name needs to be at least 2 characters long',
     'form_error_email'      =>  'This is an invalid email address',
 
+    // REDIRECT
+    'processing_waiting'    =>  'Waiting for a response',
+
     // WAYF
     'wayf_nothing_found'        => 'Nothing found',
     'wayf_apu'                  => 'Please try again with some different keywords',

--- a/theme/skeune/translations/messages.nl.php
+++ b/theme/skeune/translations/messages.nl.php
@@ -19,6 +19,9 @@ return [
     'form_error_name'       =>  'Je naam moet minstens twee tekens lang zijn',
     'form_error_email'      =>  'Dit is geen geldig e-mailadres',
 
+    // REDIRECT
+    'processing_waiting'    =>  'Wachten op een reactie',
+
     // WAYF
     'wayf_nothing_found'        => 'Niets gevonden',
     'wayf_apu'                  => 'Probeer het opnieuw met andere zoektermen',

--- a/theme/skeune/translations/messages.pt.php
+++ b/theme/skeune/translations/messages.pt.php
@@ -19,6 +19,9 @@ return [
     'form_error_name'       =>  'Your name needs to be at least 2 characters long',
     'form_error_email'      =>  'This is an invalid email address',
 
+    // REDIRECT
+    'processing_waiting'    =>  'Waiting for a response',
+
     // WAYF
     'wayf_nothing_found'        => 'Nothing found',
     'wayf_apu'                  => 'Please try again with some different keywords',


### PR DESCRIPTION
Prior to this change, the spinner page was not adjusted to the new design.

This change ensures that the design fits the skeune theme.  It should look like this: 
![image](https://user-images.githubusercontent.com/4058016/105875708-683b9800-5ffe-11eb-9f4b-a3aded30292b.png)


[Issue brought up as part of the feedback round](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam)