### PR TITLE
Avoid double encoding logo url for attribute source.

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/source.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/source.html.twig
@@ -15,7 +15,7 @@
             <span class="idpRow__providedBy-content">{{ 'consent_provided_by'|trans }}  <strong>{{ organisationName }}</strong></span>
         {% endset %}
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig' with {
-            logoUrl: attributeSourceLogoUrl(attributeSource)|escape('html_attr'),
+            logoUrl: attributeSourceLogoUrl(attributeSource),
             organisationName: organisationName,
             text: consentProvidedByOrg,
         } %}


### PR DESCRIPTION
Before, the resulting HTML looked like this:

```html
<img class="logo-small" src="https&#x3A;&#x2F;&#x2F;static.surfconext.nl&#x2F;media&#x2F;aa&#x2F;voot.png?v=6.4.6" alt="">
```

As a side note, this url comes from our own translations files.