### PR TITLE
Update security checker to use local checker

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -125,7 +125,7 @@ jobs:
               run: |
                   cd docker && docker-compose exec -T php-fpm.vm.openconext.org bash -c '
                       echo -e "\nSensioLabs Security Check\n" && \
-                      ./vendor/bin/security-checker security:check && \
+                      ./bin/securityChecker.sh && \
                       cd theme && \
                       echo -e "\nNPM Audit\n" && \
                       npm run audit

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/ignore_me.php
 /app/config/parameters.yml
 /app/config/config_local.yml
 .idea
+local-php-security-checker
 /languages/overrides.*.php
 /theme/node_modules
 /theme/.sass-cache

--- a/bin/securityChecker.sh
+++ b/bin/securityChecker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if curl -sL https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_amd64 > local-php-security-checker; then
+    chmod +x ./local-php-security-checker
+    ./local-php-security-checker
+    rm ./local-php-security-checker
+else
+    printf 'Curl failed downloading php-security-checker with error code "%d"\n' "$?" >&2
+    exit 1
+fi

--- a/build.xml
+++ b/build.xml
@@ -131,9 +131,7 @@
     </target>
 
     <target name="security-checker" description="Check for vulnerable dependencies with SensioLabs Security Checker">
-        <exec dir="${basedir}" executable="vendor/bin/security-checker" failonerror="true">
-            <arg value="security:check" />
-        </exec>
+        <exec dir="${basedir}" executable="bin/securityChecker.sh" failonerror="true"></exec>
     </target>
 
     <target name="npm-lint" description="Performs the linting of css and js">


### PR DESCRIPTION
The composer depencency is no longer operable, and was removed. This
change uses the new way of running the checker, which is to download the
local checker binary an running that.