### PR TITLE
Transparent SAML error Response for MFA entities

### DIFF
--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\EntityManager;
 use OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactor;
 use OpenConext\EngineBlock\Metadata\LoaRepository;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Service\MfaHelperInterface;
 use OpenConext\EngineBlock\Service\TimeProvider\TimeProviderInterface;
 use OpenConext\EngineBlock\Stepup\StepupEntityFactory;
 use OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper;
@@ -451,6 +452,11 @@ class EngineBlock_Application_DiContainer extends Pimple
     public function getProcessingStateHelper()
     {
         return $this->container->get('engineblock.service.processing_state_helper');
+    }
+
+    public function getMfaHelper(): MfaHelperInterface
+    {
+        return $this->container->get('engineblock.service.mfa_helper');
     }
 
     /**

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -90,6 +90,14 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         $application = EngineBlock_ApplicationSingleton::getInstance();
         $log = $application->getLogInstance();
 
+        if ($receivedResponse->isTransparentErrorResponse()) {
+            $log->info('Response contains an error response status code, SP is configured with transparent_authn_context.');
+            $response = $this->_server->createTransparentErrorResponse($receivedRequest, $receivedResponse);
+            $log->info('Sending AuthnFailed response back to SP');
+            $this->_server->sendResponseToRequestIssuer($receivedRequest, $response);
+            return;
+        }
+
         // Test if we should return a no passive status response back to the SP
         if (in_array(Constants::STATUS_NO_PASSIVE, $receivedResponse->getStatus())) {
             $log->info('Response contains NoPassive status code: responding with NoPassive status to SP');

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -538,6 +538,16 @@ class EngineBlock_Corto_ProxyServer
         return $response;
     }
 
+    public function createTransparentErrorResponse(
+        EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request,
+        EngineBlock_Saml2_ResponseAnnotationDecorator $receivedResponse
+    ) {
+        $response = $this->_createBaseResponse($request);
+        $this->_logger->info('Setting the status of the original (error) response on the SAML Response for the SP');
+        $response->setStatus($receivedResponse->getStatus());
+        return $response;
+    }
+
     /**
      * @param AuthnRequest|EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request
      * @param Response|EngineBlock_Saml2_ResponseAnnotationDecorator $sourceResponse
@@ -868,7 +878,11 @@ class EngineBlock_Corto_ProxyServer
                 EngineBlock_Exception::CODE_NOTICE
             );
         }
+        return $this->findRequestFromRequestId($requestId);
+    }
 
+    public function findRequestFromRequestId(string $requestId): ?EngineBlock_Saml2_AuthnRequestAnnotationDecorator
+    {
         $authnRequestRepository = new EngineBlock_Saml2_AuthnRequestSessionRepository($this->getLogger());
 
         $spRequestId = $authnRequestRepository->findLinkedRequestId($requestId);

--- a/library/EngineBlock/Saml2/ResponseAnnotationDecorator.php
+++ b/library/EngineBlock/Saml2/ResponseAnnotationDecorator.php
@@ -80,6 +80,8 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
      */
     protected $pdpRequestedLoas = [];
 
+    protected $isTransparentErrorResponse = false;
+
     /**
      * @param Response $response
      */
@@ -289,5 +291,21 @@ class EngineBlock_Saml2_ResponseAnnotationDecorator extends EngineBlock_Saml2_Me
     public function getOriginalResponse()
     {
         return $this->originalResponse;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTransparentErrorResponse(): bool
+    {
+        return $this->isTransparentErrorResponse;
+    }
+
+    /**
+     * @param bool $isTransparentErrorResponse
+     */
+    public function setIsTransparentErrorResponse(bool $isTransparentErrorResponse): void
+    {
+        $this->isTransparentErrorResponse = $isTransparentErrorResponse;
     }
 }

--- a/src/OpenConext/EngineBlock/Service/MfaHelper.php
+++ b/src/OpenConext/EngineBlock/Service/MfaHelper.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
+use Psr\Log\LoggerInterface;
+use function sprintf;
+
+class MfaHelper implements MfaHelperInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var MetadataRepositoryInterface
+     */
+    private $metadataRepository;
+
+    public function __construct(LoggerInterface $logger, MetadataRepositoryInterface $metadataRepository)
+    {
+        $this->logger = $logger;
+        $this->metadataRepository = $metadataRepository;
+    }
+
+    public function isTransparent(string $spEntityId, string $idpEntityId): bool
+    {
+        $this->logger->debug(sprintf('Test if SP %s is configured with transparant_authn_context via the IdP', $spEntityId));
+        $remoteIdP = $this->metadataRepository->findIdentityProviderByEntityId($idpEntityId);
+        if (!$remoteIdP) {
+            $this->logger->warning('The IdP can not be found');
+            return false;
+        }
+        $mfaEntities = $remoteIdP->getCoins()->mfaEntities();
+        $mfaEntity = $mfaEntities->findByEntityId($spEntityId);
+        if (!$mfaEntity) {
+            $this->logger->debug('The SP is not an MFA entity');
+            return false;
+        }
+        return $mfaEntity instanceof TransparentMfaEntity;
+    }
+}

--- a/src/OpenConext/EngineBlock/Service/MfaHelperInterface.php
+++ b/src/OpenConext/EngineBlock/Service/MfaHelperInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use OpenConext\EngineBlockBundle\Authentication\AuthenticationStateInterface;
+
+interface MfaHelperInterface
+{
+    /**
+     * The Mfa Helper isTransparent method can be used to figure out if the IdP is configured with
+     * MFA entity configuration. And specifically if the SP is set with the transparent_authn_context
+     */
+    public function isTransparent(string $spEntityId, string $idpEntityId): bool;
+}

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -92,6 +92,12 @@ services:
             - "@engineblock.compat.repository.metadata"
             - "@engineblock.compat.logger"
 
+    engineblock.service.mfa_helper:
+        class: OpenConext\EngineBlock\Service\MfaHelper
+        arguments:
+            - "@engineblock.compat.logger"
+            - "@engineblock.metadata.repository.cached_doctrine"
+
     engineblock.service.time_provider:
         class: OpenConext\EngineBlock\Service\TimeProvider\TimeProvider
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
@@ -88,3 +88,18 @@ Feature:
     And I pass through EngineBlock
     Then the url should match "functional-testing/SSO-IdP/sso"
     And the response should not contain "http://my-very-own-context.example.com/level9"
+
+  Scenario: While using transparent_authn_context AuthnFailed response is also passed transparently
+    Given the IdP "SSO-IdP" is configured for MFA authn method "transparent_authn_context" for SP "SSO-SP"
+    And the IdP is configured to always return Responses with StatusCode Responder/AuthnFailed
+    And the SP "SSO-SP" sends AuthnContextClassRef with value "http://sp-specific-loa.org/super-secure-second-factor-authn"
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SSO-IdP/sso"
+    And the AuthnRequest to submit should match xpath '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef[text()="http://sp-specific-loa.org/super-secure-second-factor-authn"]'
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+   Then the url should match "/functional-testing/SSO-SP/acs"
+    And the response should contain "urn:oasis:names:tc:SAML:2.0:status:Responder"
+    And the response should contain "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"

--- a/tests/unit/OpenConext/EngineBlock/Service/MfaHelperTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/MfaHelperTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\CachedDoctrineMetadataRepository;
+use OpenConext\EngineBlock\Metadata\MfaEntity;
+use OpenConext\EngineBlock\Metadata\MfaEntityCollection;
+use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class MfaHelperTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private $mfaHelper;
+
+    private $repo;
+
+    public function setUp()
+    {
+        $this->repo = m::mock(CachedDoctrineMetadataRepository::class);
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldIgnoreMissing();
+        $this->mfaHelper = new MfaHelper($logger, $this->repo);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     */
+    public function happy_flow()
+    {
+        $spEntityId = 'arbitrarySpEntityId';
+        $idpEntityId = 'arbitraryIdPEntityId';
+        $this->repo->shouldReceive('findIdentityProviderByEntityId')->with($idpEntityId)->andReturn($this->createIdP($spEntityId, true, true));
+        $isTransparent = $this->mfaHelper->isTransparent($spEntityId, $idpEntityId);
+        self::assertTrue($isTransparent);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     */
+    public function not_transparent_mfa_entity()
+    {
+        $spEntityId = 'arbitrarySpEntityId';
+        $idpEntityId = 'arbitraryIdPEntityId';
+        $this->repo->shouldReceive('findIdentityProviderByEntityId')->with($idpEntityId)->andReturn($this->createIdP($spEntityId, true, false));
+        $isTransparent = $this->mfaHelper->isTransparent($spEntityId, $idpEntityId);
+        self::assertFalse($isTransparent);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     */
+    public function not_an_mfa_entity()
+    {
+        $spEntityId = 'arbitrarySpEntityId';
+        $idpEntityId = 'arbitraryIdPEntityId';
+        $this->repo->shouldReceive('findIdentityProviderByEntityId')->with($idpEntityId)->andReturn($this->createIdP($spEntityId, false, false));
+        $isTransparent = $this->mfaHelper->isTransparent($spEntityId, $idpEntityId);
+        self::assertFalse($isTransparent);
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     */
+    public function idp_not_found()
+    {
+        $spEntityId = 'arbitrarySpEntityId';
+        $idpEntityId = 'arbitraryIdPEntityId';
+        $this->repo->shouldReceive('findIdentityProviderByEntityId')->with($idpEntityId)->andReturn(null);
+        $isTransparent = $this->mfaHelper->isTransparent($spEntityId, $idpEntityId);
+        self::assertFalse($isTransparent);
+    }
+
+    private function createIdP($spEntityId, $isSpInMfaEntities, $isTransparent)
+    {
+        $idp = m::mock(IdentityProvider::class);
+        $mfaEntities = m::mock(MfaEntityCollection::class);
+        $mfaEntity = null;
+        if ($isSpInMfaEntities) {
+            if ($isTransparent) {
+                $mfaEntity = m::mock(TransparentMfaEntity::class);
+            } else {
+                $mfaEntity = m::mock(MfaEntity::class);
+            }
+        }
+        $mfaEntities->shouldReceive('findByEntityId')->with($spEntityId)->andReturn($mfaEntity);
+        $idp->shouldReceive('getCoins->mfaEntities')->andReturn($mfaEntities);
+        return $idp;
+    }
+}


### PR DESCRIPTION
When a SP request a AuthnContext and transparent_authn_context is enabled, we pass on to the IDP. There is no way for us to know the meaning or value for this AuthnContext. If a user can't use the requested AuthnContext, the SP should be informed so it can decide what to do.

When an SP is configured for transparant_authn_context, an NoAuthContext saml error from the IDP should be copied to the SP, so it can act accordingly.

https://www.pivotaltracker.com/story/show/173602383