### PR TITLE
Add feature for attribute filter

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -24,6 +24,7 @@ open_conext_engine_block:
         eb.run_all_manipulations_prior_to_consent: "%feature_run_all_manipulations_prior_to_consent%"
         eb.block_user_on_violation: "%feature_block_user_on_violation%"
         eb.enable_sso_notification: "%feature_enable_sso_notification%"
+        eb.feature_filter_attributes: "%feature_filter_attributes%"
 
 swiftmailer:
     transport: "%mailer_transport%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -212,6 +212,7 @@ parameters:
     feature_api_deprovision: true
     feature_run_all_manipulations_prior_to_consent: false
     feature_block_user_on_violation: false
+    feature_filter_attributes: false
 
     ##########################################################################################
     ## PROFILE SETTINGS
@@ -265,3 +266,11 @@ parameters:
     sso_notification_encryption_key: <xxx>
     ## The encryption key salt used to decrypt the SSO notification
     sso_notification_encryption_key_salt: <xxx>
+
+    ##########################################################################################
+    ## FILTER ATTRIBUTES SETTINGS
+    ##########################################################################################
+    ## The attribute names added to this list are filtered from the list of attributes sent
+    ## by the IdP before showing the consent screen and sent to the SP
+    filter_attributes:
+        - example

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -533,4 +533,12 @@ class EngineBlock_Application_DiContainer extends Pimple
     {
         return $this->container->get('engineblock.service.sso_notification');
     }
+
+    /**
+     * @return array
+     */
+    public function getFilterAttributes(): ?array
+    {
+        return $this->container->getParameter('filter_attributes');
+    }
 }

--- a/library/EngineBlock/Corto/Filter/Command/FilterAttributes.php
+++ b/library/EngineBlock/Corto/Filter/Command/FilterAttributes.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
+
+class EngineBlock_Corto_Filter_Command_FilterAttributes extends EngineBlock_Corto_Filter_Command_Abstract
+    implements EngineBlock_Corto_Filter_Command_ResponseAttributesModificationInterface
+{
+
+    /**
+     * @var FeatureConfigurationInterface
+     */
+    private $featureConfiguration;
+
+    /**
+     * @var array
+     */
+    private $filterAttributes;
+
+    public function __construct(FeatureConfigurationInterface $featureConfiguration, ?array $filterAttributes)
+    {
+        $this->featureConfiguration = $featureConfiguration;
+        $this->filterAttributes = $filterAttributes;
+    }
+
+    /**
+     * Required for manipulation response attributes.
+     *
+     * @return array
+     */
+    public function getResponseAttributes(): array
+    {
+        return $this->_responseAttributes;
+    }
+
+    /**
+     * If the feature `feature_filter_attributes` is enabled, remove all the configured `filter_attributes` from the
+     * response attributes.
+     */
+    public function execute(): void
+    {
+        if ($this->featureConfiguration->isEnabled('eb.feature_filter_attributes')) {
+            $this->filterAttributes();
+        }
+    }
+
+    private function filterAttributes(): void
+    {
+        if (null !== $this->filterAttributes) {
+            foreach ($this->filterAttributes as $filterAttribute) {
+                unset($this->_responseAttributes[$filterAttribute]);
+            }
+        }
+    }
+}

--- a/library/EngineBlock/Corto/Filter/Input.php
+++ b/library/EngineBlock/Corto/Filter/Input.php
@@ -89,6 +89,9 @@ class EngineBlock_Corto_Filter_Input extends EngineBlock_Corto_Filter_Abstract
             // Check if the Policy Decision Point needs to be consulted for this request
             new EngineBlock_Corto_Filter_Command_EnforcePolicy(),
 
+            // Remove all EngineBlock configured filter_attributes from the responseAttributes
+            new EngineBlock_Corto_Filter_Command_FilterAttributes($featureConfiguration, $diContainer->getFilterAttributes()),
+
             // Apply the Attribute Release Policy before we do consent.
             new EngineBlock_Corto_Filter_Command_AttributeReleasePolicy(),
         );

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -42,6 +42,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.encrypted_assertions', true));
         $this->setFeature(new Feature('eb.encrypted_assertions_require_outer_signature', true));
         $this->setFeature(new Feature('eb.enable_sso_notification', false));
+        $this->setFeature(new Feature('eb.feature_filter_attributes', false));
     }
 
     public function setFeature(Feature $feature): void

--- a/tests/library/EngineBlock/Test/Corto/Filter/Command/FilterAttributesTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Filter/Command/FilterAttributesTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
+use PHPUnit\Framework\TestCase;
+
+class EngineBlock_Test_Corto_Filter_Command_FilterAtributesTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    const EB_FEATURE_FILTER_ATTRIBUTES = 'eb.feature_filter_attributes';
+    const FILTER_ATTRIBUTE = "filterAttribute";
+    const ADDITIONAL_FILTER_ATTRIBUTE = "additional:filter:attribute";
+    const DO_NOT_FILTER_ATTRIBUTE = "doNotFilterAttribute";
+    const ATTRIBUTE_VALUE = array("attribute value");
+
+    /**
+     * @var EngineBlock_Corto_Filter_Command_FilterAttributes
+     */
+    private $filter_Command_FilterAttributes;
+
+    /**
+     * @var FeatureConfiguration
+     */
+    private $featureConfiguration;
+
+    public function setUp()
+    {
+        $this->featureConfiguration = Phake::mock(FeatureConfiguration::class);
+        $filterAttributes = array(self::FILTER_ATTRIBUTE, self::ADDITIONAL_FILTER_ATTRIBUTE);
+
+        $this->filter_Command_FilterAttributes = new EngineBlock_Corto_Filter_Command_FilterAttributes(
+            $this->featureConfiguration, $filterAttributes);
+
+        Phake::when($this->featureConfiguration)
+            ->isEnabled(self::EB_FEATURE_FILTER_ATTRIBUTES)
+            ->thenReturn(true);
+    }
+
+    public function testFilterAttributes()
+    {
+        $this->filter_Command_FilterAttributes
+            ->setResponseAttributes(array(self::DO_NOT_FILTER_ATTRIBUTE => self::ATTRIBUTE_VALUE,
+                self::FILTER_ATTRIBUTE => self::ATTRIBUTE_VALUE,
+                self::ADDITIONAL_FILTER_ATTRIBUTE => self::ATTRIBUTE_VALUE));
+
+        $this->filter_Command_FilterAttributes->execute();
+
+        $responseAttributes = $this->filter_Command_FilterAttributes->getResponseAttributes();
+        $this->assertArrayNotHasKey(self::FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertArrayNotHasKey(self::ADDITIONAL_FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertArrayHasKey(self::DO_NOT_FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertEquals(1, sizeof($responseAttributes));
+    }
+
+    public function testDoNotFilterAttributes()
+    {
+        $this->filter_Command_FilterAttributes
+            ->setResponseAttributes(array(self::DO_NOT_FILTER_ATTRIBUTE => self::ATTRIBUTE_VALUE,
+                self::FILTER_ATTRIBUTE => self::ATTRIBUTE_VALUE,
+                self::ADDITIONAL_FILTER_ATTRIBUTE => self::ATTRIBUTE_VALUE));
+
+        Phake::when($this->featureConfiguration)
+            ->isEnabled(self::EB_FEATURE_FILTER_ATTRIBUTES)
+            ->thenReturn(false);
+
+        $this->filter_Command_FilterAttributes->execute();
+
+        $responseAttributes = $this->filter_Command_FilterAttributes->getResponseAttributes();
+        $this->assertArrayHasKey(self::FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertArrayHasKey(self::ADDITIONAL_FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertArrayHasKey(self::DO_NOT_FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertEquals(3, sizeof($responseAttributes));
+    }
+
+    public function testDoNotCrashOnMissingFilterAttribute()
+    {
+        $this->filter_Command_FilterAttributes
+            ->setResponseAttributes(array(self::DO_NOT_FILTER_ATTRIBUTE => self::ATTRIBUTE_VALUE,
+                self::ADDITIONAL_FILTER_ATTRIBUTE => self::ATTRIBUTE_VALUE));
+
+        $this->filter_Command_FilterAttributes->execute();
+
+        $responseAttributes = $this->filter_Command_FilterAttributes->getResponseAttributes();
+        $this->assertArrayNotHasKey(self::FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertArrayNotHasKey(self::ADDITIONAL_FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertArrayHasKey(self::DO_NOT_FILTER_ATTRIBUTE, $responseAttributes);
+        $this->assertEquals(1, sizeof($responseAttributes));
+    }
+}


### PR DESCRIPTION
In this pull request we have added the possibility to define a set of attributes which are always filtered from the attributes that are sent by an Identity Provider.

These attributes are subsequently also not shown in the consent screen and are not propagated to the Service Provider.

This can for example be useful when it is required to filter certain attributes for every Service Provider. For example in our case we  require certain attributes from the IdP but these attributes should never be sent to any Service Provider.