### PR TITLE
Fix errors flagged by nu html checker

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/SVG/file_info.svg
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/SVG/file_info.svg
@@ -1,7 +1,7 @@
 <svg width="50" height="50" focusable="false" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
 <title></title>
-<g id="finfo-Group 10">
-<g id="finfo-Oval Copy" filter="url(#finfo-filter0_d)">
+<g id="finfo-Group">
+<g id="finfo-Oval" filter="url(#finfo-filter0_d)">
 <circle cx="25" cy="24" r="24" fill="#DFE3E8"/>
 </g>
 <g id="common-file-text">

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/SVG/shield_key.svg
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/SVG/shield_key.svg
@@ -1,6 +1,6 @@
 <svg width="50" height="50" focusable="false" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
 <title></title>
-<g id="shield-Group 11">
+<g id="shield-Group">
 <g id="shield-Oval" filter="url(#shield-filter0_d)">
 <circle cx="25" cy="24" r="24" fill="#DFE3E8"/>
 </g>

--- a/theme/base/templates/modules/Default/Partials/warning.html.twig
+++ b/theme/base/templates/modules/Default/Partials/warning.html.twig
@@ -1,6 +1,6 @@
-<section {% if className is defined %}class="{{ className }}"{% endif %}>
+<div {% if className is defined %}class="{{ className }}"{% endif %}>
     {% if notificationTitle is defined %}
         <h3>{{ notificationTitle }}</h3>
     {% endif %}
     {{ text|striptags('consent_warning_allowed_html'|trans)|replace({'<a ': '<a target="_blank" rel="noopener noreferrer" '})|raw }}
-</section>
+</div>


### PR DESCRIPTION
Prior to this change, there were 3 errors & one warning on the page: three wrong ids in the svgs & one section without a title (warning).

This change ensures that those errors & the warning are fixed.

Issue discovered while studying for WAS certification.