### PR TITLE
Reset attributeValueTypes after an Attribute Manipulation

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/RunAttributeManipulations.php
+++ b/library/EngineBlock/Corto/Filter/Command/RunAttributeManipulations.php
@@ -21,7 +21,8 @@
  */
 class EngineBlock_Corto_Filter_Command_RunAttributeManipulations extends EngineBlock_Corto_Filter_Command_Abstract
     implements EngineBlock_Corto_Filter_Command_ResponseModificationInterface,
-    EngineBlock_Corto_Filter_Command_ResponseAttributesModificationInterface
+    EngineBlock_Corto_Filter_Command_ResponseAttributesModificationInterface,
+    EngineBlock_Corto_Filter_Command_ResponseAttributeValueTypesModificationInterface
 {
     const TYPE_SP  = 'sp';
     const TYPE_REQUESTER_SP = 'requester-sp';
@@ -51,6 +52,14 @@ class EngineBlock_Corto_Filter_Command_RunAttributeManipulations extends EngineB
     public function getResponseAttributes()
     {
         return $this->_responseAttributes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResponseAttributeValueTypes()
+    {
+        return $this->_responseAttributeValueTypes;
     }
 
     public function execute()
@@ -85,6 +94,8 @@ class EngineBlock_Corto_Filter_Command_RunAttributeManipulations extends EngineB
             );
         }
 
+        $attributesBefore = $this->_responseAttributes;
+
         // Try entity specific file based manipulation from Service Registry
         $manipulator = new EngineBlock_Attributes_Manipulator_ServiceRegistry($this->_type);
         $manipulator->manipulate(
@@ -97,6 +108,13 @@ class EngineBlock_Corto_Filter_Command_RunAttributeManipulations extends EngineB
             $this->_request
         );
 
+        // If attributes have changed, we need to reset the attribute value types
+        // since they will not correspond anymore, and we have no interface for the
+        // AM to specify the new types. Making it empty will let saml2 set the
+        // correct ones for us.
+        if($attributesBefore != $this->_responseAttributes) {
+            $this->_responseAttributeValueTypes = [];
+        }
         $this->_response->setIntendedNameId($this->_collabPersonId);
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
@@ -192,5 +192,26 @@ Feature:
     Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
     And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:uid"]/saml:AttributeValue[text()="https://engine.vm.openconext.org/authentication/idp/single-sign-on"]'
 
+  Scenario: The manipulation reduces a multivalued attribute to a single value
+    Given the IdP "Dummy-IdP" sends attribute "urn:mace:dir:attribute-def:eduPersonAffiliation" with values "student,faculty,guest,member" and xsi:type is "xs:string"
+    And SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
+      """
+      $attributes['urn:mace:dir:attribute-def:eduPersonAffiliation'] = ['guest'];
+      """
+    When I log in at "SP-with-Attribute-Manipulations"
+     And I select "Dummy-IdP" on the WAYF
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "eduPersonAffiliation"
+    And the response should contain "faculty"
+    And the response should contain "member"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:dir:attribute-def:eduPersonAffiliation"
+    And the response should contain "guest"
+    And the response should not contain "member"
+    And the response should not contain "faculty"
 #
 #  Scenario: Sp and IdP attribute manipulations

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeReleasePolicy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeReleasePolicy.feature
@@ -13,11 +13,13 @@ Feature:
     And a Service Provider named "Wildcard ARP"
     And a Service Provider named "Wrong Value ARP"
     And a Service Provider named "Right Value ARP"
+    And a Service Provider named "Specific Value ARP"
     And a Service Provider named "Two value ARP"
     And SP "Empty ARP" allows no attributes
     And SP "Wildcard ARP" allows an attribute named "urn:mace:dir:attribute-def:uid"
     And SP "Wrong Value ARP" allows an attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization" with value "example.edu"
     And SP "Right Value ARP" allows an attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization" with value "engine-test-stand.openconext.org"
+    And SP "Specific Value ARP" allows an attribute named "urn:mace:dir:attribute-def:eduPersonAffiliation" with value "faculty"
     And SP "Two value ARP" allows an attribute named "urn:mace:dir:attribute-def:uid"
     And SP "Two value ARP" allows an attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization"
     And feature "eb.run_all_manipulations_prior_to_consent" is disabled
@@ -66,7 +68,7 @@ Feature:
     Then the response should not contain "urn:mace:dir:attribute-def:uid"
     And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
 
-  Scenario: As a user for an SP with a specific value ARP I do see the attribute the right value
+  Scenario: As a user for an SP with a specific value ARP I do see the attribute if it has the right value
     When I log in at "Right Value ARP"
     And I pass through EngineBlock
     And I pass through the IdP
@@ -76,6 +78,21 @@ Feature:
     And I pass through EngineBlock
     Then the response should not contain "urn:mace:dir:attribute-def:uid"
     And the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+
+  Scenario: As a user for an SP with a specific value ARP and multiple attributes sent I do see the attribute with only the right value
+    Given the IdP "TestIdp" sends attribute "urn:mace:dir:attribute-def:eduPersonAffiliation" with values "student,faculty,guest,member" and xsi:type is "xs:string"
+    When I log in at "Specific Value ARP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:dir:attribute-def:eduPersonAffiliation"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:dir:attribute-def:eduPersonAffiliation"
+    And the response should contain "faculty"
+    And the response should not contain "member"
+    And the response should not contain "guest"
 
   Scenario: As a user for an SP with 2 attributes in the ARP I only get those attributes
     When I log in at "Two value ARP"


### PR DESCRIPTION
AttributeValueTypes is an array contains the types (string, bool, int..) for each value of all released attributes in the attributes array. The ARP ensures the two arrays remain consistent after filtering out some values. However, the Attribute Manipulation also has the option to change the released attributes in the `$attributes` array passed to it. AM's do however not have a way to change the corresponding list of types (it is not available to the AM code).

If this is not done, in the case that the resulting set has less values than the original set after ARP, one gets [an Exception from the SAML2 library](https://github.com/simplesamlphp/saml2/blob/04d0ed6c5e51cbb328afe1bdcba2cc7bd84d7e87/src/SAML2/Assertion.php#L1690) that there are more valuetypes than values.

Earlier, this would always work because after AM the ARP would be reapplied which kind of sorted out the attribute types. Not entirely correctly btw, more by chance (the number of valuetypes is adjusted to the number of values - regardless), but in practice this nearly always went well because we never deal with anything but `xsi:string`. When the second ARP step was removed, this reordering of the value types was also not present anymore and the saml2 Exception appeared in the case of an IdP releasing multivalued attribute which was by an AM reduced to less (but not 0) values.

The solution is (and this makes it actually more correct than it was), is that if anything changed about the attributes after AM, we just reset the valuetypes. This triggers a feature in the saml2 library [that if there are no types](https://github.com/simplesamlphp/saml2/blob/04d0ed6c5e51cbb328afe1bdcba2cc7bd84d7e87/src/SAML2/Assertion.php#L1712), the library will assign the correct types based on the PHP types of the values. This means that you can even decide in the AM what types you'd want by setting $attributes correctly.

The approach is especially future proof because the 5.x branch of saml2 will do away with valuetypes altogether and will always use the PHP types of the attribute values, the behaviour we now trigger explicitly will then be the only behaviour available.

The issue was not discovered in development because the functional test suite lacked tests for multivalued attributes being reduced to lesser values, both by ARP and (in this case) by an AM. This PR first adds such tests. The testsuite fails, which shows the issue we encountered being present. After applying the commit with the fix, the testsuite passes again.