### PR TITLE
Ensure IdPs are deletable after sync

### DIFF
--- a/theme/base/javascripts/wayf/matchPreviouslySelectedWithCookie.js
+++ b/theme/base/javascripts/wayf/matchPreviouslySelectedWithCookie.js
@@ -43,6 +43,7 @@ export const matchPreviouslySelectedWithCookie = () => {
           }
 
           if (!!clone) {
+            clone.classList.remove('remaining');
             // disabled idps
             if (hasDeleteDisabledButton) {
               clone.querySelector(idpDeleteDisabledSelector).appendChild(deleteButtonTemplate.querySelector(idpDeleteSelector).cloneNode(true));


### PR DESCRIPTION
Prior to this change, idps added to selected accounts after cookie sync were not deletable because they still had the "remaining" class on them.

This change removes that class ensuring the newly added idp is also deletable.

Steps to reproduce:
- have one previously selected account
- choose a new account to  log in with
- hit the backbutton
- try to delete the newly added account => shouldn't work before this fix, should work after

Issue discovered as part of acceptation testing and [reported on the wiki](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam).