### PR TITLE
Handle a11y for pressing cancel button in consent screen

### DIFF
--- a/theme/base/javascripts/consent/addA11ySupport.js
+++ b/theme/base/javascripts/consent/addA11ySupport.js
@@ -1,11 +1,12 @@
 import {
   consentAnimateInteractiveElements,
   consentHandleInvisibleTooltips,
+  consentHandleNokFocus,
   consentHideInvisibleTooltips,
   consentKeyboardBehaviourHandler,
   consentToggleTooltipPressedState,
 } from '../handlers';
-import {consentAnimatedElementSelectors, openToggleLabelSelector} from '../selectors';
+import {consentAnimatedElementSelectors, nokButtonSelector, nokCheckboxId, openToggleLabelSelector} from '../selectors';
 import {addClickHandlerOnce} from '../utility/addClickHandlerOnce';
 
 export const addAccessibilitySupport = () => {
@@ -14,4 +15,6 @@ export const addAccessibilitySupport = () => {
   consentHideInvisibleTooltips();
   addClickHandlerOnce(openToggleLabelSelector, consentHandleInvisibleTooltips);
   consentToggleTooltipPressedState();
+  addClickHandlerOnce(nokButtonSelector, consentHandleNokFocus);
+  document.getElementById(nokCheckboxId).classList.add('js');
 };

--- a/theme/base/javascripts/consent/handleNokFocus.js
+++ b/theme/base/javascripts/consent/handleNokFocus.js
@@ -1,0 +1,21 @@
+import {nokButtonSelectorForKeyboard, nokCheckboxId, nokSectionSelector, nokTitleSelector} from '../selectors';
+import {focusAndSmoothScroll} from '../utility/focusAndSmoothScroll';
+import {changeAriaPressed} from '../utility/changeAriaPressed';
+import {changeAriaExpanded} from '../utility/changeAriaExpanded';
+
+export const handleNokFocus = () => {
+  const nokCheckbox = document.getElementById(nokCheckboxId);
+  const nokTitle = document.querySelector(nokTitleSelector);
+  const nokButton = document.querySelector(nokButtonSelectorForKeyboard);
+  const nokSection = document.querySelector(nokSectionSelector);
+  const isChecked = nokSection.classList.contains('hidden');
+
+  if (!isChecked) {
+    nokTitle.focus();
+  } else {
+    focusAndSmoothScroll(nokButton);
+  }
+
+  changeAriaPressed(nokCheckbox);
+  changeAriaExpanded(nokCheckbox);
+};

--- a/theme/base/javascripts/handlers.js
+++ b/theme/base/javascripts/handlers.js
@@ -8,7 +8,6 @@ import {addClickHandlerOnce} from './utility/addClickHandlerOnce';
 import {
   backButtonSelector,
   nokButtonSelector,
-  nokSectionSelector,
   tooltipsAndModalLabels,
 } from './selectors';
 import {handlePreviousSelectionVisible} from './wayf/handlePreviousSelectionVisible';
@@ -17,20 +16,21 @@ import {searchBehaviour} from './wayf/searchBehaviour';
 import {submitForm} from './wayf/submitForm';
 import {cancelButtonClickHandlerCreator} from './wayf/noAccess/cancelButtonClickHandler';
 import {toggleFormFieldsAndButton} from './wayf/noAccess/toggleFormFieldsAndButton';
-import {changeAriaHiddenValue} from './utility/changeAriaHiddenValue';
 import {addTooltipAndModalAriaHandlers} from './consent/addTooltipAndModalAriaHandlers';
 import {hideInvisibleTooltips} from './consent/hideInvisibleTooltips';
 import {showInvisibleTooltips} from './consent/showInvisibleTooltips';
 import {handleInvisibleTooltips} from './consent/handleInvisibleTooltips';
 import {toggleTooltipPressedStates} from './consent/toggleTooltipPressedStates';
+import {handleNokFocus} from './consent/handleNokFocus';
 
 /***
  * CONSENT HANDLERS
  * ***/
 export const consentCallbackAfterLoad = () => {
-  addAccessibilitySupport();
   addClickHandlerOnce(nokButtonSelector, consentNokHandler);
+  addAccessibilitySupport();
 };
+export const consentHandleNokFocus = handleNokFocus;
 export const consentEnterHandler = (target) => enterHandler(target);
 export const consentKeyboardBehaviourHandler = keyboardBehaviour;
 export const consentAnimateInteractiveElements = (selector) => {
@@ -42,15 +42,14 @@ export const consentShowInvisibleTooltips = showInvisibleTooltips;
 export const consentHandleInvisibleTooltips = handleInvisibleTooltips;
 export const consentToggleTooltipPressedState = toggleTooltipPressedStates;
 export const consentNokHandler = (e) => {
-  const nokSection = document.querySelector(nokSectionSelector);
   switchConsentSection(e);
-  addClickHandlerOnce(backButtonSelector, backButtonHandler(nokSection));
-  changeAriaHiddenValue(nokSection);
+  consentHandleNokFocus();
+  addClickHandlerOnce(backButtonSelector, backButtonHandler());
 };
-export const backButtonHandler = (nokSection) => {
+export const backButtonHandler = () => {
   return (e) => {
     switchConsentSection(e);
-    changeAriaHiddenValue(nokSection);
+    consentHandleNokFocus();
   };
 };
 

--- a/theme/base/javascripts/selectors.js
+++ b/theme/base/javascripts/selectors.js
@@ -20,9 +20,11 @@ export const languageErrorSelector = '.comp-language.error';
  * See the @motion mixin explanation for a longer explanation as to why.
  */
 export const consentAnimatedElementSelectors = '.tooltip__value, .modal__value, .consent__attributes, .attribute__valueWrapper > .attribute__value--list';
-export const nokButtonSelector = 'label[for="cta_consent_nok"]';
+export const nokCheckboxId = 'cta_consent_nok';
+export const nokButtonSelector = `label[for="${nokCheckboxId}"]`;
 export const nokButtonSelectorForKeyboard = '.consent__ctas > .button--tertiary';
 export const nokSectionSelector = '.consent__nok';
+export const nokTitleSelector = '.consent__nok-title';
 export const contentSectionSelector = '.consent__content';
 export const backButtonSelector = '.consent__nok-back';
 export const tooltipsAndModalLabels = 'label.tooltip, label.modal';

--- a/theme/base/stylesheets/pages/consent/ctas.scss
+++ b/theme/base/stylesheets/pages/consent/ctas.scss
@@ -22,16 +22,38 @@
                 background-image: unset;
                 font-weight: 700;
                 padding-right: 0;
+
+                .expanded {
+                    display: none;
+                }
+
+                .expandable {
+                    display: inline;
+                }
             }
         }
     }
 
-    > #cta_consent_nok:checked + .button--tertiary label {
+    #cta_consent_nok:checked + .button--tertiary label.modal,
+    #cta_consent_nok[aria-expanded="true"] + .button--tertiary label.modal {
         background-image: unset;
+
+        .expanded {
+            display: inline;
+        }
+
+        .expandable {
+            display: none;
+        }
     }
 
     #cta_consent_nok:checked + .button--tertiary + .modal__value.animated {
         margin: 1rem auto 0;
+    }
+
+    // only works if JS is active
+    #cta_consent_nok.js[aria-expanded="false"] ~ section.modal__value {
+        display: none;
     }
 
     > section.modal__value {
@@ -45,7 +67,6 @@
             width: 100%;
         }
     }
-
 }
 
 @include ie11Only('.consent__ctas > .button--tertiary > div > label.modal') {

--- a/theme/base/stylesheets/pages/consent/nok.scss
+++ b/theme/base/stylesheets/pages/consent/nok.scss
@@ -1,4 +1,8 @@
 .consent__nok {
+    > .consent__nok-title {
+        @include focus;
+    }
+
     > .consent__nok-body {
         padding: 0 2rem 2.5rem;
 

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/ctas.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/ctas.html.twig
@@ -21,13 +21,14 @@
             }
         %}
     </form>
-    <input type="checkbox" tabindex="-1" role="button" aria-pressed="false" class="modal visually-hidden" id="cta_consent_nok" name="cta_consent_nok" />
+    <input type="checkbox" tabindex="-1" role="button" aria-expanded="false" aria-pressed="false" class="modal visually-hidden" id="cta_consent_nok" name="cta_consent_nok" />
     <div class="button--tertiary" tabindex="0">
         <div>
             {% include '@theme/Default/Partials/label.html.twig' with
                 {
                     class: 'modal',
                     id: 'cta_consent_nok',
+                    ariaExpandable: true,
                     hideText: false,
                     noTab: true,
                     text: text_nok

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/nokSection.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/nokSection.html.twig
@@ -1,5 +1,5 @@
-<section class="consent__nok hidden" aria-hidden="true" role="alert" data-for="cta_consent_nok">
-    <h2>{{ 'consent_nok_title'|trans }}</h2>
+<section class="consent__nok hidden" data-for="cta_consent_nok">
+    <h2 tabindex="-1" class="consent__nok-title">{{ 'consent_nok_title'|trans }}</h2>
     <div class="consent__nok-body">
         <p>{{ 'consent_nok_text'|trans }}</p>
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Modals/contact-details.html.twig' %}

--- a/theme/skeune/templates/modules/Default/Partials/label.html.twig
+++ b/theme/skeune/templates/modules/Default/Partials/label.html.twig
@@ -8,7 +8,6 @@
         {% else %}
             {{ text }}
             {% if ariaExpandable is defined and ariaExpandable %}
-                including
                 {% include '@theme/Default/Partials/a11yButtonExpandable.html.twig' %}
             {% endif %}
         {% endif %}


### PR DESCRIPTION
Prior to this change, pressing the cancel button was implemented for SRs & keyboard users with an aria alert and changes to the aria-hidden state.

This change ensures that clicking the cancel button is implemented for SRs & keyboard users as a disclosure widget.  That means the focus is moved to the title when the nok section is shown and to the button when it the user moves back.  It also means the aria-expanded attribute is set from false to true (or vice versa) depending on whether or not the nok section is shown.

Issue discovered while studying for WAS certification.