### PR TITLE
Remove double titles on skeune error pages

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Feedback/authn-context-class-ref-blacklisted.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/authn-context-class-ref-blacklisted.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_authn_context_class_ref_blacklisted'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_authn_context_class_ref_blacklisted_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_authorization_policy_violation'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/clock-issue.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/clock-issue.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_clock_issue_title'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_clock_issue_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/custom.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/custom.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = title %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ description|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/invalid-acs-binding.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/invalid-acs-binding.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_invalid_acs_binding'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_invalid_acs_binding_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/invalid-acs-location.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/invalid-acs-location.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_no_message'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_invalid_acs_location'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/invalid-attribute-value.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/invalid-attribute-value.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_invalid_attribute_value'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_invalid_attribute_value_desc'|trans({'%attributeName%': attributeName,'%attributeValue%': attributeValue})|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/invalid-mfa-authn-context-class-ref.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/invalid-mfa-authn-context-class-ref.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_invalid_mfa_authn_context_class_ref'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_invalid_mfa_authn_context_class_ref_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/metadata-entity-not-found.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/metadata-entity-not-found.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_metadata_entity_id_not_found'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}<p>{{ 'error_metadata_entity_id_not_found_desc'|trans({'%message%': message}) }}</p>{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/missing-required-fields.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/missing-required-fields.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_missing_required_fields'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_missing_required_fields_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/no-authentication-request-received.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/no-authentication-request-received.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_no_authentication_request_received'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}<p>{{ message }}.</p>{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/no-idps.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/no-idps.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_no_idps'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_no_idps_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/received-error-status-code.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/received-error-status-code.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_received_error_status_code'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_received_error_status_code_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/received-invalid-response.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/received-invalid-response.html.twig
@@ -2,5 +2,5 @@
 
 {% set pageTitle = 'error_received_invalid_response'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/received-invalid-signed-response.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/received-invalid-signed-response.html.twig
@@ -2,5 +2,5 @@
 
 {% set pageTitle = 'error_received_invalid_signed_response'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/session-lost.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/session-lost.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_session_lost'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_session_lost_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/session-not-started.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/session-not-started.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_session_not_started'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_session_not_started_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/stepup-callout-unknown.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/stepup-callout-unknown.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_stepup_callout_unknown_title'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_stepup_callout_unknown_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/stepup-callout-unmet-loa.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/stepup-callout-unmet-loa.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_stepup_callout_unmet_loa_title'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_stepup_callout_unmet_loa_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/stepup-callout-user-cancelled.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/stepup-callout-user-cancelled.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_stepup_callout_user_cancelled_title'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_stepup_callout_user_cancelled_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/stuck-in-authentication-loop.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/stuck-in-authentication-loop.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_stuck_in_authentication_loop'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_stuck_in_authentication_loop_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unable-to-receive-message.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unable-to-receive-message.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_no_message'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_no_message_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unknown-error.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unknown-error.html.twig
@@ -3,7 +3,7 @@
 {# Prepare the page title #}
 {% set pageTitle = 'error_generic'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ parent() }} - {{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_generic_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unknown-identity-provider.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unknown-identity-provider.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_unknown_identity_provider'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_unknown_identity_provider_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unknown-preselected-idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unknown-preselected-idp.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_unknown_preselected_idp'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_unknown_preselected_idp_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unknown-requesterid-in-authnrequest.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unknown-requesterid-in-authnrequest.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_unknown_requesterid_in_authnrequest'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_unknown_requesterid_in_authnrequest'|trans|raw }}{% endblock %}
+{% block errorMessage %}{{ 'error_unknown_requesterid_in_authnrequest_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unknown-service-provider.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unknown-service-provider.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_unknown_service_provider'|trans({'%arg1%': entityId}) %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_unknown_service_provider_desc'|trans|raw }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unsupported-acs-location-scheme.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unsupported-acs-location-scheme.html.twig
@@ -2,5 +2,5 @@
 
 {% set pageTitle = 'error_unsupported_acs_location_scheme'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unsupported-signature-method.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unsupported-signature-method.html.twig
@@ -2,7 +2,7 @@
 
 {% set pageTitle = 'error_unsupported_signature_method'|trans %}
 {% block pageTitle %}{{ pageTitle }}{% endblock %}
-{% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}{{ 'error_unsupported_signature_method_desc'|trans({'%arg1%': signatureMethod})|raw }}{% endblock %}


### PR DESCRIPTION
Remove double titles from skeune error pages

Prior to this change, the title element received the textual content
twice.

This change removes the double content.

As per the boyscout rule, a wrong translation tag was also adjusted from
a title in the error body to the actual description.

Issue found when testing https://www.pivotaltracker.com/story/show/176714319