### PR TITLE
Make theme translations overrideable

### DIFF
--- a/theme/base/translations/messages.en.php
+++ b/theme/base/translations/messages.en.php
@@ -1,4 +1,10 @@
 <?php
 
-return [
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.en.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
 ];

--- a/theme/base/translations/messages.nl.php
+++ b/theme/base/translations/messages.nl.php
@@ -1,3 +1,10 @@
 <?php
-return [
+
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.nl.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
 ];

--- a/theme/base/translations/messages.pt.php
+++ b/theme/base/translations/messages.pt.php
@@ -1,3 +1,10 @@
 <?php
-return [
+
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.pt.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
 ];

--- a/theme/openconext/translations/messages.en.php
+++ b/theme/openconext/translations/messages.en.php
@@ -1,6 +1,12 @@
 <?php
 
-return [
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.en.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
     // General
     'search'                    => 'Search for an %organisationNoun%...',
     'log_in_to'                 => 'Select an %organisationNoun% to login to the service',

--- a/theme/openconext/translations/messages.nl.php
+++ b/theme/openconext/translations/messages.nl.php
@@ -1,5 +1,12 @@
 <?php
-return [
+
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.nl.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
     // General
     'search'                    => 'Zoek een %organisationNoun%...',
     'log_in_to'                 => 'Selecteer een %organisationNoun% en login bij',

--- a/theme/openconext/translations/messages.pt.php
+++ b/theme/openconext/translations/messages.pt.php
@@ -1,5 +1,12 @@
 <?php
-return [
+
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.pt.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
     // General
     'search'                    => 'Procure por uma %organisationNoun%...',
     'log_in_to'                 => 'Seleccione uma %organisationNoun% para se autenticar no serviço:',

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -1351,14 +1351,6 @@
         "@jimp/utils": "^0.10.3",
         "core-js": "^3.4.1",
         "jpeg-js": "^0.3.4"
-      },
-      "dependencies": {
-        "jpeg-js": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.0.tgz",
-          "integrity": "sha512-960VHmtN1vTpasX/1LupLohdP5odwAT7oK/VSm6mW0M58LbrBnowLAPWAZhWGhDAGjzbMnPXZxzB/QYgBwkN0w==",
-          "dev": true
-        }
       }
     },
     "@jimp/plugin-blit": {
@@ -3309,18 +3301,6 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "18.1.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-              "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
-              "dev": true,
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         }
       }
@@ -4037,6 +4017,12 @@
         }
       }
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "diff2html": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-2.12.2.tgz",
@@ -4047,14 +4033,6 @@
         "hogan.js": "^3.0.2",
         "merge": "^1.2.1",
         "whatwg-fetch": "^3.0.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        }
       }
     },
     "diffie-hellman": {
@@ -6815,6 +6793,12 @@
         "core-js": "^3.4.1",
         "regenerator-runtime": "^0.13.3"
       }
+    },
+    "jpeg-js": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
+      "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
+      "dev": true
     },
     "js-base64": {
       "version": "2.6.4",
@@ -10094,9 +10078,9 @@
           },
           "dependencies": {
             "yargs-parser": {
-              "version": "18.1.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-              "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+              "version": "13.1.2",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+              "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
               "dev": true,
               "requires": {
                 "camelcase": "^5.0.0",
@@ -11125,18 +11109,6 @@
             "trim-newlines": "^3.0.0",
             "type-fest": "^0.18.0",
             "yargs-parser": "^20.2.3"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "18.1.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-              "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
-              "dev": true,
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         },
         "micromatch": {
@@ -11369,6 +11341,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
           "dev": true
         }
       }
@@ -11973,9 +11951,9 @@
       },
       "dependencies": {
         "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
           "dev": true
         }
       }
@@ -12730,9 +12708,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {
@@ -12777,6 +12755,12 @@
           }
         }
       }
+    },
+    "yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true
     },
     "yauzl": {
       "version": "2.10.0",

--- a/theme/skeune/translations/messages.en.php
+++ b/theme/skeune/translations/messages.en.php
@@ -1,5 +1,12 @@
 <?php
-return [
+
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.en.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
     // General
     'button_screenreader'        =>  ', button',
     'button_expandable_screenreader' => ', button, expandable',

--- a/theme/skeune/translations/messages.nl.php
+++ b/theme/skeune/translations/messages.nl.php
@@ -1,5 +1,11 @@
 <?php
-return [
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.nl.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
     // General
     'button_screenreader'        =>  ', knop',
     'button_expandable_screenreader' => ' ,knop, uitklapbaar',

--- a/theme/skeune/translations/messages.pt.php
+++ b/theme/skeune/translations/messages.pt.php
@@ -1,5 +1,12 @@
 <?php
-return [
+
+$overrides = [];
+$overridesFile = __DIR__ . '/overrides.pt.php';
+if (file_exists($overridesFile)) {
+    $overrides = require $overridesFile;
+}
+
+return $overrides + [
     // General
     'button_screenreader'        =>  ', button',
     'button_expandable_screenreader' => ', button, expandable',


### PR DESCRIPTION
Prior to this change, theme translations were not overrideable.

This change ensures they are in the same way that the translations in \translations\messages are overrideable.

Issue available in pivotal at https://www.pivotaltracker.com/story/show/176956726