### PR TITLE
Prevent idprow-logo from overlapping with text

### DIFF
--- a/theme/base/stylesheets/pages/consent/idpRow.scss
+++ b/theme/base/stylesheets/pages/consent/idpRow.scss
@@ -1,6 +1,6 @@
 .idpRow {
     @include display-grid;
-    @include grid-template-columns(10% 1% 50% 1% 37% 1%);
+    @include grid-template-columns(10% 3% 48% 1% 37% 1%);
     align-items: center;
     background-color: $providerGray;
     border-bottom: 1px solid $softBorderGray;
@@ -12,7 +12,7 @@
     text-align: left;
 
     @include screen('mobile') {
-        @include grid-template-columns(10% 6% 83% 1%);
+        @include grid-template-columns(15% 6% 78% 1%);
         @include grid-template-rows(min-content min-content);
         padding: 10px;
     }
@@ -28,8 +28,10 @@
     > img {
         @include grid-position(1, 2, 1, 2);
         box-sizing: content-box;
-        max-height: calculateRem(30px);
         margin-left: 9px;
+        max-height: calculateRem(30px);
+        max-width: 100%;
+        overflow: hidden;
     }
 
     label.modal {


### PR DESCRIPTION
Prior to this change, the logo in the idp-row could overlap with the text.

This change ensures that's no longer possible.  After the change this looks as follows now: 
![image](https://user-images.githubusercontent.com/4058016/107640533-b7c2ca80-6c72-11eb-8c7f-9d14ce95e0bd.png)


Issue discovered as part of acceptation testing and [reported on the wiki](https://wiki.surfnet.nl/display/coininfra/Bevindingen+nav+tests+door+supportteam).