### PR TITLE
Adjust php version in the twig linting script

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -97,7 +97,7 @@ jobs:
               run: |
                   cd docker && docker-compose exec -T php-fpm.vm.openconext.org bash -c '
                       echo -e "\nTwig lint\n"  && \
-                      php72 app/console lint:twig theme/ && \
+                      php app/console lint:twig theme/ && \
                       cd theme && \
                       echo -e "\nNPM lint\n" && \
                       npm run lint


### PR DESCRIPTION
We used php72 in the twig linting script, which is not needed in the CI.
  Just plain old "php" wil do.