### PR TITLE
Fix missing titles in functional tests

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Helper/TestEntitySeeder.php
@@ -153,10 +153,9 @@ class TestEntitySeeder
 
         $wayfIdps = array();
         foreach ($identityProviders as $identityProvider) {
+            $name = 'name' . ucfirst($currentLocale);
             $wayfIdp = array(
-                'Name_nl' => $identityProvider->nameNl,
-                'Name_en' => $identityProvider->nameEn,
-                'Name_pt' => $identityProvider->namePt,
+                'Name' => $identityProvider->$name,
                 'Logo' => $identityProvider->logo ? $identityProvider->logo->url : '/images/placeholder.png',
                 'Keywords' => $identityProvider->keywordsEn,
                 'Access' => ($identityProvider->enabledInWayf) ? '1' : '0',
@@ -167,8 +166,8 @@ class TestEntitySeeder
             $wayfIdps[] = $wayfIdp;
         }
 
-        $nameSort = function ($a, $b) use ($currentLocale) {
-            return strtolower($a['Name_'.$currentLocale]) > strtolower($b['Name_'.$currentLocale]);
+        $nameSort = function ($a, $b) {
+            return strtolower($a['Name']) > strtolower($b['Name']);
         };
 
         // Sort the IdP entries by name


### PR DESCRIPTION
Prior to this change, the titles / names / displaytitle were missing in functional tests following the changes for the PT translation.

This change ensures they are restored.