### PR TITLE
Handle accessibility for hideable attributes

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -114,6 +114,7 @@ HTML
     'send_confirm_desc'     => '<p>Your request has been forwarded to your %organisationNoun%. Further settlement and decisions on the availability of this service will be taken by the ICT staff of your %organisationNoun%.</p>',
 
     // Consent
+    'consent_attributes_screenreader'         => 'about %orgName%',
     'consent_attributes_show_more'            => 'Show more information',
     'consent_attributes_show_less'            => 'Show less information',
     'consent_no_attributes_text'              => 'This service requires no information from your %organisationNoun%.',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -111,6 +111,7 @@ HTML
     'send_confirm_desc'     => '<p>Je verzoek is doorgestuurd naar de juiste persoon binnen jouw %organisationNoun%. Het is aan deze persoon om actie te ondernemen op basis van jouw verzoek. Het kan zijn dat er nog afspraken gemaakt moeten worden tussen jouw %organisationNoun% en de dienstaanbieder.</p>',
 
     // Consent page
+    'consent_attributes_screenreader'         => 'over %orgName%',
     'consent_attributes_show_more'            => 'Toon alle gegevens',
     'consent_attributes_show_less'            => 'Toon minder gegevens',
     'consent_no_attributes_text'              => 'Voor deze dienst zijn geen gegevens van jouw %organisationNoun% nodig.',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -113,6 +113,7 @@ HTML
     'send_confirm_desc'     => '<p>A sua solicitação foi encaminha para a sua %organisationNoun%. As decisões para a disponibilidade deste serviço serão tomadas pela equipa de IT da sua %organisationNoun%.</p>',
 
     // Consent page
+    'consent_attributes_screenreader'         => 'about %orgName%',
     'consent_attributes_show_more'            => 'Mostrar mais informação',
     'consent_attributes_show_less'            => 'Mostrar menos informação',
     'consent_no_attributes_text'              => 'Este serviço não requer informações da sua instituição',

--- a/theme/base/javascripts/consent/addA11ySupport.js
+++ b/theme/base/javascripts/consent/addA11ySupport.js
@@ -1,7 +1,17 @@
-import {consentAnimateInteractiveElements, consentKeyboardBehaviourHandler} from '../handlers';
-import {consentAnimatedElementSelectors} from '../selectors';
+import {
+  consentAnimateInteractiveElements,
+  consentHandleInvisibleTooltips,
+  consentHideInvisibleTooltips,
+  consentKeyboardBehaviourHandler,
+  consentToggleTooltipPressedState,
+} from '../handlers';
+import {consentAnimatedElementSelectors, openToggleLabelSelector} from '../selectors';
+import {addClickHandlerOnce} from '../utility/addClickHandlerOnce';
 
 export const addAccessibilitySupport = () => {
   consentKeyboardBehaviourHandler();
   consentAnimateInteractiveElements(consentAnimatedElementSelectors);
+  consentHideInvisibleTooltips();
+  addClickHandlerOnce(openToggleLabelSelector, consentHandleInvisibleTooltips);
+  consentToggleTooltipPressedState();
 };

--- a/theme/base/javascripts/consent/handleInvisibleTooltips.js
+++ b/theme/base/javascripts/consent/handleInvisibleTooltips.js
@@ -1,0 +1,29 @@
+import {consentHideInvisibleTooltips, consentShowInvisibleTooltips} from '../handlers';
+import {
+  firstInvisibleAttributeSelector,
+  invisibleTooltipLabelsSelector,
+  openToggleLabelSelector,
+  showMoreCheckboxId
+} from '../selectors';
+import {changeAriaExpanded} from '../utility/changeAriaExpanded';
+import {changeAriaPressed} from '../utility/changeAriaPressed';
+
+export const handleInvisibleTooltips = () => {
+  const firstInvisibleTooltip = document.querySelector(invisibleTooltipLabelsSelector);
+  const firstInvisibleAttribute = document.querySelector(firstInvisibleAttributeSelector);
+  const showMoreCheckbox = document.getElementById(showMoreCheckboxId);
+  const isHidden = firstInvisibleTooltip.getAttribute('tabindex') === "-1";
+
+  changeAriaExpanded(showMoreCheckbox);
+  changeAriaPressed(showMoreCheckbox);
+
+  if (isHidden) {
+    consentShowInvisibleTooltips();
+    firstInvisibleAttribute.setAttribute('tabindex', "-1");
+    firstInvisibleAttribute.focus({preventScroll: true});
+    return;
+  }
+
+  consentHideInvisibleTooltips();
+  document.querySelector(openToggleLabelSelector).focus({preventScroll: true});
+};

--- a/theme/base/javascripts/consent/hideInvisibleTooltips.js
+++ b/theme/base/javascripts/consent/hideInvisibleTooltips.js
@@ -1,0 +1,8 @@
+import {invisibleTooltipLabelsSelector} from '../selectors';
+
+export const hideInvisibleTooltips = () => {
+  const invisibleTooltips = document.querySelectorAll(invisibleTooltipLabelsSelector);
+  invisibleTooltips.forEach(label => {
+    label.setAttribute('tabindex', "-1");
+  });
+};

--- a/theme/base/javascripts/consent/keyboardBehaviour.js
+++ b/theme/base/javascripts/consent/keyboardBehaviour.js
@@ -1,4 +1,6 @@
 import {consentEnterHandler} from '../handlers';
+import {fireClickEvent} from '../utility/fireClickEvent';
+import {getData} from '../utility/getData';
 
 /**
  * Make all behaviour that's possible with a mouse also keyboard accessible.
@@ -13,10 +15,36 @@ import {consentEnterHandler} from '../handlers';
  */
 export const keyboardBehaviour = () => {
   const ENTER      = 13;
+  const SPACE      = 32;
+  const TAB        = 9;
 
   document.querySelector('body').addEventListener('keydown', function(e) {
-    if (e.keyCode === ENTER) {
-      consentEnterHandler(e.target);
+    const classList = e.target.classList;
+    switch (e.keyCode) {
+      case ENTER:
+        consentEnterHandler(e.target);
+        break;
+      case SPACE:
+        classList.forEach(className => {
+          switch (className) {
+            case 'openToggle__label':
+            case 'showLess':
+            case 'showMore':
+              fireClickEvent(e.target);
+              break;
+          }
+        });
+        break;
+      case TAB:
+        classList.forEach(className => {
+          switch (className) {
+            case 'tooltip__value':
+              const dataFor = getData(e.target, 'for');
+              document.querySelector(`[for=${dataFor}]`).focus();
+              break;
+          }
+        });
+        break;
     }
   });
 };

--- a/theme/base/javascripts/consent/showInvisibleTooltips.js
+++ b/theme/base/javascripts/consent/showInvisibleTooltips.js
@@ -1,0 +1,9 @@
+import {invisibleTooltipLabelsSelector} from '../selectors';
+
+export const showInvisibleTooltips = () => {
+  const invisibleTooltips = document.querySelectorAll(invisibleTooltipLabelsSelector);
+
+  invisibleTooltips.forEach(label => {
+    label.setAttribute('tabindex', "0");
+  });
+};

--- a/theme/base/javascripts/consent/toggleTooltipPressedStates.js
+++ b/theme/base/javascripts/consent/toggleTooltipPressedStates.js
@@ -1,0 +1,26 @@
+import {tooltipLabelSelector} from '../selectors';
+import {changeAriaExpanded} from '../utility/changeAriaExpanded';
+import {changeAriaPressed} from '../utility/changeAriaPressed';
+
+export const toggleTooltipPressedStates = () => {
+  const tooltips = document.querySelectorAll(tooltipLabelSelector);
+
+  tooltips.forEach(tooltip => {
+
+    const id = tooltip.getAttribute('for');
+    const checkbox = document.getElementById(id);
+    tooltip.addEventListener('click', () => {
+      const expanded = checkbox.getAttribute('aria-expanded');
+      changeAriaExpanded(checkbox);
+      changeAriaPressed(checkbox);
+      setTimeout(() => {
+        if (expanded === 'false') {
+          const tooltipValue = document.querySelector(`[data-for="${id}"]`);
+          tooltipValue.focus();
+        } else {
+          tooltip.focus();
+        }
+      }, 200);
+    });
+  });
+};

--- a/theme/base/javascripts/handlers.js
+++ b/theme/base/javascripts/handlers.js
@@ -19,6 +19,10 @@ import {cancelButtonClickHandlerCreator} from './wayf/noAccess/cancelButtonClick
 import {toggleFormFieldsAndButton} from './wayf/noAccess/toggleFormFieldsAndButton';
 import {changeAriaHiddenValue} from './utility/changeAriaHiddenValue';
 import {addTooltipAndModalAriaHandlers} from './consent/addTooltipAndModalAriaHandlers';
+import {hideInvisibleTooltips} from './consent/hideInvisibleTooltips';
+import {showInvisibleTooltips} from './consent/showInvisibleTooltips';
+import {handleInvisibleTooltips} from './consent/handleInvisibleTooltips';
+import {toggleTooltipPressedStates} from './consent/toggleTooltipPressedStates';
 
 /***
  * CONSENT HANDLERS
@@ -33,6 +37,10 @@ export const consentAnimateInteractiveElements = (selector) => {
   animateInteractiveSections(selector);
   addTooltipAndModalAriaHandlers(tooltipsAndModalLabels);
 };
+export const consentHideInvisibleTooltips = hideInvisibleTooltips;
+export const consentShowInvisibleTooltips = showInvisibleTooltips;
+export const consentHandleInvisibleTooltips = handleInvisibleTooltips;
+export const consentToggleTooltipPressedState = toggleTooltipPressedStates;
 export const consentNokHandler = (e) => {
   const nokSection = document.querySelector(nokSectionSelector);
   switchConsentSection(e);

--- a/theme/base/javascripts/selectors.js
+++ b/theme/base/javascripts/selectors.js
@@ -30,6 +30,10 @@ export const modalLabels = 'label.modal';
 export const attributesSelector = 'ul.consent__attributes li';
 export const tooltipLabelSelector = 'label.tooltip';
 export const primaryTooltipLabelSelector = `.ie11__label > ${tooltipLabelSelector}`;
+export const invisibleTooltipLabelsSelector = '.consent__attribute:nth-of-type(n+6) label.tooltip';
+export const openToggleLabelSelector = '.openToggle__label';
+export const firstInvisibleAttributeSelector = `${attributesSelector}:nth-of-type(6)`;
+export const showMoreCheckboxId = 'showMoreCheckbox';
 
 /***
  * WAYF SELECTORS

--- a/theme/base/javascripts/utility/changeAriaExpanded.js
+++ b/theme/base/javascripts/utility/changeAriaExpanded.js
@@ -1,0 +1,12 @@
+export const changeAriaExpanded = (element) => {
+  const ariaExpanded = element.getAttribute('aria-expanded');
+  const newValue = {
+    false: true,
+    true: false,
+  };
+
+  // We use the newValue object because ariaExpanded is a string containing either "true" or "false".
+  // Casting that to a boolean will, in both instances, give us true.
+  // By using an object we can use array notation to access the right value based on what we get back from the attribute.
+  element.setAttribute('aria-expanded', newValue[ariaExpanded]);
+};

--- a/theme/base/stylesheets/pages/consent/attribute.scss
+++ b/theme/base/stylesheets/pages/consent/attribute.scss
@@ -59,13 +59,15 @@
         }
     }
 
+
+
     > label,
     .ie11__label > label {
         margin: auto 0;
         padding: 1.2rem 35px;
 
         &.tooltip {
-            margin-left: -20px;
+            margin-left: -27px;
         }
 
         @include screen('mobile') {
@@ -74,6 +76,7 @@
     }
 
     > .tooltip__value {
+        @include focus;
         @include grid-position(2, 3, 3, 6);
         margin-left: 0;
         padding: 0;

--- a/theme/base/stylesheets/pages/consent/attributeValue.scss
+++ b/theme/base/stylesheets/pages/consent/attributeValue.scss
@@ -20,8 +20,9 @@
     }
 }
 
-.attribute__valueWrapper {
+.attribute__valueWrapper:not(.joske) {
     @include grid-position(1, 2, 3, 6);
+    padding: 0;
 
     @include screen('mobile') {
         @include grid-position(2, 3, 1, 2);
@@ -29,7 +30,7 @@
 
     > .attribute__value.attribute__value--list {
         margin: 0;
-        padding: 0;
+        padding: 1rem 0;
 
         &.animated {
             max-height: initial;
@@ -43,6 +44,8 @@
 
         li:not(.consent__attributeNested--noTooltip) {
             &:first-of-type {
+                margin-top: -4px;
+
                 .attribute__value {
                     display: inline-block;
                     padding-right: 0;
@@ -51,12 +54,19 @@
 
                 .ie11__label {
                     display: inline-block;
+                    margin-top: -4px;
+                    padding-top: 12px;
                     width: 12%;
+
+                    label {
+                        background-position: left 24px top 1.1rem
+                    }
                 }
             }
 
             .attribute__value {
                 padding-right: 1rem;
+                vertical-align: text-bottom;
             }
         }
     }

--- a/theme/base/stylesheets/pages/consent/openToggle.scss
+++ b/theme/base/stylesheets/pages/consent/openToggle.scss
@@ -9,6 +9,11 @@
     > .consent__attribute:nth-of-type(n+6) {
         @include display-grid;
         @include visually-shown;
+        padding: 3px 0;
+    }
+
+    > .consent__attribute:nth-of-type(6) {
+        @include focus;
     }
 
     > .openToggle {
@@ -53,8 +58,8 @@
         height: unset;
         font-weight: $bolder;
         justify-content: left;
-        padding: 1.2rem 35px 1.2rem 0;
-        width: unset;
+        padding: 1.2rem 0;
+        width: max-content;
 
         @include screen('mobile') {
             @include grid-position(2, 3, 1, 2);

--- a/theme/base/stylesheets/shared.scss
+++ b/theme/base/stylesheets/shared.scss
@@ -34,11 +34,6 @@ body {
         @include focus;
     }
 
-    *:focus:not(:focus-visible) {
-        outline: none;
-        box-shadow: none;
-    }
-
     a {
         &:hover {
             text-decoration: underline;
@@ -226,6 +221,14 @@ body {
     label.tooltip,
     .ie11__label > label.tooltip {
         @include tooltip;
+
+        .expandable {
+            display: inline;
+        }
+
+        .expanded {
+            display: none;
+        }
     }
 
     label.tooltip,
@@ -251,6 +254,14 @@ body {
     input[type="checkbox"]:checked.tooltip ~ label.tooltip,
     input[type="checkbox"]:checked.tooltip ~ .ie11__label > label.tooltip {
         @include closeTooltip;
+
+        .expandable {
+            display: none;
+        }
+
+        .expanded {
+            display: inline;
+        }
     }
 
     .button--secondary,

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
@@ -12,7 +12,7 @@
     {% if attributeValues|length == 1 %}
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: attributeValues|first } %}
         {% if addTooltip %}
-            <input type="checkbox" tabindex="-1" aria-hidden="true" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}" />
+            <input type="checkbox" tabindex="-1" class="tooltip visually-hidden" aria-expanded="false" role="button" aria-pressed="false" id="{{ id }}" name="{{ id }}" />
             {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with { tooltipValue: attributeMotivations[attributeIdentifier] } %}
         {% endif %}
     {# Multiple attribute values #}
@@ -30,7 +30,7 @@
                 <li {% if not addTooltip %}class="consent__attributeNested--noTooltip"{% endif %}>
                     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: value } %}
                     {% if addTooltip and loop.first %}
-                        <input type="checkbox" tabindex="-1" aria-hidden="true" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}" />
+                        <input type="checkbox" tabindex="-1" aria-expanded="false" role="button" aria-pressed="false" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}" />
                         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with { tooltipValue: attributeMotivations[attributeIdentifier], id: id } %}
                     {% endif %}
                 </li>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/engineBlockAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/engineBlockAttribute.html.twig
@@ -10,7 +10,7 @@
     {% endif %}
     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: attributeValues } %}
     {% if addTooltip %}
-        <input type="checkbox" tabindex="-1" aria-hidden="true" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}" />
+        <input type="checkbox" tabindex="-1" aria-expanded="false" role="button" aria-pressed="false" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}" />
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with {
             tooltipValue: 'consent_name_id_value_tooltip'|trans({'%arg1%': 'suite_name'|trans })
         } %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/list.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/list.html.twig
@@ -1,3 +1,18 @@
+{% if attributeSource == 'engineblock' %}
+    {% set organisationName = 'suite_name'|trans %}
+    {% set logoUrl = defaultLogo %}
+{% elseif attributeSource != 'idp' %}
+    {% set organisationName = attributeSourceDisplayName(attributeSource) %}
+    {% set logoUrl = attributeSourceLogoUrl(attributeSource) %}
+{% else %}
+    {% set organisationName = idpName %}
+    {% if idp.logo is not null %}
+        {% set logoUrl = idp.logo.url %}
+    {% else %}
+        {% set logoUrl = '/images/placeholder.png' %}
+    {% endif %}
+{% endif %}
+
 {% if attributes|length > 5 %}
     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/toggleCheckbox.html.twig' with {
         className: 'openToggle__checkBox',
@@ -20,5 +35,9 @@
             </li>
         {% endif %}
     {% endfor %}
-    {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/source.html.twig' %}
+
+    {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/source.html.twig' with {
+        logoUrl: logoUrl,
+        organisationName: organisationName
+    } %}
 </ul>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/source.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/source.html.twig
@@ -1,37 +1,10 @@
 <li class="idpRow">
-    {% if attributeSource == 'engineblock' %}
-        {% set organisationName = 'suite_name'|trans %}
-        {% set consentProvidedByOrg %}
-            <span class="idpRow__providedBy-content">{{ 'consent_provided_by'|trans }}  <strong>{{ organisationName }}</strong></span>
-        {% endset %}
-        {% include '@theme/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig' with {
-            logoUrl: defaultLogo,
-            organisationName: organisationName,
-            text: consentProvidedByOrg,
-        } %}
-    {% elseif attributeSource != 'idp' %}
-        {% set organisationName = attributeSourceDisplayName(attributeSource) %}
-        {% set consentProvidedByOrg %}
-            <span class="idpRow__providedBy-content">{{ 'consent_provided_by'|trans }}  <strong>{{ organisationName }}</strong></span>
-        {% endset %}
-        {% include '@theme/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig' with {
-            logoUrl: attributeSourceLogoUrl(attributeSource),
-            organisationName: organisationName,
-            text: consentProvidedByOrg,
-        } %}
-    {% else %}
-        {% if idp.logo is not null %}
-            {% set logoUrl = idp.logo.url %}
-        {% else %}
-            {% set logoUrl = '/images/placeholder.png' %}
-        {% endif %}
-        {% set consentProvidedByIdp %}
-            <span class="idpRow__providedBy-content">{{ 'consent_provided_by'|trans }}  <strong>{{ idpName }}</strong></span>
-        {% endset %}
-        {% include '@theme/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig' with {
-            logoUrl: logoUrl,
-            organisationName: idpName,
-            text: consentProvidedByIdp,
-        } %}
-    {% endif %}
+    {% set consentProvidedBy %}
+        <span class="idpRow__providedBy-content">{{ 'consent_provided_by'|trans }}  <strong>{{ organisationName }}</strong></span>
+    {% endset %}
+    {% include '@theme/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig' with {
+        logoUrl: logoUrl,
+        organisationName: organisationName,
+        text: consentProvidedBy,
+    } %}
 </li>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/toggleCheckbox.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/toggleCheckbox.html.twig
@@ -1,1 +1,1 @@
-<input type="checkbox" id="{{ id }}" name="{{ id }}" aria-hidden="true" {% if className is defined %}class="{{ className }}"{% endif %}/>
+<input type="checkbox" id="{{ id }}" name="{{ id }}" aria-expanded="false" role="button" aria-pressed="false" class="visually-hidden{% if className is defined %} {{ className }}{% endif %}" tabindex="-1" />

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/toggleLabel.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/toggleLabel.html.twig
@@ -1,5 +1,4 @@
 <label tabindex="0" for="{{ for }}" {% if className is defined %}class="{{ className }}"{% endif %}>
-    <span class="visually-hidden">{{ 'button_screenreader'|trans }}</span>
     {% if showMore is defined %}
         <span class="showMore">
             {{ showMore|trans }}
@@ -10,4 +9,5 @@
             {{ showLess|trans }}
         </span>
     {% endif %}
+    <span class="visually-hidden">{{ 'consent_attributes_screenreader'|trans({'%orgName%': organisationName}) }}</span>
 </label>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig
@@ -7,6 +7,7 @@
             {
                 class: 'tooltip',
                 hideText: true,
+                ariaExpandable: true,
                 id: id,
                 text: 'consent_tooltip_screenreader'|trans({ '%attr_name%': attributeName|lower }),
             }
@@ -17,7 +18,7 @@
         aria-hidden="true"
         class="tooltip__value"
         data-for="{{ id }}"
-        role="alert"
+        tabindex="-1"
     >
         {{ tooltipValue }}
     </div>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
@@ -16,10 +16,10 @@
     </p>
     {# note: the div is here only for IE11, as soon as IE11 support is scrapped, this can be removed along with the CSS/JS for it  #}
     <div class="ie11__label">
-        <span class="visually-hidden">{{ 'button_screenreader'|trans }}</span>
         <label tabindex="0" for="{{ id|trim }}" class="modal">
             <span class="label-text">{{ 'consent_attributes_correction_text'|trans }}</span>
         </label>
+        <span class="visually-hidden">{{ 'button_screenreader'|trans }}</span>
     </div>
     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Modals/correction.html.twig' %}
 {% endif %}

--- a/theme/cypress/functions/terminalLog.js
+++ b/theme/cypress/functions/terminalLog.js
@@ -16,8 +16,8 @@ export const terminalLog = (violations) => {
       impact,
       description,
       nodes: nodes.length,
-      nodeTarget: nodes.length > 0 && nodes[0].any[0] ? nodes[0].any[0].relatedNodes[0].target[0] : '',
-      nodeHTML: nodes.length > 0 && nodes[0].any[0] ? nodes[0].any[0].relatedNodes[0].html : '',
+      nodeTarget: nodes.length > 0 && nodes[0].any[0] && nodes[0].any[0].relatedNodes[0] ? nodes[0].any[0].relatedNodes[0].target[0] : '',
+      nodeHTML: nodes.length > 0 && nodes[0].any[0] && nodes[0].any[0].relatedNodes[0] ? nodes[0].any[0].relatedNodes[0].html : '',
     })
   );
 

--- a/theme/skeune/templates/modules/Default/Partials/a11yButtonExpandable.html.twig
+++ b/theme/skeune/templates/modules/Default/Partials/a11yButtonExpandable.html.twig
@@ -1,0 +1,2 @@
+<span class="visually-hidden expandable">{{ 'button_expandable_screenreader'|trans }}</span>
+<span class="visually-hidden expanded">{{ 'button_screenreader'|trans }}</span>

--- a/theme/skeune/templates/modules/Default/Partials/label.html.twig
+++ b/theme/skeune/templates/modules/Default/Partials/label.html.twig
@@ -2,8 +2,15 @@
     {% if text is defined %}
         {% if hideText %}
             <span class="visually-hidden">{{ text }}</span>
+            {% if ariaExpandable is defined and ariaExpandable %}
+                {% include '@theme/Default/Partials/a11yButtonExpandable.html.twig' %}
+            {% endif %}
         {% else %}
             {{ text }}
+            {% if ariaExpandable is defined and ariaExpandable %}
+                including
+                {% include '@theme/Default/Partials/a11yButtonExpandable.html.twig' %}
+            {% endif %}
         {% endif %}
     {% endif %}
 </label>

--- a/theme/skeune/translations/messages.en.php
+++ b/theme/skeune/translations/messages.en.php
@@ -1,7 +1,9 @@
 <?php
 return [
     // General
-    'button_screenreader'        =>  'Button: ',
+    'button_screenreader'        =>  ', button',
+    'button_expandable_screenreader' => ', button, expandable',
+    'button_expanded_screenreader' => ', button, expanded',
     'required_screenreader'      =>  'Required',
     'search_screenreader'        =>  'Search',
     'send_request'  =>  'Send request',

--- a/theme/skeune/translations/messages.nl.php
+++ b/theme/skeune/translations/messages.nl.php
@@ -1,7 +1,9 @@
 <?php
 return [
     // General
-    'button_screenreader'        =>  'Knop: ',
+    'button_screenreader'        =>  ', knop',
+    'button_expandable_screenreader' => ' ,knop, uitklapbaar',
+    'button_expanded_screenreader' => ' ,knop, uitgeklapt',
     'required_screenreader'      =>  'Verplicht',
     'search_screenreader'        =>  'Zoeken',
     'send_request'  =>  'Verzoek sturen',

--- a/theme/skeune/translations/messages.pt.php
+++ b/theme/skeune/translations/messages.pt.php
@@ -1,7 +1,9 @@
 <?php
 return [
     // General
-    'button_screenreader'        =>  'Button: ',
+    'button_screenreader'        =>  ', button',
+    'button_expandable_screenreader' => ', button, expandable',
+    'button_expanded_screenreader' => ', button, expanded',
     'required_screenreader'      =>  'Required',
     'search_screenreader'        =>  'Search',
     'send_request'  =>  'Send request',


### PR DESCRIPTION
Prior to this change, there were several issues with the hidden attributes:
- their tooltips were not removed from the tab order when hidden
- showing all hidden attributes did not result in a focus change, meaning SR users were left in the dark

This change ensures that the correct attribute get's focus when showing the hidden attributes.  It also ensures the hidden attribute tooltips are no longer in the taborder.

Issue discovered while studying for WAS certification.