### PR TITLE
Make the original AuthnRequest available to attribute manipulations.

### DIFF
--- a/library/EngineBlock/Attributes/Manipulator/ServiceRegistry.php
+++ b/library/EngineBlock/Attributes/Manipulator/ServiceRegistry.php
@@ -39,7 +39,8 @@ class EngineBlock_Attributes_Manipulator_ServiceRegistry
         array &$attributes,
         EngineBlock_Saml2_ResponseAnnotationDecorator &$responseObj,
         IdentityProvider $identityProvider,
-        ServiceProvider $serviceProvider
+        ServiceProvider $serviceProvider,
+        EngineBlock_Saml2_AuthnRequestAnnotationDecorator $requestObj
     ) {
         $manipulationCode = $entity->getManipulation();
         if (empty($manipulationCode)) {
@@ -63,7 +64,8 @@ class EngineBlock_Attributes_Manipulator_ServiceRegistry
             $response,
             $responseObj,
             $idpMetadataLegacy,
-            $spMetadataLegacy
+            $spMetadataLegacy,
+            $requestObj
         );
 
         $responseObj = $translator->fromOldFormat($response);
@@ -78,7 +80,8 @@ class EngineBlock_Attributes_Manipulator_ServiceRegistry
         array &$response,
         EngineBlock_Saml2_ResponseAnnotationDecorator $responseObj,
         array $idpMetadata,
-        array $spMetadata
+        array $spMetadata,
+        EngineBlock_Saml2_AuthnRequestAnnotationDecorator $requestObj
     ) {
         $entityType = $this->_entityType;
 
@@ -93,7 +96,8 @@ class EngineBlock_Attributes_Manipulator_ServiceRegistry
                     &$response,
                     $responseObj,
                     $idpMetadata,
-                    $spMetadata
+                    $spMetadata,
+                    $requestObj
             ) {
                 eval($manipulationCode);
             },

--- a/library/EngineBlock/Corto/Filter/Command/RunAttributeManipulations.php
+++ b/library/EngineBlock/Corto/Filter/Command/RunAttributeManipulations.php
@@ -93,7 +93,8 @@ class EngineBlock_Corto_Filter_Command_RunAttributeManipulations extends EngineB
             $this->_responseAttributes,
             $this->_response,
             $this->_identityProvider,
-            $serviceProvider
+            $serviceProvider,
+            $this->_request
         );
 
         $this->_response->setIntendedNameId($this->_collabPersonId);

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
@@ -177,5 +177,20 @@ Feature:
      And the response should not match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" and text()="NOOT"]'
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]'
 
+  Scenario: The manipulation can access the AuthnRequest object
+    Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
+      """
+      $attributes['urn:mace:dir:attribute-def:uid'] = [$requestObj->getDestination()];
+      """
+    When I log in at "SP-with-Attribute-Manipulations"
+     And I select "Dummy-IdP" on the WAYF
+     And I pass through EngineBlock
+     And I pass through the IdP
+    Then I should not see "https://engine.vm.openconext.org/authentication/idp/single-sign-on"
+    When I give my consent
+     And I pass through EngineBlock
+    Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text()="https://engine.vm.openconext.org/authentication/idp/single-sign-on"]'
+
 #
 #  Scenario: Sp and IdP attribute manipulations


### PR DESCRIPTION
The Attribute Manipulations could use any items from the IdP, SP
metadata and prepared response, but could not read the AuthnRequest.
Adding `$requestObj` as an input adds a generic way to access information
from the request. It is (obviously) read only.

We're adding it only in the object form to mirror how the response is
passed, but do not convert it to any legacy format; that seems
unnecessary for a new feature.

There's a behat test that verifies that the AM can indeed read something
from the `$requestObj` variable - the AM itself in this scenario makes
not much sense but shows that we can read something from the object and
do something with it.