### PR TITLE
Fix IE11 disabled hand bug

### DIFF
--- a/theme/base/javascripts/wayf/idpFocus/arrowUp.js
+++ b/theme/base/javascripts/wayf/idpFocus/arrowUp.js
@@ -30,7 +30,6 @@ export const arrowUp = () => {
   const lastIdp = remainingIdps[remainingIdps.length - 1];
 
   if (isFocusOn(searchBar) || isFocusOn(resetButton)) {
-    console.log({lastIdp});
     focusAndSmoothScroll(lastIdp);
     return;
   } else if (isFocusOn(firstIdp)) {

--- a/theme/base/javascripts/wayf/idpFocus/checkHover.js
+++ b/theme/base/javascripts/wayf/idpFocus/checkHover.js
@@ -8,9 +8,13 @@ import {isHoverOnArrowItem} from './isHoverOnArrowItem';
  */
 
 export function checkHover(e) {
-  const focusOnArrowItem = isFocusOnArrowItem(document.activeElement);
-  if (focusOnArrowItem) {
-    return false;
+  const focusedElement = document.activeElement;
+
+  if (!!focusedElement) {
+    const focusOnArrowItem = isFocusOnArrowItem(focusedElement);
+    if (focusOnArrowItem) {
+      return false;
+    }
   }
 
   const hoveredItem = isHoverOnArrowItem(e.target);

--- a/theme/base/stylesheets/pages/wayf/idpList.scss
+++ b/theme/base/stylesheets/pages/wayf/idpList.scss
@@ -190,5 +190,25 @@
                 }
             }
         }
+
+        &.remaining {
+            > .wayf__idp {
+                > .idp__content {
+                    > .idp__deleteDisable {
+                        display: none;
+                    }
+                }
+            }
+
+            &.idpItem--noAccess {
+                > .wayf__idp {
+                    > .idp__content {
+                        > .idp__deleteDisable {
+                            display: flex;
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpItem.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpItem.html.twig
@@ -5,7 +5,7 @@
 {% endif %}
 
 <li
-    class="{% if idp['connected'] is defined and not idp['connected'] %}idpItem--noAccess{% endif %}"
+    class="{{ listName }}{% if idp['connected'] is defined and not idp['connected'] %} idpItem--noAccess{% endif %}"
     data-count="{% if idp['count'] is defined %}{{ idp['count'] }}{% else %}0{% endif %}"
     data-entityid="{{ idp['entityId'] }}"
     data-index="{{ loop.index }}"


### PR DESCRIPTION
Prior to this change, the connected idps in IE11 showed the disabled button even when not disabled.  This only happened on test2.

This change hides the delete-disabled button by default for remaining idps, and shows it only for those who are disabled.
It also cleans up a forgotten console.log statement, and adds some conditional logic to ensure that the focusOnArrowItem check only happens if there is a focused element (cleaning up the console in IE).

[Issue discovered as part of fixing tickets for the latest feedback round](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam)