### PR TITLE
Check if there is a valid authentication in the AuthenticationState

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -22,9 +22,6 @@ use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
 use OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper;
 use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
-use OpenConext\Value\Saml\Entity;
-use OpenConext\Value\Saml\EntityId;
-use OpenConext\Value\Saml\EntityType;
 use SAML2\Constants;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -137,9 +134,8 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
 
             // Authentication state needs to be registered here as the debug flow differs from the regular flow,
             // yet the procedures for both are completed when consuming the assertion in the ServiceProviderController
-            $identityProvider = new Entity(new EntityId($idp->entityId), EntityType::IdP());
             $authenticationState = $this->getAuthenticationState();
-            $authenticationState->authenticatedAt($requestId, $identityProvider);
+            $authenticationState->validateAuthenticationRequest($requestId);
 
             $this->_server->redirect(
                 $this->_server->getUrl('debugSingleSignOnService'),

--- a/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProcessConsent.php
@@ -18,6 +18,9 @@
 
 use OpenConext\EngineBlock\Service\AuthenticationStateHelperInterface;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
+use OpenConext\Value\Saml\Entity;
+use OpenConext\Value\Saml\EntityId;
+use OpenConext\Value\Saml\EntityType;
 use SAML2\Constants;
 use SAML2\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -107,8 +110,10 @@ class EngineBlock_Corto_Module_Service_ProcessConsent
         $response->setDeliverByBinding('INTERNAL');
 
         // Finally, mark the authentication procedure as being complete.
+        $identityProviderEntityId = $response->getOriginalIssuer();
+        $identityProviderSaml = new Entity(new EntityId($identityProviderEntityId), EntityType::IdP());
         $authenticationState = $this->_authenticationStateHelper->getAuthenticationState();
-        $authenticationState->completeCurrentProcedure($response->getInResponseTo());
+        $authenticationState->completeCurrentProcedure($response->getInResponseTo(), $identityProviderSaml);
 
         $this->_server->getBindingsModule()->send(
             $response,

--- a/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
@@ -21,6 +21,9 @@ use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Service\AuthenticationStateHelperInterface;
 use OpenConext\EngineBlock\Service\ConsentServiceInterface;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
+use OpenConext\Value\Saml\Entity;
+use OpenConext\Value\Saml\EntityId;
+use OpenConext\Value\Saml\EntityType;
 use SAML2\Constants;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
@@ -104,6 +107,7 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
         );
 
         $identityProviderEntityId = $response->getOriginalIssuer();
+        $identityProviderEntitySaml = new Entity(new EntityId($identityProviderEntityId), EntityType::IdP());
         $identityProvider = $this->_server->getRepository()->fetchIdentityProviderByEntityId($identityProviderEntityId);
 
         // Flush log if SP or IdP has additional logging enabled
@@ -136,7 +140,7 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
             $response->setDeliverByBinding('INTERNAL');
 
             // Consent is disabled, we now mark authentication_state as completed
-            $authenticationState->completeCurrentProcedure($response->getInResponseTo());
+            $authenticationState->completeCurrentProcedure($response->getInResponseTo(), $identityProviderEntitySaml);
 
             $this->_server->getBindingsModule()->send(
                 $response,
@@ -153,7 +157,7 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
             $response->setDeliverByBinding('INTERNAL');
 
             // Prior consent is found, we now mark authentication_state as completed
-            $authenticationState->completeCurrentProcedure($response->getInResponseTo());
+            $authenticationState->completeCurrentProcedure($response->getInResponseTo(), $identityProviderEntitySaml);
 
             $this->_server->getBindingsModule()->send(
                 $response,

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -507,10 +507,7 @@ class EngineBlock_Corto_ProxyServer
         $newResponse->setDeliverByBinding('INTERNAL');
         $newResponse->setReturn($this->_server->getUrl('processedAssertionConsumerService'));
 
-        $idp = $this->_server->getRepository()->fetchIdentityProviderByEntityId($receivedResponse->getIssuer()->getValue());
-        $identityProvider = new Entity(new EntityId($idp->entityId), EntityType::IdP());
-        $authenticationState->authenticatedAt($inResponseTo, $identityProvider);
-
+        $authenticationState->validateAuthenticationRequest($inResponseTo);
         $this->_server->getBindingsModule()->send($newResponse, $serviceProvider);
     }
 

--- a/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationProcedure.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationProcedure.php
@@ -47,7 +47,7 @@ final class AuthenticationProcedure
      * @param Entity $serviceProvider
      * @return AuthenticationProcedure
      */
-    public static function onBehalfOf(Entity $serviceProvider)
+    public static function onBehalfOf(Entity $serviceProvider): AuthenticationProcedure
     {
         return new self($serviceProvider);
     }
@@ -55,7 +55,7 @@ final class AuthenticationProcedure
     /**
      * @param Entity $identityProvider
      */
-    public function authenticatedAt(Entity $identityProvider)
+    public function authenticatedAt(Entity $identityProvider): void
     {
         $this->identityProvider = $identityProvider;
     }
@@ -63,25 +63,32 @@ final class AuthenticationProcedure
     /**
      * @param DateTimeInterface $dateTime
      */
-    public function completeOn(DateTimeInterface $dateTime)
+    public function completeOn(DateTimeInterface $dateTime): void
     {
         $this->dateOfCompletion = $dateTime;
     }
 
     /**
+     * Validates if the authentication has been completed with any Identity Provider
+     *
      * @return bool
      */
-    public function hasBeenAuthenticated()
+    public function hasBeenAuthenticated(): bool
     {
-        return $this->identityProvider === null;
+        return $this->identityProvider !== null;
     }
 
     /**
+     * Validates if the authentication has been completed with the passed Identity Provider
+     *
      * @param Entity $identityProvider
      * @return bool
      */
-    public function hasBeenAuthenticatedAt(Entity $identityProvider)
+    public function hasBeenAuthenticatedAt(Entity $identityProvider): bool
     {
+        if ($this->identityProvider === null ) {
+            return false;
+        }
         return $this->identityProvider->equals($identityProvider);
     }
 
@@ -89,7 +96,7 @@ final class AuthenticationProcedure
      * @param Entity $serviceProvider
      * @return bool
      */
-    public function isOnBehalfOf(Entity $serviceProvider)
+    public function isOnBehalfOf(Entity $serviceProvider): bool
     {
         return $this->serviceProvider->equals($serviceProvider);
     }
@@ -98,7 +105,7 @@ final class AuthenticationProcedure
      * @param DateTimeInterface $date
      * @return bool
      */
-    public function isCompletedAfter(DateTimeInterface $date)
+    public function isCompletedAfter(DateTimeInterface $date): bool
     {
         if ($this->dateOfCompletion === null) {
             return false;
@@ -111,7 +118,7 @@ final class AuthenticationProcedure
      * @param AuthenticationProcedure $other
      * @return bool
      */
-    public function equals(AuthenticationProcedure $other)
+    public function equals(AuthenticationProcedure $other): bool
     {
         $isSameServiceProvider = $this->serviceProvider->equals($other->serviceProvider);
 
@@ -123,7 +130,7 @@ final class AuthenticationProcedure
             $isSameIdentityProvider = $this->identityProvider->equals($other->identityProvider);
         }
 
-        $isSameDateOfCompletion = $this->dateOfCompletion == $other->dateOfCompletion;
+        $isSameDateOfCompletion = $this->dateOfCompletion === $other->dateOfCompletion;
 
         return $isSameServiceProvider && $isSameIdentityProvider && $isSameDateOfCompletion;
     }

--- a/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationProcedureMap.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationProcedureMap.php
@@ -43,7 +43,7 @@ final class AuthenticationProcedureMap implements Countable
      * @param AuthenticationProcedure $authenticationProcedure
      * @return AuthenticationProcedureMap
      */
-    public function add($requestId, AuthenticationProcedure $authenticationProcedure)
+    public function add($requestId, AuthenticationProcedure $authenticationProcedure): AuthenticationProcedureMap
     {
         $newAuthenticationProcedures = $this->authenticationProcedures;
         $newAuthenticationProcedures[$requestId] = $authenticationProcedure;
@@ -56,7 +56,7 @@ final class AuthenticationProcedureMap implements Countable
      * @return AuthenticationProcedure|null
      * @throws AssertionFailedException
      */
-    public function find($requestId)
+    public function find($requestId): ?AuthenticationProcedure
     {
         Assertion::string($requestId, 'The requestId must be a string (XML ID) value');
         if (isset($this->authenticationProcedures[$requestId])) {
@@ -69,7 +69,7 @@ final class AuthenticationProcedureMap implements Countable
      * @param Entity $entity
      * @return AuthenticationProcedureMap
      */
-    public function filterOnBehalfOf(Entity $entity)
+    public function filterOnBehalfOf(Entity $entity): AuthenticationProcedureMap
     {
         $filterMethod = function (AuthenticationProcedure $authenticationProcedure) use ($entity) {
             return $authenticationProcedure->isOnBehalfOf($entity);
@@ -82,7 +82,7 @@ final class AuthenticationProcedureMap implements Countable
      * @param DateTimeInterface $startDate
      * @return AuthenticationProcedureMap
      */
-    public function filterProceduresCompletedAfter(DateTimeInterface $startDate)
+    public function filterProceduresCompletedAfter(DateTimeInterface $startDate): AuthenticationProcedureMap
     {
         $filterMethod = function (AuthenticationProcedure $authenticationProcedure) use ($startDate) {
             return $authenticationProcedure->isCompletedAfter($startDate);
@@ -95,7 +95,7 @@ final class AuthenticationProcedureMap implements Countable
      * @param AuthenticationProcedure $other
      * @return bool
      */
-    public function contains(AuthenticationProcedure $other)
+    public function contains(AuthenticationProcedure $other): bool
     {
         foreach ($this->authenticationProcedures as $authenticationProcedure) {
             if ($authenticationProcedure->equals($other)) {
@@ -109,5 +109,20 @@ final class AuthenticationProcedureMap implements Countable
     public function count()
     {
         return count($this->authenticationProcedures);
+    }
+
+    /**
+     * Validates if any of the authenticationProcedures contains a valid authentication
+     *
+     * @return bool
+     */
+    public function hasBeenAuthenticated() : bool
+    {
+        foreach ($this->authenticationProcedures as $authenticationProcedure) {
+            if ($authenticationProcedure->hasBeenAuthenticated()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationState.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationState.php
@@ -49,7 +49,7 @@ final class AuthenticationState implements AuthenticationStateInterface
      * @return void
      * @throws AssertionFailedException
      */
-    public function startAuthenticationOnBehalfOf($requestId, Entity $serviceProvider)
+    public function startAuthenticationOnBehalfOf($requestId, Entity $serviceProvider): void
     {
         Assertion::string($requestId, 'The requestId must be a string (XML ID) value');
         $currentAuthenticationProcedure = AuthenticationProcedure::onBehalfOf($serviceProvider);
@@ -78,12 +78,14 @@ final class AuthenticationState implements AuthenticationStateInterface
     }
 
     /**
+     * Validates if an request can be found in session and if the request is not already authenticated
+     *
      * @param string $requestId
-     * @param Entity $identityProvider
      * @return void
      * @throws AssertionFailedException
+     * @throws LogicException
      */
-    public function authenticatedAt($requestId, Entity $identityProvider)
+    public function validateAuthenticationRequest($requestId): void
     {
         Assertion::string($requestId, 'The requestId must be a string (XML ID) value');
 
@@ -92,28 +94,8 @@ final class AuthenticationState implements AuthenticationStateInterface
         if ($currentRequest === null) {
             throw new LogicException(
                 sprintf(
-                    'The requested authentication procedure with requestId "%s" couldn\'t be found in the session storage.',
-                    $requestId
-                )
-            );
-        }
-
-        $currentRequest->authenticatedAt($identityProvider);
-    }
-
-    /**
-     * @param string $requestId
-     * @return void
-     * @throws AssertionFailedException
-     */
-    public function completeCurrentProcedure($requestId)
-    {
-        Assertion::string($requestId, 'The requestId must be a string (XML ID) value');
-        $currentRequest = $this->authenticationProcedures->find($requestId);
-        if ($currentRequest === null) {
-            throw new LogicException(
-                sprintf(
-                    'The requested authentication procedure with requestId "%s" couldn\'t be found in the session storage in order to complete.',
+                    'The requested authentication procedure with requestId "%s" couldn\'t be found in the ' .
+                    'session storage.',
                     $requestId
                 )
             );
@@ -127,7 +109,54 @@ final class AuthenticationState implements AuthenticationStateInterface
                 )
             );
         }
+    }
 
+    /**
+     * Completes the authentication procedure and sets the authenticated IDP and time
+     *
+     * @param string $requestId
+     * @param Entity $identityProvider
+     * @return void
+     * @throws AssertionFailedException
+     */
+    public function completeCurrentProcedure($requestId, Entity $identityProvider): void
+    {
+        Assertion::string($requestId, 'The requestId must be a string (XML ID) value');
+        $currentRequest = $this->authenticationProcedures->find($requestId);
+        if ($currentRequest === null) {
+            throw new LogicException(
+                sprintf(
+                    'The requested authentication procedure with requestId "%s" couldn\'t be found in the ' .
+                    'session storage in order to complete.',
+                    $requestId
+                )
+            );
+        }
+        if ($currentRequest->hasBeenAuthenticated()) {
+            throw new LogicException(
+                sprintf(
+                    'The requested authentication procedure with requestId "%s" has already been authenticated.',
+                    $requestId
+                )
+            );
+        }
+
+        $currentRequest->authenticatedAt($identityProvider);
         $currentRequest->completeOn(new DateTimeImmutable);
+    }
+
+    /**
+     * Validates if the current session contains a valid authentication
+     *
+     * @return bool
+     * @throws LogicException
+     */
+    public function isAuthenticated(): bool
+    {
+        if ($this->authenticationProcedures === null) {
+            throw new LogicException('The requested authentication procedure couldn\'t be found in the ' .
+                'session storage in order to complete.');
+        }
+        return $this->authenticationProcedures->hasBeenAuthenticated();
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationStateInterface.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/AuthenticationStateInterface.php
@@ -27,18 +27,23 @@ interface AuthenticationStateInterface
      * @param Entity $serviceProvider
      * @return void
      */
-    public function startAuthenticationOnBehalfOf($requestId, Entity $serviceProvider);
+    public function startAuthenticationOnBehalfOf($requestId, Entity $serviceProvider): void;
 
     /**
      * @param string $requestId
-     * @param Entity $identityProvider
      * @return void
      */
-    public function authenticatedAt($requestId, Entity $identityProvider);
+    public function validateAuthenticationRequest($requestId): void;
 
     /**
      * @param $requestId
+     * @param Entity $identityProvider
      * @return void
      */
-    public function completeCurrentProcedure($requestId);
+    public function completeCurrentProcedure($requestId, Entity $identityProvider): void;
+
+    /**
+     * @return bool
+     */
+    public function isAuthenticated(): bool;
 }

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/ProcessConsentTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/ProcessConsentTest.php
@@ -268,6 +268,7 @@ class EngineBlock_Test_Corto_Module_Service_ProcessConsentTest extends TestCase
         $sspResponse->setAssertions(array($assertion));
 
         $sspResponse = new EngineBlock_Saml2_ResponseAnnotationDecorator($sspResponse);
+        $sspResponse->setOriginalIssuer("https://idp.example.edu");
 
         return $sspResponse;
     }

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/ProvideConsentTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/ProvideConsentTest.php
@@ -28,6 +28,9 @@ use OpenConext\EngineBlock\Service\Dto\ProcessingStateStep;
 use OpenConext\EngineBlock\Service\ProcessingStateHelper;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
 use OpenConext\EngineBlockBundle\Authentication\AuthenticationStateInterface;
+use OpenConext\Value\Saml\Entity;
+use OpenConext\Value\Saml\EntityId;
+use OpenConext\Value\Saml\EntityType;
 use PHPUnit\Framework\TestCase;
 use SAML2\Assertion;
 use SAML2\AuthnRequest;
@@ -292,9 +295,11 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends TestCase
 
     private function mockAuthStateHelper()
     {
+        $identityProviderSaml = new Entity(new EntityId("entityID"), EntityType::IdP());
+
         $authState = Phake::mock(AuthenticationStateInterface::class);
         Phake::when($authState)
-            ->completeCurrentProcedure('_00000000-0000-0000-0000-000000000000');
+            ->completeCurrentProcedure('_00000000-0000-0000-0000-000000000000', $identityProviderSaml);
 
         $mock = Phake::mock(AuthenticationStateHelperInterface::class);
         Phake::when($mock)

--- a/tests/unit/OpenConext/EngineBlockBundle/Authentication/AuthenticationStateTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Authentication/AuthenticationStateTest.php
@@ -46,7 +46,7 @@ class AuthenticationStateTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The requested authentication procedure with requestId "_00000000-0000-0000-0000-000000000000" couldn\'t be found in the session storage.');
 
-        $authenticationState->authenticatedAt('_00000000-0000-0000-0000-000000000000', $identityProvider);
+        $authenticationState->validateAuthenticationRequest('_00000000-0000-0000-0000-000000000000', $identityProvider);
     }
 
     /**
@@ -62,27 +62,31 @@ class AuthenticationStateTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The requested authentication procedure with requestId "_00000000-0000-0000-0000-000000000000" couldn\'t be found in the session storage in order to complete.');
 
-        $authenticationState->completeCurrentProcedure('_00000000-0000-0000-0000-000000000000');
+        $identityProviderSaml = new Entity(new EntityId("entityID"), EntityType::IdP());
+
+        $authenticationState->completeCurrentProcedure('_00000000-0000-0000-0000-000000000000', $identityProviderSaml);
     }
 
     /**
      * @test
      * @group Authentication
      */
-    public function an_authentication_procedure_cannot_be_completed_if_it_has_not_been_authenticated()
+    public function an_authentication_procedure_cannot_be_completed_if_it_has_already_been_authenticated()
     {
         $authenticationLoopGuard = new AuthenticationLoopGuard(5, 30);
 
         $serviceProvider = new Entity(new EntityId('https://my-service-provider.example'), EntityType::SP());
 
         $requestId = '_00000000-0000-0000-0000-000000000000';
+        $identityProviderSaml = new Entity(new EntityId("entityID"), EntityType::IdP());
 
         $authenticationState = new AuthenticationState($authenticationLoopGuard);
         $authenticationState->startAuthenticationOnBehalfOf($requestId, $serviceProvider);
+        $authenticationState->completeCurrentProcedure($requestId, $identityProviderSaml);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The requested authentication procedure with requestId "_00000000-0000-0000-0000-000000000000" has already been authenticated.');
 
-        $authenticationState->completeCurrentProcedure($requestId);
+        $authenticationState->completeCurrentProcedure($requestId, $identityProviderSaml);
     }
 }


### PR DESCRIPTION
In this pull request we have added functionality to check if there is a valid and completed authentication. 

In AuthenticationState.php there is a new public method 'isAuthenticated()' that returns true if there is any AuthenticationProcedure in the AuthenticationProcedureMap with a completed authentication.

After discussion with @MKodde we found that there is an Issue in the AuthenticationProcedure.php were the function 'hasBeenAuthenticated()' returns false when an authentication has been successful and returns true when an authentication has not yet been completed. For this reason there have been some changes to the core of the authentication process.

- The IDP will only be set in the AuthenticationProcedure when an authentication has been successful (This is done after the consent has been given by the user)
- Before the consent is checked, we validate the authentication request if the authentication exists and if it is not already completed

We have tested the code on our development environments and the authentication flow still works. However, since these are changes to the core of the authentication please test the changes thoroughly.