### PR TITLE
Style the no-attributes case

### DIFF
--- a/theme/base/stylesheets/pages/consent/attributes.scss
+++ b/theme/base/stylesheets/pages/consent/attributes.scss
@@ -12,6 +12,12 @@
     transition: max-height .6s ease-in;
 }
 
+.consent__noAttributes {
+    list-style: none;
+    padding: 1rem;
+    text-align: center;
+}
+
 @include ie11Only('.consent__attributes') {
     max-height: 200vh;
 }

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/noAttributes.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/noAttributes.html.twig
@@ -1,3 +1,5 @@
-<li>
-   {{ 'consent_no_attributes_text'|trans }}
-</li>
+<ul class="consent__attributes">
+    <li class="consent__noAttributes">
+        {{ 'consent_no_attributes_text'|trans }}
+    </li>
+</ul>


### PR DESCRIPTION
Prior to this change, the no-attributes edge case was unstyled.  This
led to a ugly bullet point.

This change adds styling to the no-attributes edge case.

Pivotal ticket: https://www.pivotaltracker.com/story/show/178379702