### PR TITLE
Ensure logout page is styled for skeune

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -169,7 +169,7 @@ There are a lot of error pages.  To test all different kinds, you can use the ur
 - index.html.twig: `templates > modules > authentication > view > index > index.html.twig`.  You can use `https://engine.vm.openconext.org/` to develop the page.
 - cookie removal page: `templates > modules > authentication > view > identityprovider > remove-cookies.html.twig`.  You can use `https://engine.vm.openconext.org/authentication/idp/remove-cookies` to develop the page.
 - debug page: `templates > modules > authentication > view > proxy > debug-idp-response.html.twig`.  You can use `https://engine.vm.openconext.org/authentication/sp/debug` to develop the page.
-
+- logout page: `templates > modules > logout > view > index > index.html.twig`.  You can use `https://engine.vm.openconext.org/logout` to develop the page.
 
 #### Supported feature / testing flags
 

--- a/theme/base/stylesheets/application.scss
+++ b/theme/base/stylesheets/application.scss
@@ -9,3 +9,4 @@
 @import 'pages/consent';
 @import 'pages/form';
 @import 'pages/wayf';
+@import 'pages/logout';

--- a/theme/base/stylesheets/pages/form.scss
+++ b/theme/base/stylesheets/pages/form.scss
@@ -1,6 +1,6 @@
 /*******************************************************************
     CSS specific to the form page (auto submitted page that sends
-    SAML response to SP
+    SAML response to SP)
  ******************************************************************/
 .redirect {
     height: 100%;

--- a/theme/base/stylesheets/pages/logout.scss
+++ b/theme/base/stylesheets/pages/logout.scss
@@ -1,0 +1,18 @@
+/*******************************************************************
+    CSS specific to the logout page
+ ******************************************************************/
+.logout {
+    .page__header {
+        margin: 3rem auto 0 ;
+
+        @include screen('mobile') {
+            margin: 0;
+        }
+    }
+
+    .page__title {
+        @include screen('mobile') {
+            padding-top: 3rem;
+        }
+    }
+}

--- a/theme/base/stylesheets/shared.scss
+++ b/theme/base/stylesheets/shared.scss
@@ -86,6 +86,42 @@ body {
         overflow: hidden;
     }
 
+    .page__header {
+        font-family: 'Nunito', sans-serif;
+    }
+
+    .page__title {
+        @include font-style-xl;
+        background-color: $yellow;
+        color: $black;
+        line-height: calculateRem(26px);
+        margin: 0;
+        padding: calculateRem(26px) 2rem;
+
+        @include screen('mobile') {
+            padding: .8125rem 1rem;
+        }
+
+        @include screen('smallMobile') {
+            padding: .8125rem .5rem;
+        }
+    }
+
+    .page__content {
+        @include border-bottom-radius(8px);
+        background-color: $gray;
+        box-shadow: 0 3px 0 2px $darkishBlueTwo;
+        padding: 2rem 2rem 2.5rem;
+
+        @include screen('mobile') {
+            padding: 2rem 1rem 1rem;
+        }
+
+        @include screen('smallMobile') {
+            padding: 1.5rem .5rem .5rem;
+        }
+    }
+
     > .container {
         > header {
             > h1.redirectBar,
@@ -116,25 +152,6 @@ body {
             box-shadow: 0 3px 0 2px $darkishBlueTwo;
 
             > header {
-                font-family: 'Nunito', sans-serif;
-
-                h1 {
-                    @include font-style-xl;
-                    background-color: $yellow;
-                    color: $black;
-                    line-height: calculateRem(26px);
-                    margin: 0;
-                    padding: calculateRem(26px) 2rem;
-
-                    @include screen('mobile') {
-                        padding: .8125rem 1rem;
-                    }
-
-                    @include screen('smallMobile') {
-                        padding: .8125rem .5rem;
-                    }
-                }
-
                 h2 {
                     background-color: $gray;
                     color: $green;

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Shared/header.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Shared/header.html.twig
@@ -1,5 +1,5 @@
-<header>
-    <h1>{{ pageTitle }}</h1>
+<header class="page__header">
+    <h1 class="page__title">{{ pageTitle }}</h1>
     {% if h2 is defined %}
         <h2>{{ h2 }}</h2>
     {% endif %}

--- a/theme/base/templates/modules/Logout/View/Index/index.html.twig
+++ b/theme/base/templates/modules/Logout/View/Index/index.html.twig
@@ -6,11 +6,13 @@
 {% block pageHeading %}{{ parent() }} - {{ pageTitle }}{% endblock %}
 
 {% block content %}
-<div class="box">
-  <div class="mod-content">
-    <h1>Logout</h1>
-    <p>{{ 'logout_description'|trans }}</p>
-    <p>{{ 'logout_information_link'|trans|raw }}</p>
-  </div>
-</div>
+    <div class="logout">
+        <header class="page__header">
+            <h1 class="page__title">Logout</h1>
+        </header>
+        <main class="page__content">
+            <p>{{ 'logout_description'|trans }}</p>
+            <p>{{ 'logout_information_link'|trans|raw }}</p>
+        </main>
+    </div>
 {% endblock %}

--- a/theme/cypress/integration/shared/logout.a11y.spec.js
+++ b/theme/cypress/integration/shared/logout.a11y.spec.js
@@ -1,0 +1,16 @@
+import {terminalLog} from '../../functions/terminalLog';
+
+context('Logout page verify a11y', () => {
+  it('Logout page contains no a11y problems on load', () => {
+    cy.visit('https://engine.vm.openconext.org/logout', {failOnStatusCode: false
+    });
+    cy.injectAxe();
+    cy.checkA11y(null, null, terminalLog);
+  });
+
+  it('Logout page contains no html errors', () => {
+    cy.visit('https://engine.vm.openconext.org/logout', {failOnStatusCode: false
+    });
+    cy.htmlvalidate();
+  });
+});

--- a/theme/skeune/stylesheets/application.scss
+++ b/theme/skeune/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @import 'base/stylesheets/pages/consent';
 @import 'base/stylesheets/pages/wayf';
 @import 'base/stylesheets/pages/form';
+@import 'base/stylesheets/pages/logout';


### PR DESCRIPTION
Prior to this change, the logout page had no stying in skeune.

This change:
- adds styling for the logout page
- adds tests for the logout page
- adds documentation for hte logout page

As per the boyscout rule it also fixes a forgotten closing bracket in the forms.scss file.

Issue available in pivotal at https://www.pivotaltracker.com/story/show/177360659