### PR TITLE
Log the Engine SSO endpoint used

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/LogLogin.php
+++ b/library/EngineBlock/Corto/Filter/Command/LogLogin.php
@@ -55,7 +55,8 @@ class EngineBlock_Corto_Filter_Command_LogLogin extends EngineBlock_Corto_Filter
             $this->_request->getKeyId(),
             $requesterChain,
             $this->_response->getNameIdValue(),
-            $this->_response->getAssertion()->getAuthnContextClassRef()
+            $this->_response->getAssertion()->getAuthnContextClassRef(),
+            $this->_request->getDestination()
         );
     }
 }

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -313,6 +313,12 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
         $acsLocation = !empty($_GET['acs-location']) ? $_GET['acs-location']: null;
         $acsIndex    = !empty($_GET['acs-index'])    ? $_GET['acs-index']   : null;
         $binding     = !empty($_GET['acs-binding'])  ? $_GET['acs-binding'] : null;
+        $destination = null;
+        if (array_key_exists('SCRIPT_URL', $_SERVER)){
+            $destination = $_SERVER['SCRIPT_URL'];
+        } else if (array_key_exists('REDIRECT_URL', $_SERVER)){
+            $destination = $_SERVER['REDIRECT_URL'];
+        }
 
         // Requested relay state
         $relayState  = !empty($_GET['RelayState'])   ? $_GET['RelayState']  : null;
@@ -336,6 +342,10 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
         $request = new EngineBlock_Saml2_AuthnRequestAnnotationDecorator($sspRequest);
         if ($keyid = $this->_server->getKeyId()) {
             $request->setKeyId($keyid);
+        }
+        if ($destination) {
+            // Set for logging purposes (LogLogin Command) note that only the REQUEST_URI (no hostname + protocol)
+            $sspRequest->setDestination($destination);
         }
 
         $request->setUnsolicited();

--- a/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
+++ b/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
@@ -42,24 +42,16 @@ class AuthenticationLogger
     /**
      * KeyId is nullable in order to be able to differentiate between asking no specific key,
      * the default key KeyId('default') and a specific key.
-     *
-     * @param Entity $serviceProvider
-     * @param Entity $identityProvider
-     * @param CollabPersonId $collabPersonId
-     * @param array $proxiedServiceProviders
-     * @param string $workflowState
-     * @param string $originalNameId
-     * @param string|null $authnContextClassRef
-     * @param KeyId|null $keyId
      */
     public function logGrantedLogin(
         Entity $serviceProvider,
         Entity $identityProvider,
         CollabPersonId $collabPersonId,
         array $proxiedServiceProviders,
-        $workflowState,
-        $originalNameId,
-        $authnContextClassRef,
+        string $workflowState,
+        string $originalNameId,
+        ?string $authnContextClassRef,
+        ?string $engineSsoEndpointUsed,
         KeyId $keyId = null
     ) {
         $proxiedServiceProviderEntityIds = array_map(
@@ -74,15 +66,16 @@ class AuthenticationLogger
         $this->logger->info(
             'login granted',
             [
-                'login_stamp'           => $timestamp,
-                'user_id'               => $collabPersonId->getCollabPersonId(),
-                'sp_entity_id'          => $serviceProvider->getEntityId()->getEntityId(),
-                'idp_entity_id'         => $identityProvider->getEntityId()->getEntityId(),
-                'key_id'                => $keyId ? $keyId->getKeyId() : null,
+                'login_stamp' => $timestamp,
+                'user_id' => $collabPersonId->getCollabPersonId(),
+                'sp_entity_id' => $serviceProvider->getEntityId()->getEntityId(),
+                'idp_entity_id' => $identityProvider->getEntityId()->getEntityId(),
+                'key_id' => $keyId ? $keyId->getKeyId() : null,
                 'proxied_sp_entity_ids' => $proxiedServiceProviderEntityIds,
-                'workflow_state'        => $workflowState,
-                'original_name_id'      => $originalNameId,
-                'authncontextclassref'  => $authnContextClassRef,
+                'workflow_state' => $workflowState,
+                'original_name_id' => $originalNameId,
+                'authncontextclassref' => $authnContextClassRef,
+                'engine_sso_endpoint_used' => $engineSsoEndpointUsed,
             ]
         );
     }

--- a/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
+++ b/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
@@ -39,23 +39,15 @@ class AuthenticationLoggerAdapter
         $this->authenticationLogger = $authenticationLogger;
     }
 
-    /**
-     * @param ServiceProvider $serviceProvider
-     * @param IdentityProvider $identityProvider
-     * @param                   $collabPersonId
-     * @param                   $keyId
-     * @param ServiceProvider[] $proxiedServiceProviders
-     * @param string $originalNameId
-     * @param string|null $authnContextClassRef
-     */
     public function logLogin(
         ServiceProvider $serviceProvider,
         IdentityProvider $identityProvider,
-        $collabPersonId,
-        $keyId,
+        string $collabPersonId,
+        ?string $keyId,
         array $proxiedServiceProviders,
-        $originalNameId,
-        $authnContextClassRef
+        string $originalNameId,
+        ?string $authnContextClassRef,
+        ?string $engineSsoEndpointUsed
     ) {
         $keyId = $keyId ? new KeyId($keyId) : null;
 
@@ -74,6 +66,7 @@ class AuthenticationLoggerAdapter
             $serviceProvider->workflowState,
             $originalNameId,
             $authnContextClassRef,
+            $engineSsoEndpointUsed,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
@@ -55,6 +55,7 @@ class AuthenticationLoggerTest extends TestCase
         $spProxy2EntityId         = 'SpProxy2EntityId';
         $originalNameId           = 'urn:collab:person:original:some-person';
         $authnContextClassRef     = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
+        $ssoEndpointUsed = '/authentication/idp/single-sign-on';
 
         $serviceProvider       = new Entity(new EntityId($serviceProviderEntityId), EntityType::SP());
         $identityProvider      = new Entity(new EntityId($identityProviderEntityId), EntityType::IdP());
@@ -73,6 +74,7 @@ class AuthenticationLoggerTest extends TestCase
             'workflow_state' => AbstractRole::WORKFLOW_STATE_PROD,
             'original_name_id' => $originalNameId,
             'authncontextclassref' => $authnContextClassRef,
+            'engine_sso_endpoint_used' => $ssoEndpointUsed
         ];
 
         $mockLogger = m::mock('\Psr\Log\LoggerInterface');
@@ -113,6 +115,7 @@ class AuthenticationLoggerTest extends TestCase
             AbstractRole::WORKFLOW_STATE_PROD,
             $originalNameId,
             $authnContextClassRef,
+            $ssoEndpointUsed,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
@@ -54,6 +54,7 @@ class AuthenticationLoggerAdapterTest extends TestCase
         $spProxy2EntityId         = 'SpProxy2EntityId';
         $originalNameId           = 'urn:collab:person:original:some-person';
         $authnContextClassRef     = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
+        $ssoEndpointUsed = '/authentication/idp/single-sign-on';
 
         $mockAuthenticationLogger = m::mock(AuthenticationLogger::class);
         $mockAuthenticationLogger
@@ -74,6 +75,7 @@ class AuthenticationLoggerAdapterTest extends TestCase
                     AbstractRole::WORKFLOW_STATE_PROD,
                     $originalNameId,
                     $authnContextClassRef,
+                    $ssoEndpointUsed,
                     new ValueObjectEqualsMatcher(new KeyId($keyIdValue)),
                 ]
             )
@@ -90,7 +92,8 @@ class AuthenticationLoggerAdapterTest extends TestCase
                 new ServiceProvider($spProxy2EntityId),
             ],
             $originalNameId,
-            $authnContextClassRef
+            $authnContextClassRef,
+            $ssoEndpointUsed
         );
     }
 }


### PR DESCRIPTION
After a successfull login, log the sso endpoint used during authentication. This is available on the _request var present on the
LogLogin command.

https://www.pivotaltracker.com/story/show/175904919