### PR TITLE
Ensure images after search are ok in IE11

### DIFF
--- a/theme/base/javascripts/wayf/utility/convertIdpArrayToHtml.js
+++ b/theme/base/javascripts/wayf/utility/convertIdpArrayToHtml.js
@@ -35,6 +35,7 @@ function getIdpContent(idp) {
   const id = getData(idp, 'entityid');
   const connectable = getData(idp, 'connectable');
   const defaultIdp = getData(idp, 'defaultidp');
+  const logoUrl = getData(idp, 'url');
   const className = idp.classList.contains(unconnectedLiClass) ? `${idpClass} ${unconnectedIdpClass}` : idpClass;
   const clone = template.cloneNode(true);
 
@@ -49,6 +50,7 @@ function getIdpContent(idp) {
   }
   clone.querySelector(`.${idpTitleClass}`).innerText = title;
   clone.querySelector('[name="idp"]').value = id;
+  clone.querySelector('img').setAttribute('src', logoUrl);
 
   return clone;
 }

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpItem.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpItem.html.twig
@@ -4,6 +4,12 @@
     {% set connectable = 'false' %}
 {% endif %}
 
+{% if idp.logo is not null %}
+    {% set logoUrl = idp.logo %}
+{% else %}
+    {% set logoUrl = '/images/placeholder.png' %}
+{% endif %}
+
 <li
     class="{{ listName }}{% if idp['connected'] is defined and not idp['connected'] %} idpItem--noAccess{% endif %}"
     data-count="{% if idp['count'] is defined %}{{ idp['count'] }}{% else %}0{% endif %}"
@@ -14,6 +20,7 @@
     {% if idp['isDefaultIdp'] %}data-defaultidp="defaultIdp"{% endif %}
     data-describedby="idp__title{{ listName }}{{ loop.index }}"
     data-connectable="{{ connectable }}"
+    data-url="{{ logoUrl }}"
 >
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig' with { idp: idp } %}
 </li>


### PR DESCRIPTION
Prior to this change, when searching all logos became the same placeholder logo in IE11 only.

This change ensures the image url is the correct one, so the logo is the correct one.

Issue discovered as part of acceptation testing and [reported on the wiki](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam).