### PR TITLE
Couple cypress tests to same selectors

### DIFF
--- a/theme/base/javascripts/selectors.js
+++ b/theme/base/javascripts/selectors.js
@@ -10,6 +10,13 @@ export const metadataCertificateLinkSelector = 'dl.metadata-certificates-list a'
 export const indexPageSelector = '#engine-main-page';
 
 /***
+ * ERROR PAGE SELECTORS
+ * ***/
+export const errorTitleHeadingSelector = '.error-title__heading';
+export const errorTitleMessageSelector = '.error-title__error-message';
+export const languageErrorSelector = '.comp-language.error';
+
+/***
  * CONSENT SELECTORS
  * ***/
 /**
@@ -18,13 +25,16 @@ export const indexPageSelector = '#engine-main-page';
  * See the @motion mixin explanation for a longer explanation as to why.
  */
 export const consentAnimatedElementSelectors = '.tooltip__value, .modal__value, .consent__attributes, .attribute__valueWrapper > .attribute__value--list';
-
 export const nokButtonSelector = 'label[for="cta_consent_nok"]';
+export const nokButtonSelectorForKeyboard = '.consent__ctas > .button--tertiary';
 export const nokSectionSelector = '.consent__nok';
 export const contentSectionSelector = '.consent__content';
 export const backButtonSelector = '.consent__nok-back';
 export const tooltipsAndModalLabels = 'label.tooltip, label.modal';
 export const modalLabels = 'label.modal';
+export const attributesSelector = 'ul.consent__attributes li';
+export const tooltipLabelSelector = 'label.tooltip';
+export const primaryTooltipLabelSelector = `.ie11__label > ${tooltipLabelSelector}`;
 
 /***
  * WAYF SELECTORS

--- a/theme/cypress/integration/skeune/consent/consent.general.spec.js
+++ b/theme/cypress/integration/skeune/consent/consent.general.spec.js
@@ -1,3 +1,6 @@
+import {attributesSelector} from '../../../../base/javascripts/selectors';
+import {attribute6, labelSelector, nokSectionTitleSelector, tooltip3Selector} from '../testSelectors';
+
 context('Consent on Skeune theme', () => {
   beforeEach(() => {
     cy.visit('https://engine.vm.openconext.org/functional-testing/consent');
@@ -5,40 +8,27 @@ context('Consent on Skeune theme', () => {
 
   describe('Handles additional attributes correctly', () => {
     it('shows the correct amount of attributes on load', () => {
-      cy.get('ul.consent__attributes > li')
+      cy.get(attributesSelector)
         .should('have.length', '11');
-      cy.get('ul.consent__attributes li:nth-of-type(6)')
+      cy.get(attribute6)
         .should('have.css', 'height', '1px')
         .should('have.css', 'width', '1px');
     });
 
-    it('Should not show the extra attributes on load', () => {
-      cy.get('ul.consent__attributes--nested')
-        .should('not.be.visible');
-    });
-
     it('Should show the more info label', () => {
-      cy.contains('label', 'Show more information');
+      cy.contains(labelSelector, 'Show more information');
     });
   });
 
   describe('Hides the correct content on load', () => {
     it('Hides the tooltip on load', () => {
-      cy.get('label.tooltip[for="tooltip3consent_attribute_source_idp"]')
+      cy.get(tooltip3Selector)
         .next()
         .should('not.be.visible');
     });
 
     it('Should not show the nok-modal on load', () => {
-      cy.notBeVisible('label[for="cta_consent_nok"] + section h3');
-    });
-
-    it('Should not show the decline consent modal on load', () => {
-      cy.notBeVisible('label[for="cta_consent_nok"] + section h3');
-    });
-
-    it('Should not show the nok-section on load', () => {
-      cy.notBeVisible('.consent__nok');
+      cy.notBeVisible(nokSectionTitleSelector);
     });
   });
 });

--- a/theme/cypress/integration/skeune/consent/consent.keyboard.spec.js
+++ b/theme/cypress/integration/skeune/consent/consent.keyboard.spec.js
@@ -1,3 +1,6 @@
+import {attribute6, labelSelector, primaryTooltip3Selector} from '../testSelectors';
+import {backButtonSelector, contentSectionSelector, nokButtonSelectorForKeyboard, nokSectionSelector} from '../../../../base/javascripts/selectors';
+
 /**
  * Tests for behaviour of the consent screen which depends on the keyboard.
  */
@@ -8,26 +11,26 @@ context('Consent when using the keyboard', () => {
 
   describe('Test showing / hiding the extra attributes', () => {
     it('Should show the extra attributes after hitting the label', () => {
-      cy.contains('label', 'Show more information')
+      cy.contains(labelSelector, 'Show more information')
         .focus().type('{enter}');
-      cy.contains('label', 'Show less information');
-      cy.get('ul.consent__attributes li:nth-of-type(6)')
+      cy.contains(labelSelector, 'Show less information');
+      cy.get(attribute6)
         .should('not.have.css', 'height', '1px')
         .should('not.have.css', 'width', '1px');
     });
 
     it('Should hide the extra attributes after hitting the label again', () => {
       // first click the show more label to show the attributes
-      cy.contains('label', 'Show more information')
+      cy.contains(labelSelector, 'Show more information')
         .focus().type('{enter}');
 
       // try to hide them again
-      cy.contains('label', 'Show less information')
+      cy.contains(labelSelector, 'Show less information')
         .focus().type('{enter}');
 
       // test assertions
-      cy.contains('label', 'Show more information');
-      cy.get('ul.consent__attributes li:nth-of-type(6)')
+      cy.contains(labelSelector, 'Show more information');
+      cy.get(attribute6)
         .should('have.css', 'height', '1px')
         .should('have.css', 'width', '1px');
     });
@@ -35,7 +38,7 @@ context('Consent when using the keyboard', () => {
 
   describe('Shows / hides the tooltips on enter', () => {
     it('Shows the tooltip', () => {
-      cy.focusAndEnter('.ie11__label > label.tooltip[for="tooltip3consent_attribute_source_idp"]')
+      cy.focusAndEnter(primaryTooltip3Selector)
         .parent()
         .next()
         .should('be.visible');
@@ -43,12 +46,12 @@ context('Consent when using the keyboard', () => {
 
     it('Hides the tooltip', () => {
       // Make it visible
-      cy.focusAndEnter('.ie11__label > label.tooltip[for="tooltip3consent_attribute_source_idp"]')
+      cy.focusAndEnter(primaryTooltip3Selector)
         .parent()
         .next();
 
       // Hide and check if it worked
-      cy.focusAndEnter('.ie11__label > label.tooltip[for="tooltip3consent_attribute_source_idp"]')
+      cy.focusAndEnter(primaryTooltip3Selector)
         .parent()
         .next()
         .should('not.be.visible');
@@ -57,7 +60,7 @@ context('Consent when using the keyboard', () => {
 
   describe('Shows the modals on enter', () => {
     it('Should show the incorrect modal', () => {
-      cy.contains('label', 'Something incorrect?')
+      cy.contains(labelSelector, 'Something incorrect?')
         .focus().type('{enter}');
       cy.contains('Is the data shown incorrect?')
         .should('be.visible');
@@ -66,15 +69,15 @@ context('Consent when using the keyboard', () => {
 
   describe('Shows / hides the nok-section on enter', () => {
     it('Shows the nok-section when hitting the nok button', () => {
-      cy.getAndEnter('.consent__ctas > .button--tertiary');
-      cy.beVisible('.consent__nok');
-      cy.notBeVisible('.consent__content');
+      cy.getAndEnter(nokButtonSelectorForKeyboard);
+      cy.beVisible(nokSectionSelector);
+      cy.notBeVisible(contentSectionSelector);
     });
 
     it('Hides the nok-section when hitting the back button', () => {
-      cy.getAndEnter('.consent__nok-back');
-      cy.notBeVisible('.consent__nok');
-      cy.beVisible('.consent__content');
+      cy.getAndEnter(backButtonSelector);
+      cy.notBeVisible(nokSectionSelector);
+      cy.beVisible(contentSectionSelector);
     });
   });
 });

--- a/theme/cypress/integration/skeune/consent/consent.mouse.spec.js
+++ b/theme/cypress/integration/skeune/consent/consent.mouse.spec.js
@@ -1,3 +1,6 @@
+import {attribute6, labelSelector, primaryTooltip3Selector} from '../testSelectors';
+import {backButtonSelector, contentSectionSelector, nokButtonSelector, nokSectionSelector} from '../../../../base/javascripts/selectors';
+
 /**
  * Tests for behaviour of the consent screen which depends on the mouse.
  */
@@ -8,26 +11,26 @@ context('Consent when using the mouse', () => {
 
   describe('Test showing / hiding the extra attributes', () => {
     it('Should show the extra attributes after clicking the label', () => {
-      cy.contains('label', 'Show more information')
+      cy.contains(labelSelector, 'Show more information')
         .click();
-      cy.contains('label', 'Show less information');
-      cy.get('ul.consent__attributes li:nth-of-type(6)')
+      cy.contains(labelSelector, 'Show less information');
+      cy.get(attribute6)
         .should('not.have.css', 'height', '1px')
         .should('not.have.css', 'width', '1px');
     });
 
     it('Should hide the extra attributes after clicking the label again', () => {
       // first click the show more label to show the attributes
-      cy.contains('label', 'Show more information')
+      cy.contains(labelSelector, 'Show more information')
         .click({force: true});
 
       // try to hide them again
-      cy.contains('label', 'Show less information')
+      cy.contains(labelSelector, 'Show less information')
         .click({force: true});
 
       // test assertions
-      cy.contains('label', 'Show more information');
-      cy.get('ul.consent__attributes li:nth-of-type(6)')
+      cy.contains(labelSelector, 'Show more information');
+      cy.get(attribute6)
         .should('have.css', 'height', '1px')
         .should('have.css', 'width', '1px');
     });
@@ -35,7 +38,7 @@ context('Consent when using the mouse', () => {
 
   describe('Shows / hides the tooltips on click', () => {
     it('Shows the tooltip', () => {
-      cy.get('.ie11__label > label.tooltip[for="tooltip3consent_attribute_source_idp"]')
+      cy.get(primaryTooltip3Selector)
         .click({force: true})
         .parent()
         .next()
@@ -44,13 +47,13 @@ context('Consent when using the mouse', () => {
 
     it('Hides the tooltip', () => {
       // Make it visible
-      cy.get('.ie11__label > label.tooltip[for="tooltip3consent_attribute_source_idp"]')
+      cy.get(primaryTooltip3Selector)
         .click({force: true})
         .parent()
         .next();
 
       // Hide and check if it worked
-      cy.get('.ie11__label > label.tooltip[for="tooltip3consent_attribute_source_idp"]')
+      cy.get(primaryTooltip3Selector)
         .click({force: true})
         .parent()
         .next()
@@ -60,7 +63,7 @@ context('Consent when using the mouse', () => {
 
   describe('Shows the modals on click', () => {
     it('Should show the incorrect modal', () => {
-      cy.contains('label', 'Something incorrect?')
+      cy.contains(labelSelector, 'Something incorrect?')
         .click({force: true});
       cy.contains('Is the data shown incorrect?')
         .should('be.visible');
@@ -69,15 +72,15 @@ context('Consent when using the mouse', () => {
 
   describe('Shows / hides the nok-section on click', () => {
     it('Shows the nok-section when clicking the nok button', () => {
-      cy.get('label[for="cta_consent_nok"]').click({force: true});
-      cy.beVisible('.consent__nok');
-      cy.notBeVisible('.consent__content');
+      cy.get(nokButtonSelector).click({force: true});
+      cy.beVisible(nokSectionSelector);
+      cy.notBeVisible(contentSectionSelector);
     });
 
     it('Hides the nok-section when clicking the back button', () => {
-      cy.get('.consent__nok-back').click({force: true});
-      cy.notBeVisible('.consent__nok');
-      cy.beVisible('.consent__content');
+      cy.get(backButtonSelector).click({force: true});
+      cy.notBeVisible(nokSectionSelector);
+      cy.beVisible(contentSectionSelector);
     });
   });
 });

--- a/theme/cypress/integration/skeune/error/error.general.spec.js
+++ b/theme/cypress/integration/skeune/error/error.general.spec.js
@@ -1,3 +1,9 @@
+import {
+  errorTitleHeadingSelector,
+  errorTitleMessageSelector,
+  languageErrorSelector
+} from '../../../../base/javascripts/selectors';
+
 /**
  * Tests for the general behaviour of the error page.
  */
@@ -5,9 +11,9 @@ context('Error pages on skeune theme', () => {
   it('Test if the error page loads with the unknown error notice & all components', () => {
     cy.visit('https://engine.vm.openconext.org/feedback/unknown-error', {failOnStatusCode: false
     });
-    cy.beVisible('.error-title__heading');
-    cy.beVisible('.error-title__error-message');
-    cy.beVisible('.comp-language.error');
+    cy.beVisible(errorTitleHeadingSelector);
+    cy.beVisible(errorTitleMessageSelector);
+    cy.beVisible(languageErrorSelector);
     cy.contains('Error - An error occurred');
     cy.contains('we don\'t know exactly why');
     cy.contains('OpenConext Wiki');
@@ -17,9 +23,9 @@ context('Error pages on skeune theme', () => {
   it('Test if a faulty url loads the 404 page with all components', () => {
     cy.visit('https://engine.vm.openconext.org/functional-testing/a;dkfj;ad', {failOnStatusCode: false
     });
-    cy.beVisible('.error-title__heading');
-    cy.beVisible('.error-title__error-message');
-    cy.beVisible('.comp-language.error');
+    cy.beVisible(errorTitleHeadingSelector);
+    cy.beVisible(errorTitleMessageSelector);
+    cy.beVisible(languageErrorSelector);
     cy.contains('404 - Page not found');
     cy.contains('This page has not been found');
     cy.contains('Helpdesk');

--- a/theme/cypress/integration/skeune/index/index.general.spec.js
+++ b/theme/cypress/integration/skeune/index/index.general.spec.js
@@ -1,10 +1,12 @@
+import {indexPageHeader} from '../testSelectors';
+
 context('Index on Skeune theme', () => {
   beforeEach(() => {
     cy.visit('https://engine.vm.openconext.org/');
   });
 
   it('Renders the index page and has all relevant data', () => {
-    cy.beVisible('main div.main:first-of-type h1').should('have.text', 'IdP Certificate and Metadata');
+    cy.beVisible(indexPageHeader).should('have.text', 'IdP Certificate and Metadata');
     cy.contains('SP Certificate and Metadata').should('be.visible');
     cy.contains('This is a service connected through').should('be.visible');
     cy.contains('Terms of Service').should('be.visible');

--- a/theme/cypress/integration/skeune/testSelectors.js
+++ b/theme/cypress/integration/skeune/testSelectors.js
@@ -1,0 +1,31 @@
+import {attributesSelector, idpDeleteDisabledSelector, idpSelector, nokSectionSelector, previousSelectionFirstIdp, primaryTooltipLabelSelector, remainingIdpSelector, selectedIdpsSelector, tooltipLabelSelector, unconnectedIdpClass} from '../../../base/javascripts/selectors';
+
+/***
+ * INDEX SELECTORS
+ * ***/
+export const indexPageHeader = 'main div.main:first-of-type h1';
+
+/***
+ * CONSENT SELECTORS
+ * ***/
+export const attribute6 = `${attributesSelector}:nth-of-type(6)`;
+export const labelSelector = 'label';
+export const tooltip3Selector = `${tooltipLabelSelector}[for="tooltip3consent_attribute_source_idp"]`;
+export const primaryTooltip3Selector = `${primaryTooltipLabelSelector}[for="tooltip3consent_attribute_source_idp"]`;
+export const nokSectionTitleSelector = `${nokSectionSelector} h3`;
+
+
+/***
+ * WAYF SELECTORS
+ * ***/
+export const idpTitle = `${idpSelector} h3`;
+export const unconnectedIdpSelector = `.${unconnectedIdpClass}`;
+export const weight100Selector = `${remainingIdpSelector}[data-weight="100"]`;
+export const weight215Selector = `${remainingIdpSelector}[data-weight="215"]`;
+export const weight60Selector = `${remainingIdpSelector}[data-weight="60"]`;
+export const weight7Selector = `${remainingIdpSelector}[data-weight="7"]`;
+export const weight8Selector = `${remainingIdpSelector}[data-weight="8"]`;
+export const weight82Selector = `${remainingIdpSelector}[data-weight="82"]`;
+export const selectedIdpDataIndex1 = `${selectedIdpsSelector}[data-index="1"]`;
+export const firstSelectedIdpDeleteDisable = `${previousSelectionFirstIdp} ${idpDeleteDisabledSelector}`;
+export const firstRemainingIdp = '.wayf__remainingIdps li:first-of-type .wayf__idp';

--- a/theme/cypress/integration/skeune/wayf/wayf.general.spec.js
+++ b/theme/cypress/integration/skeune/wayf/wayf.general.spec.js
@@ -1,3 +1,6 @@
+import {idpTitle, unconnectedIdpSelector, weight100Selector, weight215Selector, weight60Selector, weight7Selector, weight8Selector, weight82Selector} from '../testSelectors';
+import {defaultIdpInformational, idpSelector, matchSelector, noResultSectionSelector, remainingIdpSelector, searchFieldSelector, searchResetSelector, searchSubmitSelector} from '../../../../base/javascripts/selectors';
+
 /**
  * Tests for behaviour that has nothing to do with clicking / pressing enter.
  */
@@ -12,33 +15,33 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
 
     it('Should show ten connected IdPs', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=10');
-      cy.get('.wayf__idp h3')
+      cy.get(idpTitle)
         .should('have.length', 10);
     });
 
     it('Should show no connected IdPs when cutoff point is configured', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=6&cutoffPointForShowingUnfilteredIdps=5');
-      cy.get('.wayf__remainingIdps .wayf__idp')
+      cy.get(remainingIdpSelector)
         .should('not.be.visible');
     });
 
     it('Should show found IdPs when cutoff point is configured and user searched', () => {
-      cy.get('.search__field').type('IdP');
-      cy.get('.wayf__idp')
+      cy.get(searchFieldSelector).type('IdP');
+      cy.get(idpSelector)
         .should('have.length', 6)
         .should('be.visible');
     });
 
     it('Should show 5 disconnected IdPs', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?displayUnconnectedIdpsWayf=1&unconnectedIdps=5');
-      cy.get('.wayf__idp--noAccess')
+      cy.get(unconnectedIdpSelector)
         .should('have.length', 5)
         .should('be.visible');
     });
 
     it('Should show no disconnected IdPs when the flag is false', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?displayUnconnectedIdpsWayf=0&unconnectedIdps=5');
-      cy.get('.wayf__idp--noAccess')
+      cy.get(unconnectedIdpSelector)
         .should('not.exist');
     });
   });
@@ -46,83 +49,83 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
   describe('Test if search works as it should', () => {
     it('Should show no results when no IdPs are found', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
-      cy.get('.wayf__search').type('OllekebollekeKnol');
-      cy.get('.wayf__noResults').should('be.visible');
-      cy.get('.search__submit').should('have.class', 'visually-hidden');
-      cy.get('.search__reset').should('be.visible');
+      cy.get(searchFieldSelector).type('OllekebollekeKnol');
+      cy.get(noResultSectionSelector).should('be.visible');
+      cy.get(searchSubmitSelector).should('have.class', 'visually-hidden');
+      cy.get(searchResetSelector).should('be.visible');
     });
 
     it('Should be able to search for an idp', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
-      cy.get('.wayf__search').type('4');
+      cy.get(searchFieldSelector).type('4');
       // When the user starts typing, the reset (x) button should appear, replacing the search icon
-      cy.get('.search__submit').should('have.class', 'visually-hidden');
-      cy.get('.search__reset').should('be.visible');
+      cy.get(searchSubmitSelector).should('have.class', 'visually-hidden');
+      cy.get(searchResetSelector).should('be.visible');
 
       // After filtering the search results, verify one result is visible
-      cy.get('.wayf__remainingIdps .wayf__idp:not([data-weight="0"])')
+      cy.get(matchSelector)
         .should('have.length', 1)
         .should('contain.text', 'Connected IdP 4 en');
     });
 
     it('Should get the correct weight for an idp with a full match on the title', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=50');
-      cy.get('.wayf__search').type('Connected Idp 4 en');
-      cy.get('.wayf__remainingIdps .wayf__idp[data-weight="215"]')
+      cy.get(searchFieldSelector).type('Connected Idp 4 en');
+      cy.get(weight215Selector)
         .should('have.length', 1)
         .should('contain.text', 'Connected IdP 4 en');
     });
 
     it('Should get the correct weight for an idp with a partial match on the title', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=50');
-      cy.get('.wayf__search').type('Connected Idp 4');
-      cy.get('.wayf__remainingIdps .wayf__idp[data-weight="82"]')
+      cy.get(searchFieldSelector).type('Connected Idp 4');
+      cy.get(weight82Selector)
         .should('have.length', 10);
     });
 
     it('Should get the correct weight for an idp with a full match on the keyword', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=50');
-      cy.get('.wayf__search').type('awesome idp');
-      cy.get('.wayf__remainingIdps .wayf__idp[data-weight="100"]')
+      cy.get(searchFieldSelector).type('awesome idp');
+      cy.get(weight100Selector)
         .should('have.length', 50);
     });
 
     it('Should get the correct weight for an idp with a partial match on the keyword', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=50');
-      cy.get('.wayf__search').type('awesome');
-      cy.get('.wayf__remainingIdps .wayf__idp[data-weight="8"]')
+      cy.get(searchFieldSelector).type('awesome');
+      cy.get(weight8Selector)
         .should('have.length', 50);
     });
 
     it('Should get the correct weight for an idp with a full match on the entityId', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=50');
-      cy.get('.wayf__search').type('https://example.com/entityId/1');
-      cy.get('.wayf__remainingIdps .wayf__idp[data-weight="60"]')
+      cy.get(searchFieldSelector).type('https://example.com/entityId/1');
+      cy.get(weight60Selector)
         .should('have.length', 1);
     });
 
     it('Should get the correct weight for an idp with a partial match on the entityId', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=50');
-      cy.get('.wayf__search').type('/1');
-      cy.get('.wayf__remainingIdps .wayf__idp[data-weight="7"]')
+      cy.get(searchFieldSelector).type('/1');
+      cy.get(weight7Selector)
         .should('have.length', 11);
     });
 
     it('Should not take into account the space at the end of a searchTerm', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
-      cy.get('.wayf__search').type('con 1');
-      cy.get('.wayf__remainingIdps .wayf__idp')
+      cy.get(searchFieldSelector).type('con 1');
+      cy.get(remainingIdpSelector)
         .should('have.length', 5);
     });
 
-    it.only('Should reset the search text when clicking the reset button', () => {
+    it('Should reset the search text when clicking the reset button', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
-      cy.get('.wayf__search').type('con 1');
-      cy.get('.search__reset').click({force:true});
-      cy.get('.search__submit').should('be.visible');
-      cy.get('.search__reset').should('have.class', 'visually-hidden');
-      cy.get('.remainingIdps__defaultIdp').should('be.visible');
-      cy.get('.wayf__remainingIdps .wayf__idp')
+      cy.get(searchFieldSelector).type('con 1');
+      cy.get(searchResetSelector).click({force:true});
+      cy.get(searchSubmitSelector).should('be.visible');
+      cy.get(searchResetSelector).should('have.class', 'visually-hidden');
+      cy.get(defaultIdpInformational).should('be.visible');
+      cy.get(remainingIdpSelector)
         .should('have.length', 5);
     });
   });
@@ -133,28 +136,28 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
     });
 
     it('Get the connected IdPs & check if it\'s correct', () => {
-      cy.get('.wayf__idp h3')
+      cy.get(idpTitle)
         .should('have.length', 5)
         .eq(2)
         .should('have.text', 'Login with Connected IdP 3 en');
     });
 
     it('Check if the search field is present', () => {
-      cy.get('.wayf__search').should('exist');
+      cy.get(searchFieldSelector).should('exist');
     });
 
     it('Check if the defaultIdp is present', () => {
-      cy.contains('.remainingIdps__defaultIdp', 'is available as an alternative');
+      cy.contains(defaultIdpInformational, 'is available as an alternative');
     });
 
     it('Ensure the CTA is not present when the feature flag is disabled', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?showIdPBanner=0');
-      cy.get('.remainingIdps__defaultIdp').should('not.exist');
+      cy.get(defaultIdpInformational).should('not.exist');
     });
 
     it('Ensure the default IdP has the correct data attribute', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?defaultIdpEntityId=https://example.com/entityId/3');
-      cy.get('article[data-entityid="https://example.com/entityId/3"]')
+      cy.get('[data-entityid="https://example.com/entityId/3"]')
         .should('have.id', 'defaultIdp');
     });
   });
@@ -185,7 +188,7 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
     it('Should hide the IdP link when search term is provided', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
       cy.get('.search__field').type('search-term');
-      cy.get('.remainingIdps__defaultIdp').should('not.be.visible');
+      cy.get(defaultIdpInformational).should('not.be.visible');
     });
 
     it('Should show the IdP link when search term is provided', () => {

--- a/theme/cypress/integration/skeune/wayf/wayf.keyboard.spec.js
+++ b/theme/cypress/integration/skeune/wayf/wayf.keyboard.spec.js
@@ -1,3 +1,6 @@
+import {addAccountButtonSelector, cancelButtonSelector, defaultIdpClass, defaultIdpItemSelector, defaultIdpSelector, emailErrorSelector, emailFieldSelector, idpClass, nameErrorSelector, nameFieldSelector, noAccessTitle, noAccessFieldsetsSelector, previousSelectionTitleSelector, remainingIdpSelector, searchFieldClass, searchFieldSelector, selectedIdpsSelector, selectedIdpsSectionSelector, showFormSelector, submitRequestSelector, succesMessageSelector} from '../../../../base/javascripts/selectors';
+import {firstRemainingIdp, firstSelectedIdpDeleteDisable, selectedIdpDataIndex1} from '../testSelectors';
+
 /**
  * Tests for behaviour of the WAYF which depends on the keyboard.
  */
@@ -5,7 +8,7 @@ context('WAYF when using the keyboard', () => {
   describe('Test logging in', () => {
     it('Should login when selecting an idp', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
-      cy.get('.wayf__remainingIdps .wayf__idp')
+      cy.get(remainingIdpSelector)
         .eq(1)
         .focus()
         .type('{enter}');
@@ -17,7 +20,7 @@ context('WAYF when using the keyboard', () => {
 
     it('Should login to first IdP when hitting enter', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
-      cy.get('#wayf_search')
+      cy.get(searchFieldSelector)
         .type('{enter}');
       cy.location().should((loc) => {
         expect(loc.href).to.eq('https://engine.vm.openconext.org/?idp=https%3A//example.com/entityId/1');
@@ -26,76 +29,74 @@ context('WAYF when using the keyboard', () => {
 
     it('Should login to topmost  IdP when hitting enter', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
-      cy.get('#wayf_search')
+      cy.get(searchFieldSelector)
         .type('2')
         .type('{enter}');
       cy.location().should((loc) => {
         expect(loc.href).to.eq('https://engine.vm.openconext.org/?idp=https%3A//example.com/entityId/2');
       });
     });
-
-
   });
 
   // todo if html spec is changed, or cypress fixes bug 6207, get rid of the manual focus on search.  See https://github.com/cypress-io/cypress/issues/6207
   describe('Should be able to traverse the remaining idp section with arrow keys', () => {
     it('check if pressing down works as expected', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?showIdpBanner=1');
-      cy.get('.search__field').focus();
-      cy.pressArrowOnIdpList('down', 'search__field');
-      cy.pressArrowOnIdpList('down', 'wayf__defaultIdpLink');
-      cy.pressArrowOnIdpList('down', 'wayf__idp', '1');
-      cy.pressArrowOnIdpList('down', 'wayf__idp', '2');
-      cy.pressArrowOnIdpList('down', 'wayf__idp', '3');
-      cy.pressArrowOnIdpList('down', 'wayf__idp', '4');
-      cy.pressArrowOnIdpList('down', 'wayf__idp', '5');
-      cy.pressArrowOnIdpList('down', 'search__field');
+      cy.get(searchFieldSelector).focus();
+      cy.pressArrowOnIdpList('down', searchFieldClass);
+      cy.pressArrowOnIdpList('down', defaultIdpClass);
+      cy.pressArrowOnIdpList('down', idpClass, '1');
+      cy.pressArrowOnIdpList('down', idpClass, '2');
+      cy.pressArrowOnIdpList('down', idpClass, '3');
+      cy.pressArrowOnIdpList('down', idpClass, '4');
+      cy.pressArrowOnIdpList('down', idpClass, '5');
+      cy.pressArrowOnIdpList('down', searchFieldClass);
     });
 
     it('check if pressing up works as expected', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?showIdpBanner=1');
-      cy.get('.search__field').focus();
-      cy.pressArrowOnIdpList('up', 'search__field');
-      cy.pressArrowOnIdpList('up', 'wayf__idp', '5');
-      cy.pressArrowOnIdpList('up', 'wayf__idp', '4');
-      cy.pressArrowOnIdpList('up', 'wayf__idp', '3');
-      cy.pressArrowOnIdpList('up', 'wayf__idp', '2');
-      cy.pressArrowOnIdpList('up', 'wayf__idp', '1');
-      cy.pressArrowOnIdpList('up', 'wayf__defaultIdpLink');
-      cy.pressArrowOnIdpList('up', 'search__field');
+      cy.get(searchFieldSelector).focus();
+      cy.pressArrowOnIdpList('up', searchFieldClass);
+      cy.pressArrowOnIdpList('up', idpClass, '5');
+      cy.pressArrowOnIdpList('up', idpClass, '4');
+      cy.pressArrowOnIdpList('up', idpClass, '3');
+      cy.pressArrowOnIdpList('up', idpClass, '2');
+      cy.pressArrowOnIdpList('up', idpClass, '1');
+      cy.pressArrowOnIdpList('up', defaultIdpClass);
+      cy.pressArrowOnIdpList('up', searchFieldClass);
     });
   });
 
   describe('Should show a fully functional no access section when a disabled account is selected', () => {
     it('Should show the no access section on selecting a disabled account', () => {
       cy.openUnconnectedIdp();
-      cy.contains('.noAccess__title', 'Sorry, no access for this account');
+      cy.contains(noAccessTitle, 'Sorry, no access for this account');
     });
 
     it('Should not show the form elements yet', () => {
       cy.openUnconnectedIdp();
-      cy.notBeVisible('.noAccess__requestForm fieldset');
+      cy.notBeVisible(noAccessFieldsetsSelector);
     });
 
     it('Should have a functioning cancel button', () => {
       cy.openUnconnectedIdp();
-      cy.focusAndEnter('.cta__showForm');
-      cy.getAndEnter('.cta__cancel');
-      cy.notBeVisible('.noAccess__title');
+      cy.focusAndEnter(showFormSelector);
+      cy.getAndEnter(cancelButtonSelector);
+      cy.notBeVisible(noAccessTitle);
     });
 
     it('Should show the form fields after hitting request access', () => {
       cy.openUnconnectedIdp();
-      cy.getAndEnter('.cta__showForm');
-      cy.beVisible('.noAccess__requestForm fieldset');
+      cy.getAndEnter(showFormSelector);
+      cy.beVisible(noAccessFieldsetsSelector);
     });
 
     it('Should hide form fields after hitting cancel', () => {
       cy.openUnconnectedIdp();
-      cy.getAndEnter('.cta__showForm');
-      cy.getAndEnter('.cta__cancel');
+      cy.getAndEnter(showFormSelector);
+      cy.getAndEnter(cancelButtonSelector);
       cy.focusAndEnter('.wayf__idp[data-entityid="https://unconnected.example.com/entityId/2"]');
-      cy.notBeVisible('.noAccess__requestForm fieldset');
+      cy.notBeVisible(noAccessFieldsetsSelector);
     });
 
     it('Should be able to fill the request access form', () => {
@@ -106,9 +107,9 @@ context('WAYF when using the keyboard', () => {
     it('Should be able to partially fill the request access form and get validation message', () => {
       cy.openUnconnectedIdp();
       cy.fillNoAccessForm();
-      cy.get('#name').clear();
-      cy.getAndEnter('.cta__request');
-      cy.get('#name + form_error')
+      cy.get(nameFieldSelector).clear();
+      cy.getAndEnter(submitRequestSelector);
+      cy.get(nameErrorSelector)
         .should('not.have.class', 'hidden');
       cy.notBeVisible('This is an invalid email address');
     });
@@ -116,52 +117,52 @@ context('WAYF when using the keyboard', () => {
     it('Email validation should be triggered', () => {
       cy.openUnconnectedIdp();
       cy.fillNoAccessForm();
-      cy.get('#email').clear();
-      cy.getAndEnter('.cta__request');
+      cy.get(emailFieldSelector).clear();
+      cy.getAndEnter(submitRequestSelector);
       cy.notBeVisible('Your name needs to be at least 2 characters long');
-      cy.doesNotHaveClass('#email + .form__error', 'hidden');
+      cy.doesNotHaveClass(emailErrorSelector, 'hidden');
     });
 
     it.skip('Should show the success message', () => {
       cy.openUnconnectedIdp();
       cy.fillNoAccessForm();
-      cy.getAndEnter('.cta__request');
+      cy.getAndEnter(submitRequestSelector);
       cy.wait(500);
-      cy.notBeVisible('.noAccess__title');
-      cy.beVisible('.notification__success');
+      cy.notBeVisible(noAccessTitle);
+      cy.beVisible(succesMessageSelector);
     });
 
     it('Should not show the success message when selecting a new disabled account', () => {
       cy.openUnconnectedIdp();
       cy.fillNoAccessForm();
-      cy.focusAndEnter('.cta__request');
+      cy.focusAndEnter(submitRequestSelector);
       cy.wait(500);
       cy.focusAndEnter('.wayf__idp[data-entityid="https://unconnected.example.com/entityId/3');
-      cy.notBeVisible('.notification__success');
+      cy.notBeVisible(succesMessageSelector);
     });
 
     it('Should also not show the form fields after selecting a new disabled account', () => {
       cy.openUnconnectedIdp();
       cy.fillNoAccessForm();
-      cy.focusAndEnter('.cta__request');
+      cy.focusAndEnter(submitRequestSelector);
       cy.wait(500);
       cy.focusAndEnter('.wayf__idp[data-entityid="https://unconnected.example.com/entityId/3');
-      cy.notBeVisible('.noAccess__requestForm fieldset');
+      cy.notBeVisible(noAccessFieldsetsSelector);
     });
   });
 
   describe('Should have a working default Idp Banner', () => {
     it('Should have a default Idp banner visible', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?showIdpBanner=1');
-      cy.beVisible('.wayf__defaultIdpLink');
+      cy.beVisible(defaultIdpSelector);
     });
 
     it('Should scroll to the default Idp when clicking the banner link', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=10&defaultIdpEntityId=https://example.com/entityId/9&showIdpBanner=1');
 
       // click the banner link & check if it did what it should have
-      cy.focusAndEnter('.wayf__defaultIdpLink');
-      cy.get('#defaultIdp')
+      cy.focusAndEnter(defaultIdpSelector);
+      cy.get(defaultIdpItemSelector)
         .should('be.visible')
         .should('have.focus');
     });
@@ -170,23 +171,23 @@ context('WAYF when using the keyboard', () => {
   describe('Should show a fully functional previous selection section', () => {
     it('Test if the previous section exists with the right title', () => {
       cy.addOnePreviouslySelectedIdp();
-      cy.beVisible('.previousSelection__title');
+      cy.beVisible(previousSelectionTitleSelector);
     });
 
     it('Test if the section contains the use account button', () => {
       cy.addOnePreviouslySelectedIdp();
-      cy.beVisible('.previousSelection__addAccount');
+        cy.beVisible(addAccountButtonSelector);
     });
 
     it('Test if it contains the right amount of idps', () => {
       cy.addOnePreviouslySelectedIdp();
-      cy.get('.wayf__previousSelection .wayf__idp')
+      cy.get(selectedIdpsSelector)
         .should('have.length', 1);
     });
 
     it('Test if selecting a previously selected idp works', () => {
       cy.addOnePreviouslySelectedIdp();
-      cy.selectFirstIdp(false, '.wayf__previousSelection .wayf__idp[data-index="1"]');
+      cy.selectFirstIdp(false, selectedIdpDataIndex1);
       cy.location().should((loc) => {
         expect(loc.href).to.eq('https://engine.vm.openconext.org/?idp=https%3A//example.com/entityId/1');
       });
@@ -194,9 +195,9 @@ context('WAYF when using the keyboard', () => {
 
     it('Test if the count was raised on the selected idp', () => {
       cy.addOnePreviouslySelectedIdp();
-      cy.selectFirstIdp(false, '.wayf__previousSelection .wayf__idp[data-index="1"]');
+      cy.selectFirstIdp(false, selectedIdpDataIndex1);
       cy.loadWayf();
-      cy.get('.wayf__previousSelection .wayf__idp[data-index="1"]').should('have.attr', 'data-count', '2');
+      cy.get(selectedIdpDataIndex1).should('have.attr', 'data-count', '2');
     });
 
     it('Test the edit button allows deleting an account', () => {
@@ -205,28 +206,28 @@ context('WAYF when using the keyboard', () => {
       cy.selectFirstIdpAndReturn(false);
       cy.toggleEditButton(false);
       cy.hitDeleteButton(false);
-      cy.notBeVisible('.wayf__previousSelection');
+      cy.notBeVisible(selectedIdpsSectionSelector);
     });
 
     it('Test the add account button opens up the search & puts focus on the search field, then select the focused element.', () => {
       cy.addOnePreviouslySelectedIdp();
       cy.selectAccountButton();
-      cy.focused().should('have.class', 'search__field');
-      cy.notBeVisible('.wayf__previousSelection');
+      cy.focused().should('have.class', searchFieldClass);
+      cy.notBeVisible(selectedIdpsSectionSelector);
     });
 
     it('Test deleting the last previously selected idp hides the section, shows the remaining idps, focuses on the searchbar & adds the deleted idp to the list', () => {
       cy.addOnePreviouslySelectedIdp();
-      cy.hitDeleteButton(false, '.wayf__previousSelection li:first-of-type .wayf__idp .idp__deleteDisable');
-      cy.focused().should('have.class', 'search__field');
-      cy.notBeVisible('.previousSelection__addAccount');
+      cy.hitDeleteButton(false, firstSelectedIdpDeleteDisable);
+      cy.focused().should('have.class', searchFieldClass);
+      cy.notBeVisible(addAccountButtonSelector);
     });
 
     it('Test the remaining list contains the deleted idp & is sorted alphabetically', () => {
       cy.addOnePreviouslySelectedIdp();
-      cy.hitDeleteButton(false, '.wayf__previousSelection li:first-of-type .wayf__idp .idp__deleteDisable');
+      cy.hitDeleteButton(false, firstSelectedIdpDeleteDisable);
       cy.get('.wayf__remainingIdps .wayf__idp[data-entityid="https://example.com/entityId/1"]').should('exist');
-      cy.get('.wayf__remainingIdps li:first-of-type .wayf__idp').should('have.attr', 'data-index', '1');
+      cy.get(firstRemainingIdp).should('have.attr', 'data-index', '1');
     });
   });
 });

--- a/theme/cypress/integration/skeune/wayf/wayf.mouse.spec.js
+++ b/theme/cypress/integration/skeune/wayf/wayf.mouse.spec.js
@@ -1,3 +1,6 @@
+import {addAccountButtonSelector, cancelButtonSelector, defaultIdpItemSelector, defaultIdpSelector, noAccessTitle, noAccessFieldsetsSelector, previousSelectionTitleSelector, remainingIdpSelector, searchFieldClass,  selectedIdpsSelector, selectedIdpsSectionSelector, showFormSelector, submitRequestSelector, succesMessageSelector} from '../../../../base/javascripts/selectors';
+import {firstRemainingIdp, firstSelectedIdpDeleteDisable, selectedIdpDataIndex1} from '../testSelectors';
+
 /**
  * Tests for behaviour of the WAYF which depends on the mouse
  */
@@ -5,7 +8,7 @@ context('WAYF when using the mouse', () => {
   describe('Test logging in', () => {
     it('Should login when selecting an idp', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf');
-      cy.get('.wayf__remainingIdps .wayf__idp')
+      cy.get(remainingIdpSelector)
         .eq(1)
         .click({force: true});
       cy.location().should((loc) => {
@@ -18,44 +21,44 @@ context('WAYF when using the mouse', () => {
   describe('Should show a fully functional no access section when a disabled account is selected', () => {
     it('Should show the no access section on selecting a disabled account', () => {
       cy.openUnconnectedIdp(false);
-      cy.contains('.noAccess__title', 'Sorry, no access for this account');
+      cy.contains(noAccessTitle, 'Sorry, no access for this account');
     });
 
     it('Should not show the form elements yet', () => {
       cy.openUnconnectedIdp(false);
-      cy.get('.noAccess__requestForm fieldset')
+      cy.get(noAccessFieldsetsSelector)
         .should('not.be.visible');
     });
 
     it('Should have a functioning cancel button', () => {
       cy.openUnconnectedIdp(false);
-      cy.get('.cta__showForm').click({force: true});
-      cy.get('.cta__cancel').click({force: true});
-      cy.get('.noAccess__title')
+      cy.get(showFormSelector).click({force: true});
+      cy.get(cancelButtonSelector).click({force: true});
+      cy.get(noAccessTitle)
         .should('not.be.visible');
     });
 
     it('Should show the form fields after hitting request access', () => {
       cy.openUnconnectedIdp(false);
-      cy.get('.cta__showForm').click({force: true});
-      cy.get('.noAccess__requestForm fieldset')
+      cy.get(showFormSelector).click({force: true});
+      cy.get(noAccessFieldsetsSelector)
         .should('be.visible');
     });
 
     it('Should hide form fields after hitting cancel', () => {
       cy.openUnconnectedIdp(false);
-      cy.get('.cta__showForm').click({force: true});
-      cy.get('.cta__cancel').click({force: true});
+      cy.get(showFormSelector).click({force: true});
+      cy.get(cancelButtonSelector).click({force: true});
       cy.get('.wayf__idp[data-entityid="https://unconnected.example.com/entityId/2"]').click({force: true});
-      cy.get('.noAccess__requestForm fieldset')
+      cy.get(noAccessFieldsetsSelector)
         .should('not.be.visible');
     });
 
     it.skip('Should show the success message', () => {
       cy.fillNoAccessForm(false);
-      cy.get('.cta__request').click({force: true});
-      cy.get('.noAccess__title').should('not.be.visible');
-      cy.get('.notification__success').should('be.visible');
+      cy.get(submitRequestSelector).click({force: true});
+      cy.get(noAccessTitle).should('not.be.visible');
+      cy.get(succesMessageSelector).should('be.visible');
     });
 
     it('Should be able to fill the request access form', () => {
@@ -64,18 +67,18 @@ context('WAYF when using the mouse', () => {
 
     it('Should not show the success message when selecting a new disabled account', () => {
       cy.fillNoAccessForm(false);
-      cy.get('.cta__request').click({force: true});
+      cy.get(submitRequestSelector).click({force: true});
       cy.wait(500);
       cy.get('.wayf__idp[data-entityid="https://unconnected.example.com/entityId/3').click({force: true});
-      cy.get('.notification__success').should('not.be.visible');
+      cy.get(succesMessageSelector).should('not.be.visible');
     });
 
     it('Should also not show the form fields after selecting a new disabled account', () => {
       cy.fillNoAccessForm(false);
-      cy.get('.cta__request').click({force: true});
+      cy.get(submitRequestSelector).click({force: true});
       cy.wait(500);
       cy.get('.wayf__idp[data-entityid="https://unconnected.example.com/entityId/3').click({force: true});
-      cy.get('.noAccess__requestForm fieldset')
+      cy.get(noAccessFieldsetsSelector)
         .should('not.be.visible');
     });
   });
@@ -83,15 +86,15 @@ context('WAYF when using the mouse', () => {
   describe('Should have a working default Idp Banner', () => {
     it('Should have a default Idp banner visible', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?showIdpBanner=1');
-      cy.get('.wayf__defaultIdpLink').should('be.visible');
+      cy.get(defaultIdpSelector).should('be.visible');
     });
 
     it('Should scroll to the default Idp when clicking the banner link', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=10&defaultIdpEntityId=https://example.com/entityId/9&showIdpBanner=1');
 
       // click the banner link & check if it did what it should have
-      cy.get('.wayf__defaultIdpLink').click();
-      cy.get('#defaultIdp')
+      cy.get(defaultIdpSelector).click();
+      cy.get(defaultIdpItemSelector)
         .should('be.visible')
         .should('have.focus');
     });
@@ -100,25 +103,25 @@ context('WAYF when using the mouse', () => {
   describe('Should show a fully functional previous selection section', () => {
     it('Test if the previous section exists with the right title', () => {
       cy.addOnePreviouslySelectedIdp(false);
-      cy.get('.previousSelection__title')
+      cy.get(previousSelectionTitleSelector)
         .should('be.visible');
     });
 
       it('Test if the section contains the use account button', () => {
         cy.addOnePreviouslySelectedIdp(false);
-        cy.get('.previousSelection__addAccount')
+        cy.get(addAccountButtonSelector)
           .should('be.visible');
       });
 
     it('Test if it contains the right amount of idps', () => {
       cy.addOnePreviouslySelectedIdp(false);
-      cy.get('.wayf__previousSelection .wayf__idp')
+      cy.get(selectedIdpsSelector)
         .should('have.length', 1);
     });
 
     it('Test if selecting a previously selected idp works', () => {
       cy.addOnePreviouslySelectedIdp(false);
-      cy.selectFirstIdp(true, '.wayf__previousSelection .wayf__idp[data-index="1"]');
+      cy.selectFirstIdp(true, selectedIdpDataIndex1);
       cy.location().should((loc) => {
         expect(loc.href).to.eq('https://engine.vm.openconext.org/?idp=https%3A//example.com/entityId/1');
       });
@@ -126,16 +129,16 @@ context('WAYF when using the mouse', () => {
 
     it('Test if the count was raised on the selected idp', () => {
       cy.addOnePreviouslySelectedIdp(false);
-      cy.selectFirstIdp(true, '.wayf__previousSelection .wayf__idp[data-index="1"]');
+      cy.selectFirstIdp(true, selectedIdpDataIndex1);
       cy.loadWayf();
-      cy.get('.wayf__previousSelection .wayf__idp[data-index="1"]').should('have.attr', 'data-count', '2');
+      cy.get(selectedIdpDataIndex1).should('have.attr', 'data-count', '2');
     });
 
     it('Test the add account button opens up the search & puts focus on the search field, then select the focused element.', () => {
       cy.addOnePreviouslySelectedIdp(false);
       cy.selectAccountButton(false);
-      cy.focused().should('have.class', 'search__field');
-      cy.get('.wayf__previousSelection').should('not.be.visible');
+      cy.focused().should('have.class', searchFieldClass);
+      cy.get(selectedIdpsSectionSelector).should('not.be.visible');
     });
 
     it('Test the edit button allows deleting an account', () => {
@@ -151,16 +154,16 @@ context('WAYF when using the mouse', () => {
 
     it('Test deleting the last previously selected idp hides the section, shows the remaining idps, focuses on the searchbar & adds the deleted idp to the list', () => {
       cy.addOnePreviouslySelectedIdp(false);
-      cy.hitDeleteButton(true, '.wayf__previousSelection li:first-of-type .wayf__idp .idp__deleteDisable');
-      cy.focused().should('have.class', 'search__field');
-      cy.get('.previousSelection__addAccount').should('not.be.visible');
+      cy.hitDeleteButton(true, firstSelectedIdpDeleteDisable);
+      cy.focused().should('have.class', searchFieldClass);
+      cy.get(addAccountButtonSelector).should('not.be.visible');
     });
 
     it('Test the remaining list contains the deleted idp & is sorted alphabetically', () => {
       cy.addOnePreviouslySelectedIdp(false);
-      cy.hitDeleteButton(true, '.wayf__previousSelection li:first-of-type .wayf__idp .idp__deleteDisable');
+      cy.hitDeleteButton(true, firstSelectedIdpDeleteDisable);
       cy.get('.wayf__remainingIdps .wayf__idp[data-entityid="https://example.com/entityId/1"]').should('exist');
-      cy.get('.wayf__remainingIdps li:first-of-type .wayf__idp').should('have.attr', 'data-index', '1');
+      cy.get(firstRemainingIdp).should('have.attr', 'data-index', '1');
     });
   });
 });


### PR DESCRIPTION
Couple cypress tests to same selectors

Prior to this change cypress tests were entirely decoupled from the selectors used in the rest of the application.  This resulted in tests breaking when one of those selectors was changed.

This change imports the selectors from the same file as the one used by the application JS, so that both have a single source of truth.  In instances where special test selectors are needed, a test-selector file is used which composes it's selectors maximally by incorporating the "normal" selectors.

[Issue brought up as part of fixing the IE11 bug for the latest feedback round](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam)