### PR TITLE
Temporarily disable back to sp link

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -112,20 +112,21 @@ Feature:
         And the url should match "/feedback/stepup-callout-unmet-loa"
         And the response status code should be 400
 
-    Scenario: User can click back button on error page after failing StepUp
-       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"
-        When I log in at "SSO-SP"
-         And I select "SSO-IdP" on the WAYF
-         And I pass through EngineBlock
-         And I pass through the IdP
-         And Stepup will fail if the LoA can not be given
-        Then I should see "Error - No suitable token found"
-         And the url should match "/feedback/stepup-callout-unmet-loa"
-         And the response status code should be 400
-        Then I click the return to SP button
-         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:Responder'
-         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:AuthnFailed'
-         And the response should contain '(No message provided)'
+#    TODO: fix this test after re-enabling back to sp link
+#    Scenario: User can click back button on error page after failing StepUp
+#       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"
+#        When I log in at "SSO-SP"
+#         And I select "SSO-IdP" on the WAYF
+#         And I pass through EngineBlock
+#         And I pass through the IdP
+#         And Stepup will fail if the LoA can not be given
+#        Then I should see "Error - No suitable token found"
+#         And the url should match "/feedback/stepup-callout-unmet-loa"
+#         And the response status code should be 400
+#        Then I click the return to SP button
+#         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:Responder'
+#         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:AuthnFailed'
+#         And the response should contain '(No message provided)'
 
     Scenario: Stepup authentication should show exception when user does cancel
       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"

--- a/theme/base/templates/modules/Default/View/Error/partial/footer.html.twig
+++ b/theme/base/templates/modules/Default/View/Error/partial/footer.html.twig
@@ -2,14 +2,15 @@
 <footer class="error-page-footer-buttons">
     <div class="error-page-footer-buttons__container">
         <div class="error-page-footer-buttons__row">
-            {% if hasBackToSpLink() %}
-                <div class="footer-button">
-                    <button type="submit" class="footer-button__button" form="backToSPForm">
-                        <i class="footer-button__icon fa-arrow-left"></i><br/>
-                        <span class="footer-button__text">{{ 'error_return-sp-link-text'|trans({'%spName%': getSpName()}) }}</span>
-                    </button>
-                </div>
-            {%  endif %}
+{#            TODO: fix back to sp link (see https://www.pivotaltracker.com/story/show/176960606)#}
+{#            {% if hasBackToSpLink() %}#}
+{#                <div class="footer-button">#}
+{#                    <button type="submit" class="footer-button__button" form="backToSPForm">#}
+{#                        <i class="footer-button__icon fa-arrow-left"></i><br/>#}
+{#                        <span class="footer-button__text">{{ 'error_return-sp-link-text'|trans({'%spName%': getSpName()}) }}</span>#}
+{#                    </button>#}
+{#                </div>#}
+{#            {%  endif %}#}
             {% if hasWikiLink(template) %}
                 <div class="footer-button">
                     {# The template var is set in the individual error Twigs, that's te place where we can determine what template is loaded. #}
@@ -40,7 +41,7 @@
             {%  endif %}
         </div>
     </div>
-    {% if hasBackToSpLink() %}
-        {% include '@theme/Authentication/View/Feedback/partial/saml_response_form.html.twig' %}
-    {% endif %}
+{#    {% if hasBackToSpLink() %}#}
+{#        {% include '@theme/Authentication/View/Feedback/partial/saml_response_form.html.twig' %}#}
+{#    {% endif %}#}
 </footer>


### PR DESCRIPTION
Prior to this change, the back to sp SAML payload provided the wrong
issuer, resulting in an error.

This change temporarily disables the back to sp link so the release can
be finished & this feature tackled in the next release.

Pivotal story at: https://www.pivotaltracker.com/story/show/176960606