### PR TITLE
Remove forgotten debug statement

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpDeleteDisable.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpDeleteDisable.html.twig
@@ -19,7 +19,6 @@
         {% else %}
             {% set idpTitle = '' %}
         {% endif %}
-        {{ idpTitle }}
         <span class="idp__delete">
             <span class="visually-hidden">
                 {{ 'wayf_delete_account_screenreader'|trans({'%idpTitle%': idpTitle}) }}


### PR DESCRIPTION
Prior to this change, a forgotten debug statement was visible when
deleting an account from "your accounts".

This change removes that statement.

Issue noticed when resolving https://www.pivotaltracker.com/story/show/177506557