### PR TITLE
Use "account" instead of organisation

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Debug.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Debug.feature
@@ -11,7 +11,7 @@ Feature:
 
   Scenario: When a user opens the debug endpoint the wayf should be presented
     When I go to Engineblock URL "/authentication/sp/debug"
-    Then I should see "Selecteer een organisatie om in te loggen bij OpenConext EngineBlock"
+    Then I should see "Selecteer een account om in te loggen bij OpenConext EngineBlock"
 
   Scenario: A user should be able to test a login
     When I go to Engineblock URL "/authentication/sp/debug"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
@@ -81,7 +81,7 @@ Feature:
       And SP "Step Up" is a trusted proxy
       And SP "Step Up" signs its requests
      When I log in at "Step Up"
-     Then I should see "Select an organisation to login to Loa SP"
+     Then I should see "Select an account to login to Loa SP"
       And I select "AlwaysAuth" on the WAYF
       And I pass through EngineBlock
       And I pass through the IdP
@@ -236,7 +236,7 @@ Feature:
          # Bug report: https://www.pivotaltracker.com/story/show/164069793
     Then I should not see "Error - No organisations found"
          # The WAYF should be visible
-     And I should see "Select an organisation to login to"
+     And I should see "Select an account to login to"
 
   Scenario: Trusted proxy not signing requests results in an error
     Given SP "Step Up" is authenticating for SP "Loa SP"

--- a/theme/cypress/integration/skeune/wayf/wayf.general.spec.js
+++ b/theme/cypress/integration/skeune/wayf/wayf.general.spec.js
@@ -168,7 +168,7 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
   describe('Should show the remember my choice option', () => {
     it('Ensure some elements are on the page', () => {
       cy.visit('https://engine.vm.openconext.org/functional-testing/wayf?connectedIdps=5&rememberChoiceFeature=true');
-      cy.onPage('Select an organisation to login');
+      cy.onPage('Select an account to login');
       cy.onPage('Remember my choice');
     });
 

--- a/theme/skeune/translations/messages.en.php
+++ b/theme/skeune/translations/messages.en.php
@@ -19,7 +19,7 @@ return $overrides + [
     'language_switcher'     => 'Language switcher',
 
     // FOOTER
-    'log_in_to'     => 'Select an %organisationNoun% to login to %arg1%',
+    'log_in_to'     => 'Select an account to login to %arg1%',
     'helpLink'       => 'https://wiki.surfnet.nl/display/conextsupport/The+WAYF-page',
     'footer_navigation_screenreader'    => 'Footer navigation',
 

--- a/theme/skeune/translations/messages.nl.php
+++ b/theme/skeune/translations/messages.nl.php
@@ -18,7 +18,7 @@ return $overrides + [
     'language_switcher'     => 'Wissel van taal',
 
     // FOOTER
-    'log_in_to'     => 'Selecteer een %organisationNoun% om in te loggen bij %arg1%',
+    'log_in_to'     => 'Selecteer een account om in te loggen bij %arg1%',
     'helpLink'       => 'https://wiki.surfnet.nl/display/conextsupport/De+WAYF-pagina',
     'footer_navigation_screenreader'    => 'Footer navigatie',
 


### PR DESCRIPTION
Prior to this change, there was a forgotten instance of
%organisationName% in the english and dutch translation.

This change uses the "account" vernacular instad of the organisationName
 variable.

This PR replaces https://github
.com/OpenConext/OpenConext-engineblock/pull/1111 as made by @arnoutt who
noticed the typos.