### PR TITLE
Adjust styling of PEP page

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -162,6 +162,8 @@ Below you'll find a list of the "entry points" for each page with corresponding 
 
 - wayf: `templates > modules > authentication > view > proxy > wayf.html.twig `.  You can use `https://engine.vm.openconext.org/functional-testing/wayf` to develop the page.
 - error: `templates > modules > default > view > error > error.html.twig`.  You can use `https://engine.vm.openconext.org/feedback/unknown-error` to develop the page.
+There are a lot of error pages.  To test all different kinds, you can use the urls on this page: `https://github.com/OpenConext/OpenConext-engineblock/blob/master/theme/cypress/visual-regression/ErrorPage.spec.js#L72`
+
 - redirect page: `templates > modules > authentication > view > proxy > redirect.html.twig`.
 - spinner page: `templates > modules > authentication > view > proxy > form.html.twig`.  To test it disable the onload handler on the body-tag and go to your profile (or load the page without JS).
 - index.html.twig: `templates > modules > authentication > view > index > index.html.twig`.  You can use `https://engine.vm.openconext.org/` to develop the page.

--- a/theme/base/stylesheets/pages/error-page.scss
+++ b/theme/base/stylesheets/pages/error-page.scss
@@ -31,3 +31,11 @@ body {
         }
     }
 }
+
+.error-message--no-bold {
+    font-weight: normal;
+
+    .error-title__error-message--institution {
+        font-weight: $boldest;
+    }
+}

--- a/theme/base/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
@@ -6,7 +6,6 @@
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}
-
     <h2>{{ 'error_authorization_policy_violation_info'|trans|raw }}</h2>
 
     {% if logo is not null %}
@@ -14,6 +13,7 @@
              class="pull-right"
              width="{{ logo.width }}"
              height="{{ logo.height }}"
+             alt=""
         >
     {% endif %}
 
@@ -28,6 +28,8 @@
     {{ 'error_authorization_policy_violation_desc'|trans|raw }}
 
 {% endblock %}
+
+{% block errorMessageClass %}error-message--no-bold{% endblock %}
 
 {# The PDP error page should not show the table with the feedback information and back button. #}
 {% block feedbackInfo %}{% endblock %}

--- a/theme/base/templates/modules/Default/View/Error/error.html.twig
+++ b/theme/base/templates/modules/Default/View/Error/error.html.twig
@@ -34,7 +34,7 @@
         <main class="error-container__content">
             <div class="error-title">
                 <h1 class="error-title__heading">{% block pageTitle %}{% endblock %}</h1>
-                <div class="error-title__error-message">{% block errorMessage %}{% endblock %}</div>
+                <div class="error-title__error-message {% block errorMessageClass %}{% endblock %}">{% block errorMessage %}{% endblock %}</div>
             </div>
 
             {# Some error pages omit the feedback info entirily. To ensure we do not show the intro text, check if the block is empty #}


### PR DESCRIPTION
Prior to this change the text in the error message was bolded.

This change changes the bold error message to a normal weight error message.  It also adds, in the readme, a link to the page containing functional testing endpoints for all different error pages, so they can be tested.
Last but not least an accessibility improvement was included: the logo now has an empty alt text.

[Issue discovered as part of fixing tickets for the latest feedback round](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam)