### PR TITLE
Add feature for SSO Notifications

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
- * Copyright 2010 SURFnet B.V.
+ * Copyright 20%regexp:\d{2}% %regexp:.*%
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,6 +23,7 @@ open_conext_engine_block:
         eb.encrypted_assertions_require_outer_signature: "%feature_eb_encrypted_assertions_require_outer_signature%"
         eb.run_all_manipulations_prior_to_consent: "%feature_run_all_manipulations_prior_to_consent%"
         eb.block_user_on_violation: "%feature_block_user_on_violation%"
+        enable_sso_notification: "%feature_enable_sso_notification%"
 
 swiftmailer:
     transport: "%mailer_transport%"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,7 +23,7 @@ open_conext_engine_block:
         eb.encrypted_assertions_require_outer_signature: "%feature_eb_encrypted_assertions_require_outer_signature%"
         eb.run_all_manipulations_prior_to_consent: "%feature_run_all_manipulations_prior_to_consent%"
         eb.block_user_on_violation: "%feature_block_user_on_violation%"
-        enable_sso_notification: "%feature_enable_sso_notification%"
+        eb.enable_sso_notification: "%feature_enable_sso_notification%"
 
 swiftmailer:
     transport: "%mailer_transport%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -254,3 +254,13 @@ parameters:
     # test suite for js e2e tests. This because a SED command is in place to rewrite the parameters.yml.
     # See the SED command in Gitlab Actions runner: 'Run Cypress integration tests'
     theme.name: skeune
+
+    ##########################################################################################
+    ## SSO NOTIFICATION SETTINGS
+    ##########################################################################################
+    feature_enable_sso_notification: true
+    sso_notification_encryption_algorithm: AES-256-CBC
+    ## The encryption key used to decrypt the SSO notification
+    sso_notification_encryption_key: <xxx>
+    ## The encryption key salt used to decrypt the SSO notification
+    sso_notification_encryption_key_salt: <xxx>

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -137,6 +137,7 @@ parameters:
     addgueststatus_guestqualifier: 'urn:collab:org:vm.openconext.org'
 
     ## Language cookie settings
+    ## The value for the domain is also used for clearing SSO Notification cookies if the feature is enabled
     cookie.path: /
     cookie.secure: true
     cookie.locale.domain: .vm.openconext.org
@@ -258,7 +259,7 @@ parameters:
     ##########################################################################################
     ## SSO NOTIFICATION SETTINGS
     ##########################################################################################
-    feature_enable_sso_notification: true
+    feature_enable_sso_notification: false
     sso_notification_encryption_algorithm: AES-256-CBC
     ## The encryption key used to decrypt the SSO notification
     sso_notification_encryption_key: <xxx>

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "symfony/swiftmailer-bundle": "^2.6",
         "symfony/symfony": "3.4.*",
         "twig/extensions": "^1.5",
-        "twig/twig": "^1.35"
+        "twig/twig": "^1.35",
+        "ext-openssl": "*"
     },
     "require-dev": {
         "behat/behat": "~3.0",

--- a/docs/sso_notification.md
+++ b/docs/sso_notification.md
@@ -1,0 +1,27 @@
+# SSO Notification
+
+SSO Notifications enable schools to reduce the number of steps users have to take during the login process and increase 
+user-friendliness by providing the possibility to skip the WAYF (Where Are You From) screen. This is done via the use 
+of a cookie, which can be set for example after the user has logged in on his own environment (for example an intranet page or the 
+homepage of an Electronic Learning Environment).
+
+Setting SSO Notification cookies is performed by a separate application - the SSO Notification service. Engineblock
+is able to read the cookie and retrieve the entity id of the Identity Provider which should be used to start an 
+authentication with. The contents of the SSO Notification cookie is encrypted by the SSO Notification service.
+Engineblock contains a few configuration parameters to set the encryption details.
+
+## Configuration of SSO Notification in Engineblock
+
+SSO Notification is an optional feature and can be enabled with:
+
+    feature_enable_sso_notification: true
+
+By default, AES-256 encryption is used by the SSO Notification service and is also the default configured
+in Engineblock. Configure the encryption key and salt used with the parameters:
+
+    # The encryption key used to decrypt the SSO notification
+    sso_notification_encryption_key: <xxx>
+    # The encryption key salt used to decrypt the SSO notification
+    sso_notification_encryption_key_salt: <xxx>
+    
+The values for key and salt should match the ones used in the SSO Notification service.

--- a/docs/sso_notification.md
+++ b/docs/sso_notification.md
@@ -5,9 +5,10 @@ user-friendliness by providing the possibility to skip the WAYF (Where Are You F
 of a cookie, which can be set for example after the user has logged in on his own environment (for example an intranet page or the 
 homepage of an Electronic Learning Environment).
 
-Setting SSO Notification cookies is performed by a separate application - the SSO Notification service. Engineblock
+Setting SSO Notification cookies is performed by a separate application - the SSO Notification service 
+(found [here](https://github.com/OpenConext/OpenConext-SSO-Notification)). Engineblock
 is able to read the cookie and retrieve the entity id of the Identity Provider which should be used to start an 
-authentication with. The contents of the SSO Notification cookie is encrypted by the SSO Notification service.
+authentication with. The contents of the SSO Notification cookie are encrypted by the SSO Notification service.
 Engineblock contains a few configuration parameters to set the encryption details.
 
 ## Configuration of SSO Notification in Engineblock

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -520,4 +520,17 @@ class EngineBlock_Application_DiContainer extends Pimple
     {
         return $this->container->get('engineblock.configuration.stepup.endpoint');
     }
+
+    public function getCookieDomain()
+    {
+        return $this->container->getParameter('cookie.locale.domain');
+    }
+
+    /**
+     * @return OpenConext\EngineBlock\Service\SsoNotificationService
+     */
+    public function getSsoNotificationService()
+    {
+        return $this->container->get('engineblock.service.sso_notification');
+    }
 }

--- a/library/EngineBlock/Corto/Filter/Command/Helpers/CookieHandler.php
+++ b/library/EngineBlock/Corto/Filter/Command/Helpers/CookieHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+class EngineBlock_Corto_Filter_Command_Helpers_CookieHandler
+{
+    /**
+     * Clears the cookie for the specified name, path and domain.
+     *
+     * @param string $cookieName the cookie name
+     * @param string $cookiePath the cookie path
+     * @param string $cookieDomain the cookie domain
+     */
+    public function clearCookie($cookieName, $cookiePath, $cookieDomain)
+    {
+        setcookie($cookieName, '', -1, $cookiePath, $cookieDomain);
+    }
+}

--- a/library/EngineBlock/Corto/Filter/Command/Helpers/CookieHandler.php
+++ b/library/EngineBlock/Corto/Filter/Command/Helpers/CookieHandler.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 class EngineBlock_Corto_Filter_Command_Helpers_CookieHandler
 {
     /**

--- a/library/EngineBlock/Corto/Filter/Command/SsoNotificationCookieFilter.php
+++ b/library/EngineBlock/Corto/Filter/Command/SsoNotificationCookieFilter.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 class EngineBlock_Corto_Filter_Command_SsoNotificationCookieFilter extends EngineBlock_Corto_Filter_Command_Abstract
 {
     private $_ssoNotificationCookieName = "ssonot";

--- a/library/EngineBlock/Corto/Filter/Command/SsoNotificationCookieFilter.php
+++ b/library/EngineBlock/Corto/Filter/Command/SsoNotificationCookieFilter.php
@@ -14,9 +14,11 @@ class EngineBlock_Corto_Filter_Command_SsoNotificationCookieFilter extends Engin
      */
     private $_diContainer;
 
-    public function __construct(EngineBlock_Corto_Filter_Command_Helpers_CookieHandler $cookieHandler,
-                                EngineBlock_Application_DiContainer $diContainer)
-    {
+    public function __construct(
+        EngineBlock_Corto_Filter_Command_Helpers_CookieHandler $cookieHandler,
+        EngineBlock_Application_DiContainer $diContainer
+    ) {
+    
         $this->_cookieHandler = $cookieHandler;
         $this->_diContainer = $diContainer;
     }
@@ -28,9 +30,11 @@ class EngineBlock_Corto_Filter_Command_SsoNotificationCookieFilter extends Engin
         }
 
         if (!is_null($this->_diContainer->getSymfonyRequest()->cookies->get($this->_ssoNotificationCookieName))) {
-            $this->_cookieHandler->clearCookie($this->_ssoNotificationCookieName,
+            $this->_cookieHandler->clearCookie(
+                $this->_ssoNotificationCookieName,
                 $this->_diContainer->getCookiePath(),
-                $this->_diContainer->getCookieDomain());
+                $this->_diContainer->getCookieDomain()
+            );
         }
     }
 }

--- a/library/EngineBlock/Corto/Filter/Command/SsoNotificationCookieFilter.php
+++ b/library/EngineBlock/Corto/Filter/Command/SsoNotificationCookieFilter.php
@@ -1,0 +1,36 @@
+<?php
+
+class EngineBlock_Corto_Filter_Command_SsoNotificationCookieFilter extends EngineBlock_Corto_Filter_Command_Abstract
+{
+    private $_ssoNotificationCookieName = "ssonot";
+
+    /**
+     * @var EngineBlock_Corto_Filter_Command_Helpers_CookieHandler
+     */
+    private $_cookieHandler;
+
+    /**
+     * @var EngineBlock_Application_DiContainer
+     */
+    private $_diContainer;
+
+    public function __construct(EngineBlock_Corto_Filter_Command_Helpers_CookieHandler $cookieHandler,
+                                EngineBlock_Application_DiContainer $diContainer)
+    {
+        $this->_cookieHandler = $cookieHandler;
+        $this->_diContainer = $diContainer;
+    }
+
+    public function execute(): void
+    {
+        if (!$this->_diContainer->getFeatureConfiguration()->isEnabled('enable_sso_notification')) {
+            return;
+        }
+
+        if (!is_null($this->_diContainer->getSymfonyRequest()->cookies->get($this->_ssoNotificationCookieName))) {
+            $this->_cookieHandler->clearCookie($this->_ssoNotificationCookieName,
+                $this->_diContainer->getCookiePath(),
+                $this->_diContainer->getCookieDomain());
+        }
+    }
+}

--- a/library/EngineBlock/Corto/Filter/Command/SsoNotificationCookieFilter.php
+++ b/library/EngineBlock/Corto/Filter/Command/SsoNotificationCookieFilter.php
@@ -23,7 +23,7 @@ class EngineBlock_Corto_Filter_Command_SsoNotificationCookieFilter extends Engin
 
     public function execute(): void
     {
-        if (!$this->_diContainer->getFeatureConfiguration()->isEnabled('enable_sso_notification')) {
+        if (!$this->_diContainer->getFeatureConfiguration()->isEnabled('eb.enable_sso_notification')) {
             return;
         }
 

--- a/library/EngineBlock/Corto/Filter/Input.php
+++ b/library/EngineBlock/Corto/Filter/Input.php
@@ -40,6 +40,12 @@ class EngineBlock_Corto_Filter_Input extends EngineBlock_Corto_Filter_Abstract
         $authnContextClassRefBlacklistPattern = $diContainer->getAuthnContextClassRefBlacklistRegex();
 
         $commands = array(
+            // remove SSO Cookie
+            new EngineBlock_Corto_Filter_Command_SsoNotificationCookieFilter(
+                new EngineBlock_Corto_Filter_Command_Helpers_CookieHandler(),
+                $diContainer
+            ),
+
             // Validate if the authnContextClassRef is not blacklisted
             new EngineBlock_Corto_Filter_Command_ValidateAuthnContextClassRef($logger, $authnContextClassRefBlacklistPattern),
 

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -200,7 +200,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
         }
 
         // Auto-select IdP when 'feature_enable_sso_notification' is enabled and send AuthenticationRequest on success
-        if ($application->getDiContainer()->getFeatureConfiguration()->isEnabled("enable_sso_notification")) {
+        if ($application->getDiContainer()->getFeatureConfiguration()->isEnabled("eb.enable_sso_notification")) {
             $idpEntityId = $application->getDiContainer()->getSsoNotificationService()->handleSsoNotification(
                 $application->getDiContainer()->getSymfonyRequest()->cookies, $this->_server);
 

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -199,6 +199,24 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             return;
         }
 
+        // Auto-select IdP when 'feature_enable_sso_notification' is enabled and send AuthenticationRequest on success
+        if ($application->getDiContainer()->getFeatureConfiguration()->isEnabled("enable_sso_notification")) {
+            $idpEntityId = $application->getDiContainer()->getSsoNotificationService()->handleSsoNotification(
+                $application->getDiContainer()->getSymfonyRequest()->cookies, $this->_server);
+
+            if (!empty($idpEntityId)) {
+                try {
+                    $log->info("Auto-selecting IdP '$idpEntityId' from SSO notification: " .
+                        "omitting WAYF, sending authentication request");
+                    $this->_server->sendAuthenticationRequest($request, $idpEntityId);
+                    return;
+                } catch (EngineBlock_Corto_ProxyServer_Exception $exception) {
+                    $log->error("Failed to send authentication request for SSO notification " .
+                        "with IdP '$idpEntityId'", array('exception' => $exception));
+                }
+            }
+        }
+
         // Auto-select IdP when 'wayf.rememberChoice' feature is enabled and is allowed for the current request
         if (($application->getDiContainer()->getRememberChoice() === true) && !($request->getForceAuthn() || $request->isDebugRequest())) {
             $cookies = $application->getDiContainer()->getSymfonyRequest()->cookies->all();

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -201,8 +201,8 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
 
         // Auto-select IdP when 'feature_enable_sso_notification' is enabled and send AuthenticationRequest on success
         if ($application->getDiContainer()->getFeatureConfiguration()->isEnabled("eb.enable_sso_notification")) {
-            $idpEntityId = $application->getDiContainer()->getSsoNotificationService()->handleSsoNotification(
-                $application->getDiContainer()->getSymfonyRequest()->cookies, $this->_server);
+            $idpEntityId = $application->getDiContainer()->getSsoNotificationService()->
+                handleSsoNotification($application->getDiContainer()->getSymfonyRequest()->cookies, $this->_server);
 
             if (!empty($idpEntityId)) {
                 try {

--- a/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
+++ b/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace OpenConext\EngineBlock\Service;
 
 use EngineBlock_Corto_ProxyServer;

--- a/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
+++ b/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
@@ -37,8 +37,9 @@ class SsoNotificationService
     private $logger;
 
     public function __construct(string $encryptionKey, string $encryptionSalt, string $encryptionAlgorithm,
-                                LoggerInterface $logger)
-    {
+        LoggerInterface $logger
+    ) {
+    
         $this->encryptionKey = $encryptionKey;
         $this->encryptionSalt = $encryptionSalt;
         $this->encryptionAlgorithm = $encryptionAlgorithm;
@@ -48,8 +49,8 @@ class SsoNotificationService
     /**
      * Parses the SSO notification cookie and if successful starts an authentication with the parsed IdP.
      *
-     * @param ParameterBag $cookies the cookies in the current HTTP request
-     * @param EngineBlock_Corto_ProxyServer $server the proxy server to start authentication from
+     * @param  ParameterBag                  $cookies the cookies in the current HTTP request
+     * @param  EngineBlock_Corto_ProxyServer $server  the proxy server to start authentication from
      * @return string the entity ID of a known Identity Provider, otherwise an empty string
      */
     public function handleSsoNotification(ParameterBag $cookies, EngineBlock_Corto_ProxyServer $server): string
@@ -66,8 +67,10 @@ class SsoNotificationService
                     $this->logger->warning("SSO notification found for unknown IdP: '$idpEntityId'");
                 }
             } else {
-                $this->logger->warning("Field '" . self::FIELD_ENTITY_ID . "' not found in parsed SSO " .
-                    "notification: " . json_encode($parsedSsoNotification));
+                $this->logger->warning(
+                    "Field '" . self::FIELD_ENTITY_ID . "' not found in parsed SSO " .
+                    "notification: " . json_encode($parsedSsoNotification)
+                );
             }
         }
 
@@ -77,10 +80,11 @@ class SsoNotificationService
     /**
      * Retrieves the SSO notification cookie from the provided set of cookies.
      *
-     * @param ParameterBag $cookies the set of cookies to retrieve the SSO notification cookie from
+     * @param  ParameterBag $cookies the set of cookies to retrieve the SSO notification cookie from
      * @return mixed|null the SSO notification cookie or null if not present
      */
-    public function getSsoCookie(ParameterBag $cookies) {
+    public function getSsoCookie(ParameterBag $cookies) 
+    {
         return $cookies->get(self::SSO_NOT_COOKIE_NAME);
     }
 
@@ -89,7 +93,7 @@ class SsoNotificationService
      * The provided SSO notification should be a base64 string of a cipher to decrypt and an initialization vector to
      * decrypt with.
      *
-     * @param string $ssoNotification the SSO notification as a base64 string
+     * @param  string $ssoNotification the SSO notification as a base64 string
      * @return array array containing the data of the SSO notification or an empty array in case of an error
      */
     private function parseSsoNotification(string $ssoNotification): array
@@ -101,15 +105,19 @@ class SsoNotificationService
         $iv = substr($base64Decoded, 0, self::IV_SIZE);
         $cipherText = substr($base64Decoded, self::IV_SIZE);
         // Construct encryption key
-        $key = hash_pbkdf2('sha256', $this->encryptionKey, $this->encryptionSalt, self::ITERATION_COUNT,
-            self::KEY_SIZE, true);
+        $key = hash_pbkdf2(
+            'sha256', $this->encryptionKey, $this->encryptionSalt, self::ITERATION_COUNT,
+            self::KEY_SIZE, true
+        );
 
         $jsonString = $this->decryptSsoNotification($cipherText, $key, $this->encryptionAlgorithm, $iv);
         try {
             $data = JsonResponseParser::parse($jsonString);
         } catch (InvalidJsonException $exception) {
-            $this->logger->error("Failed to parse JSON string '$jsonString' from SSO notification",
-                array('exception' => $exception));
+            $this->logger->error(
+                "Failed to parse JSON string '$jsonString' from SSO notification",
+                array('exception' => $exception)
+            );
         }
         return $data;
     }
@@ -118,19 +126,22 @@ class SsoNotificationService
      * Decrypts the SSO notification using the provided key, encryption algorithm and initialization vector.
      * Returns a JSON string or an empty string if the SSO notification cannot be decrypted.
      *
-     * @param string $ssoNotification the SSO notification to decrypt
-     * @param string $encryptionKey the encryption key to decrypt with
-     * @param string $encryptionAlgorithm the encryption algorithm
-     * @param string $iv the initialization vector to decrypt with
+     * @param  string $ssoNotification     the SSO notification to decrypt
+     * @param  string $encryptionKey       the encryption key to decrypt with
+     * @param  string $encryptionAlgorithm the encryption algorithm
+     * @param  string $iv                  the initialization vector to decrypt with
      * @return string a JSON string or an empty string in case the data could not be decrypted
      */
     private function decryptSsoNotification(string $ssoNotification, string $encryptionKey, string $encryptionAlgorithm,
-                                            string $iv): string
-    {
+        string $iv
+    ): string {
+    
         $data = openssl_decrypt($ssoNotification, $encryptionAlgorithm, $encryptionKey, OPENSSL_RAW_DATA, $iv);
         if (!$data) {
-            $this->logger->error("Failed to decrypt SSO notification '$ssoNotification' using algorithm " .
-                "'$encryptionAlgorithm', returning empty string");
+            $this->logger->error(
+                "Failed to decrypt SSO notification '$ssoNotification' using algorithm " .
+                "'$encryptionAlgorithm', returning empty string"
+            );
 
             return '';
         }

--- a/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
+++ b/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
@@ -36,7 +36,10 @@ class SsoNotificationService
      */
     private $logger;
 
-    public function __construct(string $encryptionKey, string $encryptionSalt, string $encryptionAlgorithm,
+    public function __construct(
+        string $encryptionKey,
+        string $encryptionSalt,
+        string $encryptionAlgorithm,
         LoggerInterface $logger
     ) {
     
@@ -60,8 +63,8 @@ class SsoNotificationService
 
             if (array_key_exists(self::FIELD_ENTITY_ID, $parsedSsoNotification)) {
                 $idpEntityId = $parsedSsoNotification[self::FIELD_ENTITY_ID];
-                if (!is_null($idpEntityId) && !is_null($server->getRepository()->findIdentityProviderByEntityId($idpEntityId))) {
-
+                if (!is_null($idpEntityId) &&
+                    !is_null($server->getRepository()->findIdentityProviderByEntityId($idpEntityId))) {
                     return $idpEntityId;
                 } else {
                     $this->logger->warning("SSO notification found for unknown IdP: '$idpEntityId'");
@@ -83,7 +86,7 @@ class SsoNotificationService
      * @param  ParameterBag $cookies the set of cookies to retrieve the SSO notification cookie from
      * @return mixed|null the SSO notification cookie or null if not present
      */
-    public function getSsoCookie(ParameterBag $cookies) 
+    public function getSsoCookie(ParameterBag $cookies)
     {
         return $cookies->get(self::SSO_NOT_COOKIE_NAME);
     }
@@ -106,8 +109,12 @@ class SsoNotificationService
         $cipherText = substr($base64Decoded, self::IV_SIZE);
         // Construct encryption key
         $key = hash_pbkdf2(
-            'sha256', $this->encryptionKey, $this->encryptionSalt, self::ITERATION_COUNT,
-            self::KEY_SIZE, true
+            'sha256',
+            $this->encryptionKey,
+            $this->encryptionSalt,
+            self::ITERATION_COUNT,
+            self::KEY_SIZE,
+            true
         );
 
         $jsonString = $this->decryptSsoNotification($cipherText, $key, $this->encryptionAlgorithm, $iv);
@@ -132,7 +139,10 @@ class SsoNotificationService
      * @param  string $iv                  the initialization vector to decrypt with
      * @return string a JSON string or an empty string in case the data could not be decrypted
      */
-    private function decryptSsoNotification(string $ssoNotification, string $encryptionKey, string $encryptionAlgorithm,
+    private function decryptSsoNotification(
+        string $ssoNotification,
+        string $encryptionKey,
+        string $encryptionAlgorithm,
         string $iv
     ): string {
     
@@ -147,5 +157,4 @@ class SsoNotificationService
         }
         return $data;
     }
-
 }

--- a/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
+++ b/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace OpenConext\EngineBlock\Service;
+
+use EngineBlock_Corto_ProxyServer;
+use OpenConext\EngineBlock\Exception\InvalidJsonException;
+use OpenConext\EngineBlock\Http\JsonResponseParser;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class SsoNotificationService
+{
+    private const SSO_NOT_COOKIE_NAME = "ssonot";
+    private const FIELD_ENTITY_ID = "entityId";
+    private const IV_SIZE = 16;
+    private const KEY_SIZE = 256;
+    private const ITERATION_COUNT = 1000;
+
+    /**
+     * @var string
+     */
+    private $encryptionKey;
+
+    /**
+     * @var string
+     */
+    private $encryptionSalt;
+
+    /**
+     * @var string
+     */
+    private $encryptionAlgorithm;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(string $encryptionKey, string $encryptionSalt, string $encryptionAlgorithm,
+                                LoggerInterface $logger)
+    {
+        $this->encryptionKey = $encryptionKey;
+        $this->encryptionSalt = $encryptionSalt;
+        $this->encryptionAlgorithm = $encryptionAlgorithm;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Parses the SSO notification cookie and if successful starts an authentication with the parsed IdP.
+     *
+     * @param ParameterBag $cookies the cookies in the current HTTP request
+     * @param EngineBlock_Corto_ProxyServer $server the proxy server to start authentication from
+     * @return string the entity ID of a known Identity Provider, otherwise an empty string
+     */
+    public function handleSsoNotification(ParameterBag $cookies, EngineBlock_Corto_ProxyServer $server): string
+    {
+        if (!is_null($ssoNotification = $this->getSsoCookie($cookies))) {
+            $parsedSsoNotification = $this->parseSsoNotification($ssoNotification);
+
+            if (array_key_exists(self::FIELD_ENTITY_ID, $parsedSsoNotification)) {
+                $idpEntityId = $parsedSsoNotification[self::FIELD_ENTITY_ID];
+                if (!is_null($idpEntityId) && array_search($idpEntityId,
+                        $server->getRepository()->findAllIdentityProviderEntityIds()) !== false) {
+
+                    return $idpEntityId;
+                } else {
+                    $this->logger->warning("SSO notification found for unknown IdP: '$idpEntityId'");
+                }
+            } else {
+                $this->logger->warning("Field '" . self::FIELD_ENTITY_ID . "' not found in parsed SSO " .
+                    "notification: " . json_encode($parsedSsoNotification));
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Retrieves the SSO notification cookie from the provided set of cookies.
+     *
+     * @param ParameterBag $cookies the set of cookies to retrieve the SSO notification cookie from
+     * @return mixed|null the SSO notification cookie or null if not present
+     */
+    public function getSsoCookie(ParameterBag $cookies) {
+        return $cookies->get(self::SSO_NOT_COOKIE_NAME);
+    }
+
+    /**
+     * Parses the provided SSO notification and returns an associative array if successful and an empty array otherwise.
+     * The provided SSO notification should be a base64 string of a cipher to decrypt and an initialization vector to
+     * decrypt with.
+     *
+     * @param string $ssoNotification the SSO notification as a base64 string
+     * @return array array containing the data of the SSO notification or an empty array in case of an error
+     */
+    private function parseSsoNotification(string $ssoNotification): array
+    {
+        $data = [];
+
+        // Extract cipher and initialization vector
+        $base64Decoded = base64_decode($ssoNotification);
+        $iv = substr($base64Decoded, 0, self::IV_SIZE);
+        $cipherText = substr($base64Decoded, self::IV_SIZE);
+        // Construct encryption key
+        $key = hash_pbkdf2('sha256', $this->encryptionKey, $this->encryptionSalt, self::ITERATION_COUNT,
+            self::KEY_SIZE, true);
+
+        $jsonString = $this->decryptSsoNotification($cipherText, $key, $this->encryptionAlgorithm, $iv);
+        try {
+            $data = JsonResponseParser::parse($jsonString);
+        } catch (InvalidJsonException $exception) {
+            $this->logger->error("Failed to parse JSON string '$jsonString' from SSO notification",
+                array('exception' => $exception));
+        }
+        return $data;
+    }
+
+    /**
+     * Decrypts the SSO notification using the provided key, encryption algorithm and initialization vector.
+     * Returns a JSON string or an empty string if the SSO notification cannot be decrypted.
+     *
+     * @param string $ssoNotification the SSO notification to decrypt
+     * @param string $encryptionKey the encryption key to decrypt with
+     * @param string $encryptionAlgorithm the encryption algorithm
+     * @param string $iv the initialization vector to decrypt with
+     * @return string a JSON string or an empty string in case the data could not be decrypted
+     */
+    private function decryptSsoNotification(string $ssoNotification, string $encryptionKey, string $encryptionAlgorithm,
+                                            string $iv): string
+    {
+        $data = openssl_decrypt($ssoNotification, $encryptionAlgorithm, $encryptionKey, OPENSSL_RAW_DATA, $iv);
+        if (!$data) {
+            $this->logger->error("Failed to decrypt SSO notification '$ssoNotification' using algorithm " .
+                "'$encryptionAlgorithm', returning empty string");
+
+            return '';
+        }
+        return $data;
+    }
+
+}

--- a/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
+++ b/src/OpenConext/EngineBlock/Service/SsoNotificationService.php
@@ -54,13 +54,12 @@ class SsoNotificationService
      */
     public function handleSsoNotification(ParameterBag $cookies, EngineBlock_Corto_ProxyServer $server): string
     {
-        if (!is_null($ssoNotification = $this->getSsoCookie($cookies))) {
-            $parsedSsoNotification = $this->parseSsoNotification($ssoNotification);
+        if (!is_null($this->getSsoCookie($cookies))) {
+            $parsedSsoNotification = $this->parseSsoNotification($this->getSsoCookie($cookies));
 
             if (array_key_exists(self::FIELD_ENTITY_ID, $parsedSsoNotification)) {
                 $idpEntityId = $parsedSsoNotification[self::FIELD_ENTITY_ID];
-                if (!is_null($idpEntityId) && array_search($idpEntityId,
-                        $server->getRepository()->findAllIdentityProviderEntityIds()) !== false) {
+                if (!is_null($idpEntityId) && !is_null($server->getRepository()->findIdentityProviderByEntityId($idpEntityId))) {
 
                     return $idpEntityId;
                 } else {

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -41,6 +41,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.block_user_on_violation', true));
         $this->setFeature(new Feature('eb.encrypted_assertions', true));
         $this->setFeature(new Feature('eb.encrypted_assertions_require_outer_signature', true));
+        $this->setFeature(new Feature('eb.enable_sso_notification', false));
     }
 
     public function setFeature(Feature $feature): void

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -101,6 +101,14 @@ services:
     engineblock.service.time_provider:
         class: OpenConext\EngineBlock\Service\TimeProvider\TimeProvider
 
+    engineblock.service.sso_notification:
+        class: OpenConext\EngineBlock\Service\SsoNotificationService
+        arguments:
+            - "%sso_notification_encryption_key%"
+            - "%sso_notification_encryption_key_salt%"
+            - "%sso_notification_encryption_algorithm%"
+            - "@engineblock.compat.logger"
+
     engineblock.factory.service_provider_factory:
         class: OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactory
         arguments:

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/SsoNotificationCookieFilterTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/SsoNotificationCookieFilterTest.php
@@ -51,7 +51,7 @@ class EngineBlock_Test_Corto_Filter_Command_SsoNotificationCookieFilterTest exte
 
         $featureConfiguration = Phake::mock(FeatureConfiguration::class);
         Phake::when($featureConfiguration)
-            ->isEnabled('enable_sso_notification')
+            ->isEnabled('eb.enable_sso_notification')
             ->thenReturn(true);
         Phake::when($_diContainerMock)
             ->getFeatureConfiguration()

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/SsoNotificationCookieFilterTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/SsoNotificationCookieFilterTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
 use PHPUnit\Framework\TestCase;

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/SsoNotificationCookieFilterTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/SsoNotificationCookieFilterTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class EngineBlock_Test_Corto_Filter_Command_SsoNotificationCookieFilterTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private $_domain = "domain";
+    private $_path = "/";
+    private $_cookieName = "ssonot";
+    private $_cookieValue = "value";
+
+    /**
+     * @var Request
+     */
+    private $_request;
+
+    /**
+     * @var EngineBlock_Corto_Filter_Command_Helpers_CookieHandler
+     */
+    private $_cookieHandlerMock;
+
+    /**
+     * @var EngineBlock_Corto_Filter_Command_SsoNotificationCookieFilter
+     */
+    private $_ssoNotificationCookieFilter;
+
+    public function setUp()
+    {
+        $_diContainerMock = Phake::mock(EngineBlock_Application_DiContainer::class);
+        $this->_cookieHandlerMock = Phake::mock(EngineBlock_Corto_Filter_Command_Helpers_CookieHandler::class);
+        $this->_ssoNotificationCookieFilter = new EngineBlock_Corto_Filter_Command_SsoNotificationCookieFilter(
+            $this->_cookieHandlerMock,
+            $_diContainerMock
+        );
+        $this->_request = new Request();
+
+        Phake::when($_diContainerMock)
+            ->getSymfonyRequest(Phake::anyParameters())
+            ->thenReturn($this->_request);
+        Phake::when($_diContainerMock)
+            ->getCookiePath(Phake::anyParameters())
+            ->thenReturn($this->_path);
+        Phake::when($_diContainerMock)
+            ->getCookieDomain(Phake::anyParameters())
+            ->thenReturn($this->_domain);
+
+        $featureConfiguration = Phake::mock(FeatureConfiguration::class);
+        Phake::when($featureConfiguration)
+            ->isEnabled('enable_sso_notification')
+            ->thenReturn(true);
+        Phake::when($_diContainerMock)
+            ->getFeatureConfiguration()
+            ->thenReturn($featureConfiguration);
+    }
+
+    public function testCookieFound()
+    {
+        $this->_request->cookies->add([ $this->_cookieName => $this->_cookieValue ]);
+
+        $this->_ssoNotificationCookieFilter->execute();
+
+        Phake::verify($this->_cookieHandlerMock)->clearCookie($this->_cookieName, $this->_path, $this->_domain);
+    }
+
+    public function testCookieNotFound()
+    {
+        $this->_ssoNotificationCookieFilter->execute();
+
+        Phake::verifyNoInteraction($this->_cookieHandlerMock);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Service/SsoNotificationServiceTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/SsoNotificationServiceTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace OpenConext\EngineBlock\Service;
 
 use EngineBlock_Corto_ProxyServer;

--- a/tests/unit/OpenConext/EngineBlock/Service/SsoNotificationServiceTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/SsoNotificationServiceTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace OpenConext\EngineBlock\Service;
+
+use EngineBlock_Corto_ProxyServer;
+use EngineBlock_Saml2_AuthnRequestAnnotationDecorator;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\InMemoryMetadataRepository;
+use Phake;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Tests\Logger;
+
+class SsoNotificationServiceTest extends TestCase
+{
+
+    private $idpEntityId = "testIdP";
+    private $idpUrl = "https://testIdP.com";
+    private $encryptionKey = "testEncryptionKey";
+    private $encryptionKeySalt = "testSalt";
+    private $encryptionMethod = "AES-256-CBC";
+    private $iv = "encryptionTestIv";
+    private $cookieValue;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var Logger
+     */
+    private $loggerMock;
+
+    /**
+     * @var EngineBlock_Corto_ProxyServer
+     */
+    private $proxyServerMock;
+
+    /**
+     * @var EngineBlock_Saml2_AuthnRequestAnnotationDecorator
+     */
+    private $requestMock;
+
+    /**
+     * @var SsoNotificationService
+     */
+    private $ssoNotificationService;
+
+    public function setUp()
+    {
+        $this->loggerMock = Phake::mock(Logger::class);
+        $this->proxyServerMock = Phake::mock(EngineBlock_Corto_ProxyServer::class);
+        $this->requestMock = Phake::mock(EngineBlock_Saml2_AuthnRequestAnnotationDecorator::class);
+        $this->ssoNotificationService = new SsoNotificationService(
+            $this->encryptionKey,
+            $this->encryptionKeySalt,
+            $this->encryptionMethod,
+            $this->loggerMock
+        );
+        $this->cookieValue = $this->getStandardCookieValue($this->idpEntityId);
+        $this->request = new Request();
+
+        Phake::when($this->proxyServerMock)
+            ->getRepository()
+            ->thenReturn(new InMemoryMetadataRepository(
+                array(new IdentityProvider($this->idpEntityId)),
+                array()
+            ));
+    }
+
+    /**
+     * @test
+     * @group SsoNotification
+     */
+    public function test_get_sso_cookie()
+    {
+        $this->request->cookies->add([ 'ssonot' => $this->cookieValue ]);
+
+        $response = $this->ssoNotificationService->getSsoCookie($this->request->cookies);
+        $this->assertEquals($this->cookieValue, $response);
+
+    }
+
+    /**
+     * @test
+     * @group SsoNotification
+     */
+    public function test_handle_sso_notification()
+    {
+        $this->request->cookies->add([ 'ssonot' => $this->cookieValue ]);
+
+        $entityId = $this->ssoNotificationService->handleSsoNotification($this->request->cookies, $this->proxyServerMock);
+
+        $this->assertEquals($this->idpEntityId, $entityId);
+    }
+
+    /**
+     * @test
+     * @group SsoNotification
+     */
+    public function test_handle_unknown_idp()
+    {
+        $this->request->cookies->add([ 'ssonot' => $this->getStandardCookieValue($this->idpEntityId . "test") ]);
+
+        $this->ssoNotificationService->handleSsoNotification($this->request->cookies, $this->proxyServerMock);
+
+        Phake::verify($this->loggerMock)->warning(Phake::anyParameters());
+    }
+
+    /**
+     * @test
+     * @group SsoNotification
+     */
+    public function test_invalid_encryption_key()
+    {
+        $ssoNotificationService = new SsoNotificationService(
+            $this->encryptionKey . "test",
+            $this->encryptionKeySalt,
+            $this->encryptionMethod,
+            $this->loggerMock
+        );
+        $this->request->cookies->add([ 'ssonot' => $this->cookieValue ]);
+
+        $ssoNotificationService->handleSsoNotification($this->request->cookies, $this->proxyServerMock);
+
+        Phake::verify($this->loggerMock, Phake::times(2))->error(Phake::anyParameters());
+        Phake::verify($this->loggerMock)->warning(Phake::anyParameters());
+    }
+
+    /**
+     * @test
+     * @group SsoNotification
+     */
+    public function test_invalid_json()
+    {
+        $data = "{\"url\":\"$this->idpUrl\"}";
+        $this->request->cookies->add([ 'ssonot' => $this->encryptData($data) ]);
+
+        $this->ssoNotificationService->handleSsoNotification($this->request->cookies, $this->proxyServerMock);
+
+        Phake::verify($this->loggerMock)->warning(Phake::anyParameters());
+    }
+
+    private function getStandardCookieValue($entityId)
+    {
+        $data = "{\"entityId\":\"$entityId\", \"url\":\"$this->idpUrl\"}";
+        return $this->encryptData($data);
+    }
+
+    private function encryptData($data)
+    {
+        $key = hash_pbkdf2('sha256', $this->encryptionKey, $this->encryptionKeySalt, 1000, 256, true);
+        $encrypted = openssl_encrypt($data, $this->encryptionMethod, $key, OPENSSL_RAW_DATA, $this->iv);
+        return base64_encode($this->iv . $encrypted);
+    }
+
+}


### PR DESCRIPTION
In this pull request we have added functionality to be able to process SSO Notifications.

**Short introduction on SSO Notifications**

SSO Notifications enable schools to reduce the number of steps users have to take during the login process and increase 
user-friendliness by providing the possibility to skip the WAYF (Where Are You From) screen. This is done via the use 
of a cookie, which can be set for example after the user has logged in on his own environment (for example an intranet page or the 
homepage of an Electronic Learning Environment).

---

Setting SSO Notification cookies is performed by a separate application - the SSO Notification service. Engineblock
is able to read the cookie and retrieve the entity id of the Identity Provider which should be used to start an 
authentication with. The contents of the SSO Notification cookie is encrypted by the SSO Notification service.
Engineblock contains a few configuration parameters to set the encryption details.
We are currently separately preparing to share the SSO Notification application as well.

For Engineblock the idea is to, in the Single Sign On process, check if there is a SSO Notification which can be used to scope to an Identity Provider. In SingleSignOn.php an additional check has been added for this feature and will call a service to read and parse the cookie if present. If the Identity Provider is known, then it is used to authenticate.

