### PR TITLE
Fix the spinner page in the excel browser

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
@@ -40,7 +40,8 @@
     </main>
 
     <script>
-        window.addEventListener('load', () => {
+        // do not use arrow notation here, as that breaks the in-built excel browser.
+        window.addEventListener('load', function() {
             document.querySelector('.hideNoJS').classList.remove('hideNoJS');
         });
     </script>


### PR DESCRIPTION
Prior to this change, the spinner page used arrow notation.  This
apparently broke the excel built-in browser.

This change uses the older function notation.

Pivotal ticket @ https://www.pivotaltracker.com/story/show/178713929