### PR TITLE
Reduce missing translation warnings

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -109,7 +109,7 @@ HTML
     'cancel'                => 'Cancel',
     'send'                  => 'Send',
     'close'                 => 'Close',
-
+    'required'              => 'Required',
     'send_confirm'          => 'Your request has been sent',
     'send_confirm_desc'     => '<p>Your request has been forwarded to your %organisationNoun%. Further settlement and decisions on the availability of this service will be taken by the ICT staff of your %organisationNoun%.</p>',
 

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -106,7 +106,7 @@ HTML
     'cancel'                => 'Annuleren',
     'send'                  => 'Verstuur',
     'close'                 => 'Sluiten',
-
+    'required'              => 'Verplicht',
     'send_confirm'          => 'Je verzoek is verzonden',
     'send_confirm_desc'     => '<p>Je verzoek is doorgestuurd naar de juiste persoon binnen jouw %organisationNoun%. Het is aan deze persoon om actie te ondernemen op basis van jouw verzoek. Het kan zijn dat er nog afspraken gemaakt moeten worden tussen jouw %organisationNoun% en de dienstaanbieder.</p>',
 

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -108,6 +108,7 @@ HTML
     'cancel'                => 'Cancelar',
     'send'                  => 'Enviar',
     'close'                 => 'Fechar',
+    'required'              => 'Obrigatório',
 
     'send_confirm'          => 'O seu pedido foi enviado',
     'send_confirm_desc'     => '<p>A sua solicitação foi encaminha para a sua %organisationNoun%. As decisões para a disponibilidade deste serviço serão tomadas pela equipa de IT da sua %organisationNoun%.</p>',

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -567,7 +567,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             return $identityProvider->nameNl;
         }
 
-        EngineBlock_ApplicationSingleton::getLog()->warning(
+        EngineBlock_ApplicationSingleton::getLog()->notice(
             'No NL displayName and name found for idp: ' . $identityProvider->entityId,
             array('additional_info' => $additionalLogInfo->toArray())
         );
@@ -587,7 +587,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             return $identityProvider->nameEn;
         }
 
-        EngineBlock_ApplicationSingleton::getLog()->warning(
+        EngineBlock_ApplicationSingleton::getLog()->notice(
             'No EN displayName and name found for idp: ' . $identityProvider->entityId,
             array('additional_info' => $additionalInfo->toArray())
         );
@@ -607,7 +607,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             return $identityProvider->namePt;
         }
 
-        EngineBlock_ApplicationSingleton::getLog()->warning(
+        EngineBlock_ApplicationSingleton::getLog()->notice(
             'No PT displayName and name found for idp: ' . $identityProvider->entityId,
             array('additional_info' => $additionalInfo->toArray())
         );

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -21,6 +21,7 @@ use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactory;
 use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
+use OpenConext\EngineBlockBundle\Exception\InvalidArgumentException as EngineBlockBundleInvalidArgumentException;
 use SAML2\AuthnRequest;
 use SAML2\Response;
 use SAML2\XML\saml\Issuer;
@@ -493,10 +494,10 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
 
             $isAccessible = $identityProvider->enabledInWayf || $isDebugRequest;
 
+            $name = $this->getName($currentLocale, $identityProvider, $additionalInfo);
+
             $wayfIdp = array(
-                'Name_nl'   => $this->getNameNl($identityProvider, $additionalInfo),
-                'Name_en'   => $this->getNameEn($identityProvider, $additionalInfo),
-                'Name_pt'   => $this->getNamePt($identityProvider, $additionalInfo),
+                'Name'   => $name,
                 'Logo'      => $identityProvider->logo ? $identityProvider->logo->url : '/images/placeholder.png',
                 'Keywords'  => $this->getKeywords($identityProvider),
                 'Access'    => $isAccessible ? '1' : '0',
@@ -553,6 +554,22 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             ->setBody($output, 'text/plain');
 
         $diContainer->getMailer()->send($message);
+    }
+
+    private function getName(string $locale, IdentityProvider $identityProvider, AdditionalInfo $additionalInfo)
+    {
+        switch ($locale) {
+            case "nl":
+                return $this->getNameNl($identityProvider, $additionalInfo);
+            case "en":
+                return $this->getNameEn($identityProvider, $additionalInfo);
+            case "pt":
+                return $this->getNamePt($identityProvider, $additionalInfo);
+            default:
+                throw new EngineBlockBundleInvalidArgumentException(
+                    sprintf('Trying to get the IdP name for an unsupported language (%s)', $locale)
+                );
+        }
     }
 
     private function getNameNl(

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
@@ -89,8 +89,8 @@ class Wayf extends Twig_Extension
                     [
                         'entityId' => $idp['EntityID'],
                         'connected' => $idp['Access'] === '1',
-                        'displayTitle' => $idp['Name_' . $locale],
-                        'title' => strtolower($idp['Name_' . $locale]),
+                        'displayTitle' => $idp['Name'],
+                        'title' => strtolower($idp['Name']),
                         'keywords' => strtolower(join('|', $idpKeywords)),
                         'logo' => $idp['Logo'],
                         'isDefaultIdp' => (bool) $idp['isDefaultIdp'],
@@ -101,8 +101,8 @@ class Wayf extends Twig_Extension
             $formattedIdpList[] = [
                 'entityId' => $idp['EntityID'],
                 'connected' => $idp['Access'] === '1',
-                'displayTitle' => $idp['Name_'.$locale],
-                'title' => strtolower($idp['Name_'.$locale]),
+                'displayTitle' => $idp['Name'],
+                'title' => strtolower($idp['Name']),
                 'keywords' => strtolower(join('|', $idpKeywords)),
                 'logo' => $idp['Logo'],
                 'isDefaultIdp' => (bool) $idp['isDefaultIdp'],


### PR DESCRIPTION
Several changes where made to the WAYF generation logic to reduce the amount of missing translation warnings.

1. Only load the IdP name for the current locale. This gets rid of the missing PT translation on our platform where PT is not an active language. This should solve similar issues for OpenConext users that use only one or two of the supported languages.
2. Translated the `required` translation id
3. Lowered the log level for this missing IdP name log entry.

See: https://www.pivotaltracker.com/story/show/176817180