### PR TITLE
Add a 'back to SP' button on the Stepup failed error pages

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -146,7 +146,8 @@ HTML
     'error_help-desk-href' => 'https://www.surf.nl/over-surf/dienstverlening-support-werkmaatschappijen',
     'error_help-desk-link-text' => 'Helpdesk',
     'error_help-desk-link-text-short' => 'Helpdesk',
-
+    'error_return-sp-link-text' => 'Return to %spName%',
+    'error_return-sp-link-text-short' => 'Return to service',
 
     'error_404'                         => '404 - Page not found',
     'error_404_desc'                    => 'This page has not been found.',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -145,6 +145,8 @@ HTML
     'error_help-desk-href' => 'https://www.surf.nl/over-surf/dienstverlening-support-werkmaatschappijen',
     'error_help-desk-link-text' => 'Helpdesk',
     'error_help-desk-link-text-short' => 'Helpdesk',
+    'error_return-sp-link-text' => 'Terug naar %spName%',
+    'error_return-sp-link-text-short' => 'Terug naar dienst',
 
     'error_404'                         => '404 - Pagina niet gevonden',
     'error_404_desc'                    => 'De pagina is niet gevonden.',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -146,7 +146,8 @@ HTML
     'error_help-desk-href' => 'https://www.surf.nl/over-surf/dienstverlening-support-werkmaatschappijen',
     'error_help-desk-link-text' => 'Helpdesk',
     'error_help-desk-link-text-short' => 'Helpdesk',
-
+    'error_return-sp-link-text' => 'Voltar ao %spName%',
+    'error_return-sp-link-text-short' => 'Voltar ao serviço',
 
     'error_404'                         => '404 - Página não encontrada',
     'error_404_desc'                    => 'Esta página não foi encontrada.',

--- a/src/OpenConext/EngineBlock/Stepup/StepupDecision.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupDecision.php
@@ -91,6 +91,10 @@ class StepupDecision
 
     private function isLoaRequirementSet(): bool
     {
+        // If the highest level is 1, no step up callout is requred.
+        if ($this->getStepupLoa() && $this->getStepupLoa()->getLevel() === 1) {
+            return false;
+        }
         return ($this->spLoa || $this->idpLoa || count($this->authnRequestLoas) > 0 || count($this->pdpLoas) > 0);
     }
 

--- a/src/OpenConext/EngineBlockBundle/Authentication/Service/SamlResponseHelper.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Service/SamlResponseHelper.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Authentication\Service;
+
+use DateTime;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlockBundle\Exception\RuntimeException;
+use SAML2\Constants;
+use SAML2\Response as SAMLResponse;
+use SAML2\XML\saml\Issuer;
+use function sprintf;
+
+class SamlResponseHelper
+{
+    /**
+     * @var MetadataRepositoryInterface
+     */
+    private $metaDataRepository;
+
+    public function __construct(MetadataRepositoryInterface $metaDataRepository)
+    {
+        $this->metaDataRepository = $metaDataRepository;
+    }
+
+    public function createAuthnFailedResponse(string $spEntityId, string $idpEntityId, string $originalRequestId, string $message): string
+    {
+        $issuer = new Issuer();
+        $issuer->setValue($idpEntityId);
+        $response = new SAMLResponse();
+        $response->setDestination($this->getAcu($spEntityId));
+        $response->setIssuer($issuer);
+        $response->setIssueInstant((new DateTime('now'))->getTimestamp());
+        $response->setInResponseTo($originalRequestId);
+        $response->setStatus([
+            'Code' => Constants::STATUS_RESPONDER,
+            'SubCode' => Constants::STATUS_AUTHN_FAILED,
+            'Message' => $message
+        ]);
+        return base64_encode($response->toUnsignedXML()->ownerDocument->saveXML());
+    }
+
+    public function getAcu(string $spEntityId)
+    {
+        $sp = $this->metaDataRepository->findServiceProviderByEntityId($spEntityId);
+        if ($sp) {
+            $acsLocations = $sp->assertionConsumerServices;
+            foreach ($acsLocations as $acsLocation) {
+                if ($acsLocation->binding === Constants::BINDING_HTTP_POST) {
+                    return $acsLocation->location;
+                }
+            }
+            throw new RuntimeException('No suitable ACS location could be find, no HTTP-POST binding available');
+        }
+        throw new RuntimeException(
+            sprintf('The SP with entity id "%s" could not be found while building the error response', $spEntityId)
+        );
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -279,6 +279,11 @@ services:
     engineblock.validator.saml_response_validator:
         class: OpenConext\EngineBlock\Validator\SamlResponseValidator
 
+    OpenConext\EngineBlockBundle\Authentication\Service\SamlResponseHelper:
+        class: OpenConext\EngineBlockBundle\Authentication\Service\SamlResponseHelper
+        arguments:
+            - "@engineblock.metadata.repository.cached_doctrine"
+
     engineblock.twig.extension.debug:
         class: OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Debug
         tags:
@@ -290,6 +295,7 @@ services:
             - "@engineblock.compat.application"
             - "@engineblock.error_feedback"
             - "@engineblock.compat.repository.metadata"
+            - "@OpenConext\\EngineBlockBundle\\Authentication\\Service\\SamlResponseHelper"
         tags:
              - { name: 'twig.extension' }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
+use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use DOMDocument;
@@ -412,6 +413,16 @@ class EngineBlockContext extends AbstractSubContext
         }
 
         throw new RuntimeException('Request access button found on page');
+    }
+
+    /**
+     * @Then /^I click the return to SP button$/
+     */
+    public function iClickTheAuthnFailedButton()
+    {
+        $page = $this->minkContext->getSession()->getPage();
+        $element = $page->find('css', '.footer-button__button');
+        $element->click();
     }
 
     /**

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -70,7 +70,6 @@ Feature:
         And I pass through EngineBlock
       Then the url should match "/functional-testing/SSO-SP/acs"
 
-    @WIP
     Scenario: LoA 1 is allowed, but refrains from doing a step up callout
       Given SP "SSO-SP" requests LoA "http://vm.openconext.org/assurance/loa1"
       When I log in at "SSO-SP"
@@ -112,6 +111,20 @@ Feature:
       Then I should see "Error - No suitable token found"
         And the url should match "/feedback/stepup-callout-unmet-loa"
         And the response status code should be 400
+    @WIP
+    Scenario: User can click back button on error page after failing StepUp
+       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"
+        When I log in at "SSO-SP"
+         And I select "SSO-IdP" on the WAYF
+         And I pass through EngineBlock
+         And I pass through the IdP
+         And Stepup will fail if the LoA can not be given
+        Then I should see "Error - No suitable token found"
+         And the url should match "/feedback/stepup-callout-unmet-loa"
+         And the response status code should be 400
+        Then I click the Authn Failed button
+         And the response should contain 'Responder'
+         And the response should contain 'SubCode'
 
     Scenario: Stepup authentication should show exception when user does cancel
       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -111,7 +111,7 @@ Feature:
       Then I should see "Error - No suitable token found"
         And the url should match "/feedback/stepup-callout-unmet-loa"
         And the response status code should be 400
-    @WIP
+
     Scenario: User can click back button on error page after failing StepUp
        Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"
         When I log in at "SSO-SP"
@@ -122,9 +122,10 @@ Feature:
         Then I should see "Error - No suitable token found"
          And the url should match "/feedback/stepup-callout-unmet-loa"
          And the response status code should be 400
-        Then I click the Authn Failed button
-         And the response should contain 'Responder'
-         And the response should contain 'SubCode'
+        Then I click the return to SP button
+         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:Responder'
+         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:AuthnFailed'
+         And the response should contain '(No message provided)'
 
     Scenario: Stepup authentication should show exception when user does cancel
       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
@@ -138,7 +138,7 @@ class StepupDecisionTest extends TestCase
             'Use highest PdP LoA if multiple PdP LoA set (allow no stepup)' => [['', '', [], ['loa3', 'loa2'], true], [true, 'loa3', true]],
             'Use highest PdP LoA if multiple PdP LoA set in different order (allow no stepup)' => [['', '', [], ['loa3', 'loa2'], true], [true, 'loa3', true]],
 
-            'Allow AuthnRequest (SP) LoA1, but take no action' => [['', '', [$this->buildLoa('loa1')], [], true], [false, 'loa1', true]],
+            'Allow AuthnRequest (SP) LoA1, but take no action' => [['', '', [$this->buildLoa('loa1')], [], true], [false, 'loa1', false]],
             'Use AuthnRequest (SP) LoA if SP LoA is lower' => [['loa2', '', [$this->buildLoa('loa3')], [], true], [true, 'loa3', true]],
             'Use IdP LoA if IdP LoA is highest and AuthnRequest (SP) LoA set (allow no stepup)' => [['', 'loa3', [$this->buildLoa('loa2')], [], true], [true, 'loa3', true]],
             'Use PdP LoA if  AuthnRequest (SP) LoA set (allow no stepup)' => [['', '', [$this->buildLoa('loa3')], [], true], [true, 'loa3', true]],

--- a/theme/base/stylesheets/components/old-not-converted/error-page/footer.scss
+++ b/theme/base/stylesheets/components/old-not-converted/error-page/footer.scss
@@ -18,6 +18,7 @@
 .footer-button {
     border-right: 1px solid white;
     display: inline-block;
+    height: 100%;
     text-align: center;
     width: 33.33%;
 
@@ -39,6 +40,20 @@
 
         &:hover {
             text-decoration: none;
+        }
+    }
+
+    &__button {
+        @include button-reset(inherit);
+        color: white;
+        cursor: pointer;
+        padding: 1.5rem 2rem 0.2rem;
+        text-decoration: none;
+        width: 100%;
+
+        .footer-button__text {
+            display: inline-block;
+            margin-bottom: 1rem;
         }
     }
 

--- a/theme/base/templates/modules/Authentication/View/Feedback/partial/saml_response_form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/partial/saml_response_form.html.twig
@@ -1,4 +1,4 @@
 <p class="footer-button__text footer-button__text--small">{{ 'error_return-sp-link-text-short'|trans }}</p>
-<form method="post" action="{{ getAcu() }}">
+<form method="post" action="{{ getAcu() }}" id="backToSPForm">
     <input type="hidden" name="SAMLResponse" value="{{ getSamlFailedResponse() }}"/>
 </form>

--- a/theme/base/templates/modules/Authentication/View/Feedback/partial/saml_response_form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/partial/saml_response_form.html.twig
@@ -1,0 +1,4 @@
+<p class="footer-button__text footer-button__text--small">{{ 'error_return-sp-link-text-short'|trans }}</p>
+<form method="post" action="{{ getAcu() }}">
+    <input type="hidden" name="SAMLResponse" value="{{ getSamlFailedResponse() }}"/>
+</form>

--- a/theme/base/templates/modules/Default/View/Error/partial/footer.html.twig
+++ b/theme/base/templates/modules/Default/View/Error/partial/footer.html.twig
@@ -2,6 +2,15 @@
 <footer class="error-page-footer-buttons">
     <div class="error-page-footer-buttons__container">
         <div class="error-page-footer-buttons__row">
+            {% if hasBackToSpLink() %}
+                <div class="footer-button">
+                    <span class="footer-button__link">
+                        <i class="footer-button__icon fa-arrow-left"></i>
+                        <p class="footer-button__text">{{ 'error_return-sp-link-text'|trans({'%spName%': getSpName()}) }}</p>
+                        {% include '@theme/Authentication/View/Feedback/partial/saml_response_form.html.twig' %}
+                    </span>
+                </div>
+            {%  endif %}
             {% if hasWikiLink(template) %}
                 <div class="footer-button">
                     {# The template var is set in the individual error Twigs, that's te place where we can determine what template is loaded. #}

--- a/theme/base/templates/modules/Default/View/Error/partial/footer.html.twig
+++ b/theme/base/templates/modules/Default/View/Error/partial/footer.html.twig
@@ -4,11 +4,10 @@
         <div class="error-page-footer-buttons__row">
             {% if hasBackToSpLink() %}
                 <div class="footer-button">
-                    <span class="footer-button__link">
-                        <i class="footer-button__icon fa-arrow-left"></i>
-                        <p class="footer-button__text">{{ 'error_return-sp-link-text'|trans({'%spName%': getSpName()}) }}</p>
-                        {% include '@theme/Authentication/View/Feedback/partial/saml_response_form.html.twig' %}
-                    </span>
+                    <button type="submit" class="footer-button__button" form="backToSPForm">
+                        <i class="footer-button__icon fa-arrow-left"></i><br/>
+                        <span class="footer-button__text">{{ 'error_return-sp-link-text'|trans({'%spName%': getSpName()}) }}</span>
+                    </button>
                 </div>
             {%  endif %}
             {% if hasWikiLink(template) %}
@@ -41,4 +40,7 @@
             {%  endif %}
         </div>
     </div>
+    {% if hasBackToSpLink() %}
+        {% include '@theme/Authentication/View/Feedback/partial/saml_response_form.html.twig' %}
+    {% endif %}
 </footer>


### PR DESCRIPTION
When required data is available, a back to SP button is rendered. Clicking this button sends a AuthnFailed SAML response back to the issuing SP.

https://www.pivotaltracker.com/story/show/176960606