### PR TITLE
Remove assertsversion tag from externally hosted images.

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
@@ -1,4 +1,4 @@
-<img class="logo-small" src="{{ logoUrl }}?v={{ assetsVersion }}"
+<img class="logo-small" src="{{ logoUrl }}"
      alt="" />
 {% if attributeSource == 'engineblock' %}
     {# note: the div is here only for IE11, as soon as IE11 support is scrapped, this can be removed along with the CSS/JS for it  #}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
@@ -18,9 +18,9 @@
         {% if idp.logo is not null %}
             {% set logoUrl = idp.logo %}
         {% else %}
-            {% set logoUrl = '/images/placeholder.png' %}
+            {% set logoUrl = "/images/placeholder.png?v={{ assetsVersion }}" %}
         {% endif %}
-        <img src="{{ logoUrl }}?v={{ assetsVersion }}" alt="" loading="lazy">
+        <img src="{{ logoUrl }}" alt="" loading="lazy">
     </div>
     <div class="idp__content">
         <div class="idp__border"></div>

--- a/theme/openconext/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -49,12 +49,12 @@
                                          alt=""/>
                                     <h2>{{ 'suite_name'|trans }}</h2>
                                 {% elseif attributeSource != 'idp' %}
-                                    <img class="logo-small" src="{{ attributeSourceLogoUrl(attributeSource)|escape('html_attr') }}?v={{ assetsVersion }}"
+                                    <img class="logo-small" src="{{ attributeSourceLogoUrl(attributeSource)|escape('html_attr') }}"
                                          alt=""/>
                                     <h2>{{ attributeSourceDisplayName(attributeSource) }}</h2>
                                 {% else %}
                                     {% if idp.logo is not null %}
-                                        <img class="logo-small" src="{{ idp.logo.url }}?v={{ assetsVersion }}" alt=""/>
+                                        <img class="logo-small" src="{{ idp.logo.url }}" alt=""/>
                                     {% else %}
                                         <img class="logo-small" src="/images/placeholder.png?v={{ assetsVersion }}" alt=""/>
                                     {% endif %}


### PR DESCRIPTION
The IdP/Attribute source logo are hosted on a static vhost and do not
change as a result of a new EB software version. They may change for
other reasons but the EB assetversion has no relation to it. Remove the
assetsversion from the request so we do not needlessly invalidate these
logos when upgrading EB.