### PR TITLE
Prevent logo flicker in FF when possible

### DIFF
--- a/theme/base/javascripts/wayf/searchBehaviour.js
+++ b/theme/base/javascripts/wayf/searchBehaviour.js
@@ -11,21 +11,33 @@ export const searchBehaviour = () => {
   const searchBar = document.querySelector(searchFieldSelector);
   const resetButton = document.querySelector(searchResetSelector);
   const idpArray = nodeListToArray(idpList);
+  let previousSearchTerm = '';
 
   // attach handler to search field
-  searchBar.addEventListener('keyup', throttle(event => searchAndSortIdps(idpArray, event.target.value), 250));
+  searchBar.addEventListener('keyup', throttle(event => searchHandler(idpArray, event.target.value), 250));
   searchBar.addEventListener('keyup', event => toggleDefaultIdPLinkVisibility(event.target.value));
   searchBar.addEventListener('keyup',  event => toggleSearchAndResetButton(idpArray, event.target.value));
-  searchBar.addEventListener('click', event => searchAndSortIdps(idpArray, event.target.value));
-  searchBar.addEventListener('input', event => searchAndSortIdps(idpArray, event.target.value));
+  searchBar.addEventListener('click', event => searchHandler(idpArray, event.target.value));
+  searchBar.addEventListener('input', event => searchHandler(idpArray, event.target.value));
 
   resetButton.addEventListener('click', () => {
     toggleSearchAndResetButton(idpArray, '');
     focusAndSmoothScroll(searchBar);
+    previousSearchTerm = '';
   });
   // attach handler to search form
   document.querySelector('.wayf__search').addEventListener('submit', event => {
     event.preventDefault();
     searchAndSortIdps(idpArray, event.target.value);
   });
+
+  function searchHandler(idpArray, searchTerm) {
+    if (searchTerm === previousSearchTerm) {
+      return;
+    }
+
+    searchAndSortIdps(idpArray, event.target.value);
+    previousSearchTerm = searchTerm;
+  }
 };
+


### PR DESCRIPTION
Prior to this change, the logo flickers in FF whenever there's an interaction with the search bar.

This change limits the flicker to actual redraws of the idp list by preventing the search handler from being triggered if the previous search term matches the current one.

Issue discovered as part of acceptation testing and [reported on the wiki](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam).