### PR TITLE
Ensure fallbacks in the error pages function correctly

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -244,6 +244,7 @@ Your %organisationNoun% has denied you access to this service. You will have to 
     'error_received_invalid_response'       => 'Error - Invalid %idpName% SAML response',
     'error_received_invalid_response_no_idp_name'       => 'Error - Invalid %organisationNoun% SAML response',
     'error_received_invalid_signed_response'=> 'Error - Invalid signature on %idpName% response',
+    'error_received_invalid_signed_response_no_idp_name'=> 'Error - Invalid signature on %organisationNoun% response',
     'error_stuck_in_authentication_loop' => 'Error - You got stuck in a black hole',
     'error_stuck_in_authentication_loop_desc' => 'You\'ve successfully authenticated at %idpName% but %spName% sends you back again to %suiteName%. Because you are already logged in, %suiteName% then sends you back to %spName%, which results in an infinite black hole. Likely, this is caused by an error at %spName%.',
     'error_stuck_in_authentication_loop_desc_no_idp_name' => 'You\'ve successfully authenticated at your %organisationNoun% but %spName% sends you back again to %suiteName%. Because you are already logged in, %suiteName% then sends you back to %spName%, which results in an infinite black hole. Likely, this is caused by an error at %spName%.',

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -157,6 +157,7 @@ HTML
     'error_help_desc'               => '<p></p>',
     'error_no_idps'                 => 'Error - No %organisationNounPlural% found',
     'error_no_idps_desc'            => 'Logging into %spName% is not possible via %suiteName%. %spName% is not connected to any %organisationNounPlural%.',
+    'error_no_idps_desc_no_sp_name'            => 'Logging into this service is not possible via %suiteName%. The service is not connected to any %organisationNounPlural%.',
     'error_session_lost'            => 'Error - your session was lost',
     'error_session_lost_desc'       => 'To continue to the service an active session is required. However, your session expired. Perhaps you waited too long with logging in? Please go back to the service and try again. If that doesn\'t work, close your browser first and then try again.',
     'error_session_not_started'            => 'Error - No session found',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -181,7 +181,7 @@ HTML
     'error_unknown_service_provider'                => 'Error - %spName% onbekend',
     'error_unknown_service_provider_no_sp_name'     => 'Error - Onbekende dienst',
     'error_unknown_service_provider_desc'     => '%spName% is onbekend bij %suiteName%. Wellicht heeft %idpName% toegang tot deze dienst niet geactiveerd. Wil je gebruik maken van %spName%, wend je dan tot de helpdesk van %idpName%.',
-    'error_unknown_service_provider_desc_no_sp_name' => 'De verzochte Service Provider is onbekend bij %suiteName%. Wellicht heeft %idpName% toegang tot deze dienst niet geactiveerd. Wil je gebruik maken van deze dienst, wend je dan tot de helpdesk %idpName%.',
+    'error_unknown_service_provider_desc_no_sp_name' => 'De verzochte Service Provider is onbekend bij %suiteName%. Wellicht heeft %idpName% toegang tot deze dienst niet geactiveerd. Wil je gebruik maken van deze dienst, wend je dan tot de helpdesk van %idpName%.',
     'error_unknown_service_provider_desc_no_idp_name' => '%spName% is onbekend bij %suiteName%. Wellicht heeft je %organisationNoun% toegang tot deze dienst niet geactiveerd. Wil je gebruik maken van %spName%, wend je dan tot de helpdesk van je %organisationNoun%.',
     'error_unknown_service_provider_desc_no_names' => 'De verzochte Service Provider is onbekend bij %suiteName%. Wellicht heeft je %organisationNoun% toegang tot deze dienst niet geactiveerd. Wil je gebruik maken van deze dienst, wend je dan tot de helpdesk van je %organisationNoun%.',
     'error_unsupported_acs_location_scheme' => 'Fout - URI scheme van de ACS locatie wordt niet ondersteund',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -156,6 +156,7 @@ HTML
     'error_help_desc'                   => '<p></p>',
     'error_no_idps'                     => 'Error - Geen %organisationNounPlural% gevonden',
     'error_no_idps_desc'                => 'Inloggen op %spName% via %suiteName% is onmogelijk. %spName% is niet gekoppeld met een %organisationNoun%.',
+    'error_no_idps_desc_no_sp_name'                => 'Inloggen op de dienst via %suiteName% is onmogelijk. De dienst is niet gekoppeld met een %organisationNoun%.',
     'error_session_lost'                => 'Fout - Sessie is verloren gegaan',
     'error_session_lost_desc'           => 'Om verder te gaan naar de dienst heb je een actieve sessie nodig, maar deze is verlopen. Heb je misschien te lang gewacht met inloggen? Ga terug naar de dienst en probeer het nog een keer. Als dat niet werkt, sluit je browser af en probeer nogmaals opnieuw in te loggen.',
     'error_session_not_started'                => 'Fout - Geen sessie gevonden',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -257,6 +257,7 @@ Je %organisationNoun% heeft je de toegang geweigerd tot deze dienst. Je zult dus
     'error_received_invalid_response'        => 'Fout - Ongeldig SAML-bericht van %idpName%',
     'error_received_invalid_response_no_idp_name'        => 'Fout - Ongeldig SAML-bericht van %organisationNoun%',
     'error_received_invalid_signed_response' => 'Fout - Ongeldige handtekening op antwoord van %idpName%',
+    'error_received_invalid_signed_response_no_idp_name' => 'Fout - Ongeldige handtekening op antwoord van %organisationNoun%',
     'error_stuck_in_authentication_loop' => 'Fout - Je zit vast in een zwart gat',
     'error_stuck_in_authentication_loop_desc' => 'Je bent succesvol ingelogd bij %idpName% maar %spName% stuurt je weer terug naar %suiteName%. Omdat je succesvol bent ingelogd, stuurt %suiteName% je weer naar %spName%, wat resulteert in een oneindig zwart gat. Dit komt waarschijnlijk door een foutje aan de kant van %spName%.',
     'error_stuck_in_authentication_loop_desc_no_idp_name' => 'Je bent succesvol ingelogd bij je %organisationNoun% maar %spName% stuurt je weer terug naar %suiteName%. Omdat je succesvol bent ingelogd, stuurt %suiteName% je weer naar %spName%, wat resulteert in een oneindig zwart gat. Dit komt waarschijnlijk door een foutje aan de kant van %spName%.',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -253,6 +253,7 @@ A sua %organisationNoun% negou-lhe acesso a este serviço. Terá de entrar em co
     'error_received_invalid_response'       => 'Erro - Resposta inválida do %idpName%',
     'error_received_invalid_response_no_idp_name'       => 'Erro - Resposta inválida do Fornecedor de Identidade',
     'error_received_invalid_signed_response'=> 'Erro - resposta de assinatura inválida do %idpName%',
+    'error_received_invalid_signed_response'=> 'Erro - resposta de assinatura inválida do %organisationNoun%',
     'error_stuck_in_authentication_loop' => 'Erro - Ficou preso(a) no vazio',
     'error_stuck_in_authentication_loop_desc' => 'Autenticou-se com sucesso no seu %idpName%, mas o %spName% reencaminhou-o de volta para %suiteName%. Como já está autenticado, o %suiteName% o reencaminha de volta para o %spName%, o que resulta num ciclo infinito. Muito provavelmente, isto é provocado por um erro no %spName%.',
     'error_stuck_in_authentication_loop_desc_no_idp_name' => 'Autenticou-se com sucesso no seu Fornecedor de Identidade, mas o %spName% reencaminhou-o de volta para %suiteName%. Como já está autenticado, o %suiteName% o reencaminha de volta para o %spName%, o que resulta num ciclo infinito. Muito provavelmente, isto é provocado por um erro no %spName%.',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -157,6 +157,7 @@ HTML
     'error_help_desc'               => '<p></p>',
     'error_no_idps'                 => 'Erro - Não foi encontrado nenhum Fornecedor de Identidade',
     'error_no_idps_desc'            => 'O %spName% a que pretende ligar-se não está acessível através da %organisationNounPlural%.',
+    'error_no_idps_desc_no_sp_name'            => 'O serviço (&lsquo;Service Provider&rsquo;) a que pretende ligar-se não está acessível através da %organisationNounPlural%.',
     'error_session_lost'            => 'Erro - a sua sessão foi perdida',
     'error_session_lost_desc'       => '<p>Esta ação requer uma sessão ativa, no entanto, não conseguimos encontrar a sessão. Está a aguardar há muito tempo? Feche o browser e tente novamente, ou tente um browser diferente.</p>',
     'error_session_not_started'            => 'Erro - a sua sessão não foi encontrada',

--- a/theme/base/templates/modules/Authentication/View/Feedback/missing-required-fields.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/missing-required-fields.html.twig
@@ -6,13 +6,13 @@
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}
-    {% if withIdpName %}
+    {% if withIdpName and withSpName %}
         {{ 'error_missing_required_fields_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName'], '%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
     {% elseif withIdpName %}
-        {{ 'error_missing_required_fields_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+        {{ 'error_missing_required_fields_desc_no_sp_name'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
     {% elseif withSpName %}
-        {{ 'error_missing_required_fields_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
+        {{ 'error_missing_required_fields_desc_no_idp_name'|trans({'%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
     {% else %}
-        {{ 'error_missing_required_fields_desc'|trans|raw }}
+        {{ 'error_missing_required_fields_desc_no_name'|trans|raw }}
     {% endif %}
 {% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/no-idps.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/no-idps.html.twig
@@ -5,4 +5,10 @@
 {% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_no_idps_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName'] })|raw }}{% endblock %}
+{% block errorMessage %}
+    {% if withSpName %}
+        {{ 'error_no_idps_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName'] })|raw }}
+    {% else %}
+        {{ 'error_no_idps_desc_no_sp_name'|trans|raw }}
+    {% endif %}
+{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/received-invalid-signed-response.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/received-invalid-signed-response.html.twig
@@ -1,6 +1,17 @@
 {% extends '@theme/Default/View/Error/error.html.twig' %}
 
-{% set pageTitle = 'error_received_invalid_signed_response'|trans({'%idpName%': feedbackInfoMap['identityProviderName']}) %}
-{% block pageTitle %}{{ 'error_received_invalid_signed_response'|trans({'%idpName%': feedbackInfoMap['identityProviderName']}) }}{% endblock %}
+{% if feedbackInfoMap is defined and feedbackInfoMap['identityProviderName'] %}
+    {% set pageTitle = 'error_received_invalid_signed_response'|trans({'%idpName%': feedbackInfoMap['identityProviderName']}) %}
+{% else %}
+    {% set pageTitle = 'error_received_invalid_signed_response_no_idp_name'|trans %}
+{% endif %}
+
+{% block pageTitle %}
+    {% if withIdpName %}
+        {{ 'error_received_invalid_signed_response'|trans({'%idpName%': feedbackInfoMap['identityProviderName']}) }}
+    {% else %}
+        {{ 'error_received_invalid_signed_response_no_idp_name'|trans }}
+    {% endif %}
+{% endblock %}
 {% block title %}{{ parent() }}{% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}

--- a/theme/base/templates/modules/Authentication/View/Feedback/unknown-service-provider.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unknown-service-provider.html.twig
@@ -17,9 +17,13 @@
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}
-    {% if withSpName %}
-        {{ 'error_unknown_service_provider_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
+    {% if withSpName and withIdpName %}
+        {{ 'error_unknown_service_provider_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName'], '%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% elseif withSpName %}
+        {{ 'error_unknown_service_provider_desc_no_idp_name'|trans({'%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
+    {% elseif withIdpName %}
+        {{ 'error_unknown_service_provider_desc_no_sp_name'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
     {% else %}
-        {{ 'error_unknown_service_provider_desc_no_sp_name'|trans|raw }}
+        {{ 'error_unknown_service_provider_desc_no_names'|trans|raw }}
     {% endif %}
 {% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/authn-context-class-ref-blacklisted.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/authn-context-class-ref-blacklisted.html.twig
@@ -5,4 +5,10 @@
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_authn_context_class_ref_blacklisted_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}{% endblock %}
+{% block errorMessage %}
+    {% if withIdpName %}
+        {{ 'error_authn_context_class_ref_blacklisted_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% else %}
+        {{ 'error_authn_context_class_ref_blacklisted_desc_no_idp_name'|trans|raw }}
+    {% endif %}
+{% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/authorization-policy-violation.html.twig
@@ -6,7 +6,13 @@
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
 {% block errorMessage %}
-    <h2>{{ 'error_authorization_policy_violation_info'|trans({'%spName%': feedbackInfoMap['serviceProviderName'], '%idpName%': feedbackInfoMap['identityProviderName']})|raw }}</h2>
+    <h2>
+        {% if withIdpName %}
+            {{ 'error_authorization_policy_violation_info'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+        {% else %}
+            {{ 'error_authorization_policy_violation_info_no_idp_name'|trans|raw }}
+        {% endif %}
+    </h2>
 
     {% if logo is not null %}
         <img src="{{ logo.url }}"
@@ -25,7 +31,15 @@
         </div>
 
     {% endif %}
-    {{ 'error_authorization_policy_violation_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName'], '%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% if withIdpName and withSpName %}
+        {{ 'error_authorization_policy_violation_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName'], '%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% elseif withIdpName %}
+        {{ 'error_authorization_policy_violation_desc_no_sp_name'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% elseif withSpName %}
+        {{ 'error_authorization_policy_violation_desc_no_idp_name'|trans({'%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
+    {% else %}
+        {{ 'error_authorization_policy_violation_desc_no_name'|trans|raw }}
+    {% endif %}
 {% endblock %}
 
 {# The PDP error page should not show the table with the feedback information and back button. #}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/clock-issue.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/clock-issue.html.twig
@@ -5,4 +5,10 @@
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_clock_issue_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}{% endblock %}
+{% block errorMessage %}
+    {% if withIdpName %}
+        {{ 'error_clock_issue_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% else %}
+        {{ 'error_clock_issue_desc_no_idp_name'|trans|raw }}
+    {% endif %}
+{% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/invalid-attribute-value.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/invalid-attribute-value.html.twig
@@ -5,4 +5,10 @@
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_invalid_attribute_value_desc'|trans({'%attributeName%': attributeName,'%attributeValue%': attributeValue, '%idpName%': feedbackInfoMap['identityProviderName']})|raw }}{% endblock %}
+{% block errorMessage %}
+    {% if withIdpName %}
+        {{ 'error_invalid_attribute_value_desc'|trans({'%attributeName%': attributeName,'%attributeValue%': attributeValue, '%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% else %}
+        {{ 'error_invalid_attribute_value_desc_no_idp_name'|trans({'%attributeName%': attributeName,'%attributeValue%': attributeValue})|raw }}
+    {% endif %}
+{% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/invalid-mfa-authn-context-class-ref.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/invalid-mfa-authn-context-class-ref.html.twig
@@ -5,4 +5,10 @@
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_invalid_mfa_authn_context_class_ref_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}{% endblock %}
+{% block errorMessage %}
+    {% if withIdpName %}
+        {{ 'error_invalid_mfa_authn_context_class_ref_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% else %}
+        {{ 'error_invalid_mfa_authn_context_class_ref_desc_no_idp_name'|trans|raw }}
+    {% endif %}
+{% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/missing-required-fields.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/missing-required-fields.html.twig
@@ -5,4 +5,14 @@
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_missing_required_fields_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName'], '%spName%': feedbackInfoMap['serviceProviderName']})|raw }}{% endblock %}
+{% block errorMessage %}
+    {% if withIdpName and withSpName %}
+        {{ 'error_missing_required_fields_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName'], '%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
+    {% elseif withIdpName %}
+        {{ 'error_missing_required_fields_desc_no_sp_name'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% elseif withSpName %}
+        {{ 'error_missing_required_fields_desc_no_idp_name'|trans({'%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
+    {% else %}
+        {{ 'error_missing_required_fields_desc_no_name'|trans|raw }}
+    {% endif %}
+{% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/no-idps.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/no-idps.html.twig
@@ -5,4 +5,10 @@
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_no_idps_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName'] })|raw }}{% endblock %}
+{% block errorMessage %}
+    {% if withSpName %}
+        {{ 'error_no_idps_desc'|trans({'%spName%': feedbackInfoMap['serviceProviderName'] })|raw }}
+    {% else %}
+        {{ 'error_no_idps_desc_no_sp_name'|trans|raw }}
+    {% endif %}
+{% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/received-invalid-signed-response.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/received-invalid-signed-response.html.twig
@@ -1,6 +1,18 @@
 {% extends '@theme/Default/View/Error/error.html.twig' %}
 
-{% set pageTitle = 'error_received_invalid_signed_response'|trans({'%idpName%': feedbackInfoMap['identityProviderName']}) %}
-{% block pageTitle %}{{ 'error_received_invalid_signed_response'|trans({'%idpName%': feedbackInfoMap['identityProviderName']}) }}{% endblock %}
+{% if feedbackInfoMap is defined and feedbackInfoMap['identityProviderName'] %}
+    {% set pageTitle = 'error_received_invalid_signed_response'|trans({'%idpName%': feedbackInfoMap['identityProviderName']}) %}
+{% else %}
+    {% set pageTitle = 'error_received_invalid_signed_response_no_idp_name'|trans %}
+{% endif %}
+
+{% block pageTitle %}
+    {% if withIdpName %}
+        {{ 'error_received_invalid_signed_response'|trans({'%idpName%': feedbackInfoMap['identityProviderName']}) }}
+    {% else %}
+        {{ 'error_received_invalid_signed_response_no_idp_name'|trans }}
+    {% endif %}
+{% endblock %}
+
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/stuck-in-authentication-loop.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/stuck-in-authentication-loop.html.twig
@@ -5,4 +5,14 @@
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ pageTitle }}{% endblock %}
 
-{% block errorMessage %}{{ 'error_stuck_in_authentication_loop_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName'], '%spName%': feedbackInfoMap['serviceProviderName']})|raw }}{% endblock %}
+{% block errorMessage %}
+    {% if withIdpName and withSpName %}
+        {{ 'error_stuck_in_authentication_loop_desc'|trans({'%idpName%': feedbackInfoMap['identityProviderName'], '%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
+    {% elseif withIdpName %}
+        {{ 'error_stuck_in_authentication_loop_desc_no_sp_name'|trans({'%idpName%': feedbackInfoMap['identityProviderName']})|raw }}
+    {% elseif withSpName %}
+        {{ 'error_stuck_in_authentication_loop_desc_no_idp_name'|trans({'%spName%': feedbackInfoMap['serviceProviderName']})|raw }}
+    {% else %}
+        {{ 'error_stuck_in_authentication_loop_desc_no_name'|trans|raw }}
+    {% endif %}
+{% endblock %}

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -3877,8 +3877,7 @@
         },
         "engine.io-client": {
           "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
-          "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "component-emitter": "~1.3.0",
@@ -3890,7 +3889,6 @@
             "parseqs": "0.0.6",
             "parseuri": "0.0.6",
             "ws": "~7.4.2",
-            "xmlhttprequest-ssl": "~1.5.4",
             "yeast": "0.1.2"
           },
           "dependencies": {
@@ -12660,12 +12658,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true
-    },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
       "dev": true
     },
     "xtend": {


### PR DESCRIPTION
Prior to this change:
- the fallback of the unknown-service-provider had
a missing case: that for no idp name.  There was also a word missing
from the Dutch translation.
- there was no fallback for the received an invalid signed response error
- there was a missing fallback for no-idps-error
- the name of the fallbacks for missing required fields was incorrect
- the openconext theme had several missing fallbacks

This change adds the cases & fixes the translation.

Pivotal story at: https://www.pivotaltracker.com/story/show/176714319
Relevant comments at:
- https://www.pivotaltracker.com/story/show/176714319/comments/224272628
- https://www.pivotaltracker.com/story/show/176714319/comments/224272649