### PR TITLE
Ensure search results remain after ENTER

### DIFF
--- a/theme/base/javascripts/wayf/searchBehaviour.js
+++ b/theme/base/javascripts/wayf/searchBehaviour.js
@@ -28,7 +28,6 @@ export const searchBehaviour = () => {
   // attach handler to search form
   document.querySelector('.wayf__search').addEventListener('submit', event => {
     event.preventDefault();
-    searchAndSortIdps(idpArray, event.target.value);
   });
 
   function searchHandler(idpArray, searchTerm) {


### PR DESCRIPTION
Prior to this change, the search results disappeared after pressing
enter.  This was only visible when enough idps were in the WAYF.  It did
 not prevent the first search result from being selected to log in with.
   But it wasn't right either.

This change prevents the search function from running when the form is
submitted (such as when you enter), thereby ensuring the search results
don't disappear.

Pivotal issue at https://www.pivotaltracker.com/story/show/177506557