### PR TITLE
Add configuration options for requested attributes in proxy SP metadata

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -54,6 +54,10 @@ parameters:
         - http
         - https
 
+    ## Add RequestedAttributes to the AttributeConsumingService of the SP Proxy metadata of Engineblock, default is all
+    ## Options are 'all' (optional and required attributes), 'required' (only required attributes) or 'none'
+    metadata_add_requested_attributes: all
+
     ##########################################################################################
     ## PHP SETTINGS
     ##########################################################################################

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -143,6 +143,7 @@ services:
             - "@OpenConext\\EngineBlock\\Metadata\\X509\\KeyPairFactory"
             - "@OpenConext\\EngineBlock\\Xml\\DocumentSigner"
             - "@engineblock.service.time_provider"
+            - "%metadata_add_requested_attributes%"
 
     OpenConext\EngineBlock\Xml\MetadataProvider:
         arguments:

--- a/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
@@ -101,7 +101,7 @@ class MetadataRendererTest extends TestCase
             $keyPairFactory,
             $documentSigner,
             new TimeProvider(),
-            'terms-of-use'
+            'all'
         );
 
         parent::setUp();

--- a/theme/base/templates/modules/Authentication/View/Metadata/sp.xml.twig
+++ b/theme/base/templates/modules/Authentication/View/Metadata/sp.xml.twig
@@ -18,7 +18,7 @@
         <md:AssertionConsumerService Binding="{{ metadata.assertionConsumerService.binding }}"
                                      Location="{{ metadata.assertionConsumerService.location }}"
                                      index="0"></md:AssertionConsumerService>
-        {% if metadata.requestedAttributes is not empty %}
+        {% if requestedAttributes is not empty %}
             <md:AttributeConsumingService index="0">
                 {% for locale in locales %}
                     <md:ServiceName xml:lang="{{ locale }}">{{ metadata.name(locale) }}</md:ServiceName>
@@ -26,7 +26,7 @@
                 {% for locale in locales %}
                     <md:ServiceDescription xml:lang="{{ locale }}">{{ metadata.description(locale) }}</md:ServiceDescription>
                 {% endfor %}
-                {% for attribute in metadata.requestedAttributes %}
+                {% for attribute in requestedAttributes %}
                     <md:RequestedAttribute Name="{{ attribute.name }}" NameFormat="{{ attribute.nameFormat }}" isRequired="{{ attribute.required ? 'true' : 'false' }}"></md:RequestedAttribute>
                 {% endfor %}
             </md:AttributeConsumingService>

--- a/theme/openconext/templates/modules/Authentication/View/Metadata/sp.xml.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Metadata/sp.xml.twig
@@ -18,7 +18,7 @@
         <md:AssertionConsumerService Binding="{{ metadata.assertionConsumerService.binding }}"
                                      Location="{{ metadata.assertionConsumerService.location }}"
                                      index="0"></md:AssertionConsumerService>
-        {% if metadata.requestedAttributes is not empty %}
+        {% if requestedAttributes is not empty %}
             <md:AttributeConsumingService index="0">
                 {% for locale in locales %}
                     <md:ServiceName xml:lang="{{ locale }}">{{ metadata.name(locale) }}</md:ServiceName>
@@ -26,7 +26,7 @@
                 {% for locale in locales %}
                     <md:ServiceDescription xml:lang="{{ locale }}">{{ metadata.description(locale) }}</md:ServiceDescription>
                 {% endfor %}
-                {% for attribute in metadata.requestedAttributes %}
+                {% for attribute in requestedAttributes %}
                     <md:RequestedAttribute Name="{{ attribute.name }}" NameFormat="{{ attribute.nameFormat }}" isRequired="{{ attribute.required ? 'true' : 'false' }}"></md:RequestedAttribute>
                 {% endfor %}
             </md:AttributeConsumingService>


### PR DESCRIPTION
Currently an IdP based on SimpleSAMLphp (v1.19.1) sends a limited list of attributes to an SP which defines RequestedAttributes, namely only the attributes which are defined in the RequestedAttributes. This limits the use of attribute conditions within Engineblock since the min condition, which adds the attribute to RequestedAttributes, can not be used. 
We have added an option to allow control over the RequestedAttribute list added to the proxy SP metadata of Engineblock where options 'all', 'required' and 'none' are supported. Default has been set to 'all' which is how currently Engineblock works. This may turn out to be a temporary solution if this is handled in SimpleSAMLphp but we wanted to provide this all the same.