### PR TITLE
Keep WAYF operable when syncing cookies

### DIFF
--- a/theme/base/javascripts/wayf/matchPreviouslySelectedWithCookie.js
+++ b/theme/base/javascripts/wayf/matchPreviouslySelectedWithCookie.js
@@ -4,61 +4,74 @@ import {sortIdpList} from './utility/sortIdpList';
 import {getData} from '../utility/getData';
 
 export const matchPreviouslySelectedWithCookie = () => {
-  const cookieName = JSON.parse(document.getElementById(configurationId).innerHTML).previousSelectionCookieName;
-  const selectedIdps = document.querySelectorAll(selectedIdpsSelector);
-  const selectedIdpList = document.querySelector(selectedIdpsListSelector);
-  let cookie = Cookies.get(cookieName);
-  let listMustBeSorted = false;
+  try {
+    const cookieName = JSON.parse(document.getElementById(configurationId).innerHTML).previousSelectionCookieName;
+    const selectedIdps = document.querySelectorAll(selectedIdpsSelector);
+    const selectedIdpList = document.querySelector(selectedIdpsListSelector);
+    let cookie = Cookies.get(cookieName);
+    let listMustBeSorted = false;
 
-  if (cookie) {
-    if (selectedIdps) {
-      for (const idp of selectedIdps) {
-        const id = getData(idp, 'entityid');
+    if (cookie) {
+      if (selectedIdps) {
+        for (const idp of selectedIdps) {
+          const id = getData(idp, 'entityid');
 
-        // check if idp is in cookie, if not remove it from the list
-        if (cookie && cookie.indexOf(id) === -1) {
-          idp.parentElement.remove();
-          listMustBeSorted = true;
+          // check if idp is in cookie, if not remove it from the list
+          if (cookie && cookie.indexOf(id) === -1) {
+            idp.parentElement.remove();
+            listMustBeSorted = true;
+          }
         }
+      }
+
+      cookie = JSON.parse(cookie);
+      // check if each idp in the cookie is in the list, if not add it
+      cookie.forEach(idp => {
+        const id = `[data-entityid="${idp.idp}"]`;
+        const inPreviouslySelected = document.querySelector(`${selectedIdpsSelector}${id}:first-of-type`);
+
+        if (!inPreviouslySelected) {
+          const deleteButtonTemplate = document.getElementById(deleteButtonTemplateId);
+          const original = document.querySelector(`${remainingIdpSelector}${id}`);
+          let clone = null;
+          let hasDeleteDisabledButton = null;
+
+          // not all Idps are always in the list
+          if (!!original) {
+            clone = original.parentElement.cloneNode(true);
+            hasDeleteDisabledButton = clone.querySelector(idpDeleteDisabledSelector);
+          }
+
+          if (!!clone) {
+            // disabled idps
+            if (hasDeleteDisabledButton) {
+              clone.querySelector(idpDeleteDisabledSelector).appendChild(deleteButtonTemplate.querySelector(idpDeleteSelector).cloneNode(true));
+            }
+
+            // non-disabled idps
+            if (!hasDeleteDisabledButton) {
+              clone.querySelector(`.${idpContentClass}`).appendChild(deleteButtonTemplate.content.cloneNode(true));
+            }
+
+            selectedIdpList.appendChild(clone);
+            listMustBeSorted = true;
+          }
+        }
+
+        if (inPreviouslySelected) {
+          const count = getData(inPreviouslySelected, 'count');
+          if (count !== idp.count) {
+            inPreviouslySelected.setAttribute('data-count', idp.count);
+          }
+        }
+      });
+
+      if (listMustBeSorted) {
+        const selectedIdpLis = document.querySelectorAll(selectedIdpsLiSelector);
+        sortIdpList(selectedIdpLis, 'previous');
       }
     }
-
-    cookie = JSON.parse(cookie);
-    // check if each idp in the cookie is in the list, if not add it
-    cookie.forEach(idp => {
-      const id = `[data-entityid="${idp.idp}"]`;
-      const inPreviouslySelected = document.querySelector(`${selectedIdpsSelector}${id}:first-of-type`);
-
-      if (!inPreviouslySelected) {
-        const deleteButtonTemplate = document.getElementById(deleteButtonTemplateId);
-        const clone = document.querySelector(`${remainingIdpSelector}${id}`).parentElement.cloneNode(true);
-        const hasDeleteDisabledButton = clone.querySelector(idpDeleteDisabledSelector);
-
-        // disabled idps
-        if (hasDeleteDisabledButton) {
-          clone.querySelector(idpDeleteDisabledSelector).appendChild(deleteButtonTemplate.querySelector(idpDeleteSelector).cloneNode(true));
-        }
-
-        // non-disabled idps
-        if (!hasDeleteDisabledButton) {
-          clone.querySelector(`.${idpContentClass}`).appendChild(deleteButtonTemplate.content.cloneNode(true));
-        }
-
-        selectedIdpList.appendChild(clone);
-        listMustBeSorted = true;
-      }
-
-      if (inPreviouslySelected) {
-        const count = getData(inPreviouslySelected, 'count');
-        if (count !== idp.count) {
-          inPreviouslySelected.setAttribute('data-count', idp.count);
-        }
-      }
-    });
-
-    if (listMustBeSorted) {
-      const selectedIdpLis = document.querySelectorAll(selectedIdpsLiSelector);
-      sortIdpList(selectedIdpLis, 'previous');
-    }
+  } catch (e) {
+    console.log(e);
   }
 };


### PR DESCRIPTION
Prior to this change, it was possible that the WAYF was rendered inoperable when syncing cookies.  This happened when an idp was in the cookie, but not available when connecting to a service.  The resulting null error in the JS rendered the entire wayf inoperable.

This change ensures the cookie-syncing doesn't freeze the WAYF.  The problem should be solved with the extra null checks.  But as the sync should never freeze the wayf, it is now wrapped in a try/catch block to be on the safe side.

Issue discovered as part of acceptation testing and [reported in the wiki](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam).  It can be tested on functional by adding some of the regular "fake idps" to your selected accounts (preferably only one), then testing with [the random idp link](https://engine.vm.openconext.org/functional-testing/wayf?randomIdps=20)