### PR TITLE
Apply ARP only once in the filter chain.

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/AddEduPersonTargettedId.php
+++ b/library/EngineBlock/Corto/Filter/Command/AddEduPersonTargettedId.php
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+use SAML2\Constants;
+
 class EngineBlock_Corto_Filter_Command_AddEduPersonTargettedId extends EngineBlock_Corto_Filter_Command_Abstract
     implements EngineBlock_Corto_Filter_Command_ResponseAttributesModificationInterface
 {
@@ -39,6 +41,14 @@ class EngineBlock_Corto_Filter_Command_AddEduPersonTargettedId extends EngineBlo
             $this->_server->getRepository()
         );
 
+        // Find out if the EduPersonTargetedId is in the ARP of the destination SP.
+        // If the ARP is NULL this means no ARP = let everything through including ePTI.
+        // Otherwise only add ePTI if it's acutally in the ARP.
+        $arp = $destinationMetadata->getAttributeReleasePolicy();
+        if (!is_null($arp) && !$arp->hasAttribute(Constants::EPTI_URN_MACE)) {
+            return;
+        }
+
         // Resolve what NameID we should send the destination.
         $resolver = new EngineBlock_Saml2_NameIdResolver();
         $nameId = $resolver->resolve(
@@ -48,8 +58,6 @@ class EngineBlock_Corto_Filter_Command_AddEduPersonTargettedId extends EngineBlo
             $this->_collabPersonId
         );
 
-        $this->_responseAttributes['urn:mace:dir:attribute-def:eduPersonTargetedID'] = array(
-            $nameId
-        );
+        $this->_responseAttributes[Constants::EPTI_URN_MACE] = [ $nameId ];
     }
 }

--- a/library/EngineBlock/Corto/Filter/Output.php
+++ b/library/EngineBlock/Corto/Filter/Output.php
@@ -83,9 +83,6 @@ class EngineBlock_Corto_Filter_Output extends EngineBlock_Corto_Filter_Abstract
             // Add the appropriate NameID to the 'eduPeronTargetedID'.
             new EngineBlock_Corto_Filter_Command_AddEduPersonTargettedId(),
 
-            // Apply ARP to custom added attributes one last time for the eduPersonTargetedId
-            new EngineBlock_Corto_Filter_Command_AttributeReleasePolicy(),
-
             // Convert all attributes to their OID format (if known) and add these.
             new EngineBlock_Corto_Filter_Command_DenormalizeAttributes(),
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/EduPersonTargetedId.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/EduPersonTargetedId.feature
@@ -1,0 +1,92 @@
+Feature:
+  In order to pass a NameID to SPs that can only consume attributes
+  As an OpenConext admin
+  I need EB to add an EduPersonTargetedId attribute when requested in the ARP
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+    And no registered SPs
+    And no registered Idps
+    And an Identity Provider named "TestIdp"
+    And a Service Provider named "No ARP"
+    And a Service Provider named "Empty ARP"
+    And a Service Provider named "ARP without ePTI"
+    And a Service Provider named "ARP with ePTI"
+    And a Service Provider named "Step Up"
+    And SP "ARP with ePTI" uses the Unspecified NameID format
+    And SP "Empty ARP" allows no attributes
+    And SP "ARP without ePTI" allows an attribute named "urn:mace:dir:attribute-def:uid"
+    And SP "ARP with ePTI" allows an attribute named "urn:mace:dir:attribute-def:uid"
+    And SP "ARP with ePTI" allows an attribute named "urn:mace:dir:attribute-def:eduPersonTargetedID"
+    And feature "eb.run_all_manipulations_prior_to_consent" is disabled
+
+  Scenario: As a user for an SP with an empty ARP I get no attributes (ergo no ePTI)
+    When I log in at "Empty ARP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should not contain "urn:mace:dir:attribute-def:eduPersonTargetedId"
+
+  Scenario: As a user for an Idp SP without ARP I get all attributes, including ePTI
+    When I log in at "No ARP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    And the response should contain "urn:mace:dir:attribute-def:eduPersonTargetedID"
+
+  Scenario: As a user for an SP with an ARP which does not contain ePTI, I do not get ePTI
+    When I log in at "ARP without ePTI"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    And the response should not contain "urn:mace:dir:attribute-def:eduPersonTargetedID"
+
+  Scenario: As a user for an SP with an ARP which contains ePTI, I do get ePTI
+    When I log in at "ARP with ePTI"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    And the response should not contain "urn:mace:dir:attribute-def:eduPersonTargetedID"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    And the response should contain "urn:mace:dir:attribute-def:eduPersonTargetedID"
+
+  Scenario: As a user for an SP with an ARP which contains ePTI, the EPTI is a SAML NameID
+    When I log in at "ARP with ePTI"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    And the response should not contain "urn:mace:dir:attribute-def:eduPersonTargetedID"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonTargetedID"]/saml:AttributeValue/saml:NameID[@Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"]'
+
+  Scenario: Whether an ePTI is released is determined by the destination SP in case of trusted proxy
+    Given SP "Step Up" is authenticating for SP "ARP with ePTI"
+    And SP "Step Up" is a trusted proxy
+    And SP "Step Up" signs its requests
+    And SP "Step Up" does not require consent
+    And SP "Step Up" uses the Unspecified NameID format
+    When I log in at "Step Up"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "urn:mace:dir:attribute-def:eduPersonTargetedID"
+    And I pass through EngineBlock
+    Then the response should contain "urn:mace:dir:attribute-def:eduPersonTargetedID"


### PR DESCRIPTION
Currently EB applies the ARP two times in the filter chain. The second time it is just done because ePTI is first added unconditionally, then the entire ARP is applied to decide whether this is to be let through. So if you have an ARP that results in (a,b) in the first pass, the AddEduPeronTargetedId filter command makes the attribute set be (a,b,ePTI), the second ARP is applied and the attribute set is again (a,b).

This has several drawbacks:
- Anything added in the attribute manipulation is filtered out by the second ARP run. This usually means that you need to disable the ARP when having an AM. This has quite some consequences including confusing display in the Consent screen and in Dashboard.
- Attribute aggregation is configured in the ARP so you cannot use AA with an Attribute Manipulation now.
- Complexity and elevated mental load in understanding the filter chain and EB's processing for people working with EB as admins or developers.
- It does not seem optimal performance wise, but probably this is not that significant.

To resolve these issues, the decision on whether to add the ePTI is moved into the AddEduPersonTargetedId filter command. First, we added some tests to confirm the current ePTI behaviour (since these were not present yet). Then, the second ARP step is removed and in the AddEduPersonTargetedId command it is checked whether the ePTI is in the ARP. Only when it is, it is generated and released. The ePTI command is still well understandable and the logic of releasing the ePTI and its value is now kept together. The added tests still pass afterwards.

Closes: #632 