### PR TITLE
Correct display of tooltip for group attributes

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
@@ -90,11 +90,12 @@ class ConsentController
             'urn:mace:dir:attribute-def:givenName' => ['John'],
             'urn:mace:dir:attribute-def:mail' => ['j.doe@example.com'],
             'urn:mace:terena.org:attribute-def:schacHomeOrganization' => ['example.com'],
-            'urn:mace:dir:attribute-def:isMemberOf' => ['urn:collab:org:vm.openconext.org'],
+            'urn:mace:dir:attribute-def:isMemberOf' => ['urn:collab:org:vm.openconext.org', 'urn:collab:org:example.com'],
         ];
         $attributeMotivations = [
             'urn:mace:dir:attribute-def:eduPersonPrincipalName' => 'Test  tooltip',
             'urn:mace:dir:attribute-def:givenName' => 'Test tooltip',
+            'urn:mace:dir:attribute-def:isMemberOf' => 'Test tooltip',
         ];
 
         if ($attributeAggregationEnabled) {

--- a/theme/base/stylesheets/pages/consent/attribute.scss
+++ b/theme/base/stylesheets/pages/consent/attribute.scss
@@ -45,13 +45,13 @@
         text-align: left;
     }
 
-    > input[type="checkbox"]:checked.tooltip ~ .attribute__name > label.tooltip {
+    input[type="checkbox"]:checked.tooltip ~ .attribute__name > label.tooltip {
         @include closeTooltip;
         background-position: left 17px bottom 11px;
     }
 
-    > .ie11__label,
-    > .attribute__name > .label.tooltip {
+    .ie11__label,
+    .attribute__name > .label.tooltip {
         @include grid-position(1, 2, 5, 6);
 
         @include screen('mobile') {

--- a/theme/base/stylesheets/pages/consent/attributeValue.scss
+++ b/theme/base/stylesheets/pages/consent/attributeValue.scss
@@ -21,7 +21,14 @@
 }
 
 .attribute__valueWrapper {
+    @include grid-position(1, 2, 3, 6);
+
+    @include screen('mobile') {
+        @include grid-position(2, 3, 1, 2);
+    }
+
     > .attribute__value.attribute__value--list {
+        margin: 0;
         padding: 0;
 
         &.animated {
@@ -34,6 +41,24 @@
             max-height: 60vh;
         }
 
+        li:not(.consent__attributeNested--noTooltip) {
+            &:first-of-type {
+                .attribute__value {
+                    display: inline-block;
+                    padding-right: 0;
+                    width: 86.5%;
+                }
+
+                .ie11__label {
+                    display: inline-block;
+                    width: 12%;
+                }
+            }
+
+            .attribute__value {
+                padding-right: 1rem;
+            }
+        }
     }
 
     > .groupMembership__label {

--- a/theme/base/stylesheets/shared.scss
+++ b/theme/base/stylesheets/shared.scss
@@ -186,7 +186,7 @@ body {
 
     .tooltip__value {
         display: none;
-        text-align: right;
+        text-align: left;
     }
 
     .modal__value.animated,
@@ -215,6 +215,7 @@ body {
 
         // set max-height for tooltips
     input[type="checkbox"]:checked.tooltip ~ .tooltip__value.animated {
+        font-weight: $normal;
         max-height: initial;
     }
 

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
@@ -17,8 +17,8 @@
         {% endif %}
     {# Multiple attribute values #}
     {% else %}
+        <div class="attribute__valueWrapper">
         {% if attributeValues|length > 5 %}
-            <div class="attribute__valueWrapper">
                 {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/toggleCheckbox.html.twig' with {
                     className: 'groupMembership__checkbox',
                     id: 'attribute' ~ loop.index,
@@ -27,11 +27,11 @@
         {% endif %}
         <ul class="attribute__value attribute__value--list">
             {% for value in attributeValues %}
-                <li>
+                <li {% if not addTooltip %}class="consent__attributeNested--noTooltip"{% endif %}>
                     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: value } %}
-                    {% if addTooltip %}
+                    {% if addTooltip and loop.first %}
                         <input type="checkbox" tabindex="-1" aria-hidden="true" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}" />
-                        {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with { tooltipValue: attributeMotivations[attributeIdentifier] } %}
+                        {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with { tooltipValue: attributeMotivations[attributeIdentifier], id: id } %}
                     {% endif %}
                 </li>
             {% endfor %}
@@ -44,8 +44,8 @@
                 showLess: 'consent_groupmembership_show_less',
               }
             %}
-            </div>
         {% endif %}
+        </div>
     {% endif %}
 </li>
 

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig
@@ -1,5 +1,7 @@
 {% if tooltipValue %}
-    {% set id = 'tooltip%index%%orgId%'|replace({ '%index%': loop.index, '%orgId%': orgId })|trim %}
+    {% if not id %}
+        {% set id = 'tooltip%index%%orgId%'|replace({ '%index%': loop.index, '%orgId%': orgId })|trim %}
+    {% endif %}
     <div class="ie11__label">
         {% include '@theme/Default/Partials/label.html.twig' with
             {

--- a/theme/cypress/integration/skeune/consent/consent.general.spec.js
+++ b/theme/cypress/integration/skeune/consent/consent.general.spec.js
@@ -9,7 +9,7 @@ context('Consent on Skeune theme', () => {
   describe('Handles additional attributes correctly', () => {
     it('shows the correct amount of attributes on load', () => {
       cy.get(attributesSelector)
-        .should('have.length', '11');
+        .should('have.length', '13');
       cy.get(attribute6)
         .should('have.css', 'height', '1px')
         .should('have.css', 'width', '1px');


### PR DESCRIPTION
Correct display of tooltip for group attributes

Prior to this change, goup attributes had their tooltip on every row.  The icon for the tooltip was below the value instead of next to it (as for normal attributes) and the tooltip become bold.

This change ensures the tooltip doesn't repeat, the icon is positioned properly and the text of the tooltip is normal weight.

The before screenshot is present in the wiki page mentioned below.  The after screenshot looks like this:
![image](https://user-images.githubusercontent.com/4058016/107494848-9341f200-6b8f-11eb-976e-f1490e464de9.png)

Testing can be done by changing line 93-98 of the ConsentController in the functional testing bundle to:
```
            'urn:mace:dir:attribute-def:isMemberOf' => [
                'urn:collab:org:vm.openconext.org',
                'urn:collab:org:vm.openconext.org2:biefstuk:met:frietjes',
                'urn:collab:org:vm.openconext.org3:witloof:in:den:oven',
                'urn:collab:org:vm.openconext.org4:vanillepudding:met:speculoos',
                'urn:collab:org:vm.openconext.org5:ooohooohohoohoooo:n:potje:choco',
                'urn:collab:org:vm.openconext.org6:schatjes:van:patatjes',
                'urn:collab:org:vm.openconext.org8:1:reep:chocola:is:geen:reep:chocola',
            ],
        ];
        $attributeMotivations = [
            'urn:mace:dir:attribute-def:eduPersonPrincipalName' => 'Test  tooltip',
            'urn:mace:dir:attribute-def:givenName' => 'Test tooltip',
            'urn:mace:dir:attribute-def:isMemberOf' => 'Test tooltip'
        ];
```

Issue discovered as part of acceptation testing and [reported on the wiki](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam).