### PR TITLE
Save custom objects using custom doctrine type mappings

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -95,9 +95,19 @@ doctrine:
                 mapping_types:
                     enum: string
         types:
+            engineblock_attribute_release_policy: OpenConext\EngineBlockBundle\Doctrine\Type\AttributeReleasePolicyType
+            engineblock_certificate_array: OpenConext\EngineBlockBundle\Doctrine\Type\CertificateArrayType
             engineblock_collab_person_id: OpenConext\EngineBlockBundle\Doctrine\Type\CollabPersonIdType
             engineblock_collab_person_uuid: OpenConext\EngineBlockBundle\Doctrine\Type\CollabPersonUuidType
+            engineblock_contact_person_array: OpenConext\EngineBlockBundle\Doctrine\Type\ContactPersonArrayType
+            engineblock_indexed_service_array: OpenConext\EngineBlockBundle\Doctrine\Type\IndexedServiceArrayType
+            engineblock_logo: OpenConext\EngineBlockBundle\Doctrine\Type\LogoType
             engineblock_metadata_coins: OpenConext\EngineBlockBundle\Doctrine\Type\MetadataCoinType
+            engineblock_organization: OpenConext\EngineBlockBundle\Doctrine\Type\OrganizationType
+            engineblock_requested_attribute_array: OpenConext\EngineBlockBundle\Doctrine\Type\RequestedAttributeArrayType
+            engineblock_service: OpenConext\EngineBlockBundle\Doctrine\Type\ServiceType
+            engineblock_service_array: OpenConext\EngineBlockBundle\Doctrine\Type\ServiceArrayType
+            engineblock_shib_md_scope_array: OpenConext\EngineBlockBundle\Doctrine\Type\ShibMdScopeArrayType
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
         proxy_dir: '%kernel.cache_dir%/doctrine/orm/Proxies'

--- a/database/DoctrineMigrations/Version20211019150744.php
+++ b/database/DoctrineMigrations/Version20211019150744.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211019150744 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE sso_provider_roles_eb6 (id INT AUTO_INCREMENT NOT NULL, entity_id VARCHAR(255) NOT NULL, name_nl VARCHAR(255) DEFAULT NULL, name_en VARCHAR(255) DEFAULT NULL, name_pt VARCHAR(255) DEFAULT NULL, description_nl VARCHAR(255) DEFAULT NULL, description_en VARCHAR(255) DEFAULT NULL, description_pt VARCHAR(255) DEFAULT NULL, display_name_nl VARCHAR(255) DEFAULT NULL, display_name_en VARCHAR(255) DEFAULT NULL, display_name_pt VARCHAR(255) DEFAULT NULL, logo LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_logo)\', organization_nl_name LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_organization)\', organization_en_name LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_organization)\', organization_pt_name LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_organization)\', keywords_nl VARCHAR(255) DEFAULT NULL, keywords_en VARCHAR(255) DEFAULT NULL, keywords_pt VARCHAR(255) DEFAULT NULL, certificates LONGTEXT NOT NULL COMMENT \'(DC2Type:engineblock_certificate_array)\', workflow_state VARCHAR(255) NOT NULL, contact_persons LONGTEXT NOT NULL COMMENT \'(DC2Type:engineblock_contact_person_array)\', name_id_format VARCHAR(255) DEFAULT NULL, name_id_formats LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\', single_logout_service LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_service)\', requests_must_be_signed TINYINT(1) NOT NULL, manipulation LONGTEXT DEFAULT NULL, coins LONGTEXT NOT NULL COMMENT \'(DC2Type:engineblock_metadata_coins)\', type VARCHAR(255) NOT NULL, attribute_release_policy LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_attribute_release_policy)\', assertion_consumer_services LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_indexed_service_array)\', allowed_idp_entity_ids LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\', allow_all TINYINT(1) DEFAULT NULL, requested_attributes LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_requested_attribute_array)\', support_url_en VARCHAR(255) DEFAULT NULL, support_url_nl VARCHAR(255) DEFAULT NULL, support_url_pt VARCHAR(255) DEFAULT NULL, enabled_in_wayf TINYINT(1) DEFAULT NULL, single_sign_on_services LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_service_array)\', consent_settings LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\', shib_md_scopes LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:engineblock_shib_md_scope_array)\', INDEX idx_sso_provider_roles_eb6_type (type), INDEX idx_sso_provider_roles_eb6_entity_id (entity_id), UNIQUE INDEX idx_sso_provider_roles_eb6_entity_id_type (type, entity_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE sso_provider_roles_eb6');
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/AttributeReleasePolicy.php
+++ b/src/OpenConext/EngineBlock/Metadata/AttributeReleasePolicy.php
@@ -235,4 +235,14 @@ class AttributeReleasePolicy
     {
         return $this->attributeRules;
     }
+
+    /**
+     * A convenience static constructor for the AttributeReleasePolicy.
+     * @param array $attributeReleasePolicy
+     * @return AttributeReleasePolicy
+     */
+    public static function fromArray(array $attributeReleasePolicy): AttributeReleasePolicy
+    {
+        return new self($attributeReleasePolicy);
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/ContactPerson.php
+++ b/src/OpenConext/EngineBlock/Metadata/ContactPerson.php
@@ -25,17 +25,30 @@ namespace OpenConext\EngineBlock\Metadata;
 class ContactPerson
 {
     public $contactType;
-    public $emailAddress = '';
-    public $telephoneNumber = '';
-    public $givenName = '';
-    public $surName = '';
+    public $emailAddress;
+    public $telephoneNumber;
+    public $givenName;
+    public $surName;
 
     /**
      * @param $contactType
+     * @param string $emailAddress
+     * @param string $telephoneNumber
+     * @param string $givenName
+     * @param string $surName
      */
-    public function __construct($contactType)
-    {
+    public function __construct(
+        $contactType,
+        string $emailAddress = '',
+        string $telephoneNumber = '',
+        string $givenName = '',
+        string $surName = ''
+    ) {
         $this->contactType = $contactType;
+        $this->emailAddress = $emailAddress;
+        $this->telephoneNumber = $telephoneNumber;
+        $this->givenName = $givenName;
+        $this->surName = $surName;
     }
 
     /**
@@ -60,5 +73,19 @@ class ContactPerson
         $contact->emailAddress = $emailAddress;
         $contact->telephoneNumber = $telephoneNumber;
         return $contact;
+    }
+
+    /**
+     * A convenience static constructor for the contact person.
+     * @param array $contactPerson
+     * @return ContactPerson
+     */
+    public static function fromArray(array $contactPerson): ContactPerson
+    {
+        return new self($contactPerson["contactType"],
+            $contactPerson["emailAddress"],
+            $contactPerson["telephoneNumber"],
+            $contactPerson["givenName"],
+            $contactPerson["surName"]);
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRoleEb6.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/AbstractRoleEb6.php
@@ -1,0 +1,395 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata\Entity;
+
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RuntimeException;
+use SAML2\Constants;
+
+/**
+ * This class has been added to temporary push to both sso_provider_roles_eb5
+ * and sso_provider_roles_eb6
+ *
+ * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+ *
+ * Abstract base class for configuration entities.
+ *
+ * @package OpenConext\EngineBlock\Metadata\Entity
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ *
+ * @ORM\Entity
+ * @ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
+ * @ORM\Table(
+ *      name="sso_provider_roles_eb6",
+ *      uniqueConstraints={
+ *          @ORM\UniqueConstraint(
+ *              name="idx_sso_provider_roles_eb6_entity_id_type",
+ *              columns={"type", "entity_id"}
+ *          )
+ *      },
+ *      indexes={
+ *          @ORM\Index(
+ *              name="idx_sso_provider_roles_eb6_type",
+ *              columns={"type"}
+ *          ),
+ *          @ORM\Index(
+ *              name="idx_sso_provider_roles_eb6_entity_id",
+ *              columns={"entity_id"}
+ *          ),
+ *      }
+ * )
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ *  "sp"  = "OpenConext\EngineBlock\Metadata\Entity\ServiceProviderEb6",
+ *  "idp" = "OpenConext\EngineBlock\Metadata\Entity\IdentityProviderEb6"
+ * })
+ *
+ * @SuppressWarnings(PHPMD.UnusedPrivateField)
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ */
+abstract class AbstractRoleEb6
+{
+    const WORKFLOW_STATE_PROD = 'prodaccepted';
+    const WORKFLOW_STATE_TEST = 'testaccepted';
+    const WORKFLOW_STATE_DEFAULT = self::WORKFLOW_STATE_PROD;
+
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="entity_id", type="string")
+     */
+    public $entityId;
+
+    /**
+     * @var null|string
+     * @ORM\Column(name="name_nl", type="string", nullable=true)
+     */
+    public $nameNl;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="name_en", type="string", nullable=true)
+     */
+    public $nameEn;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="name_pt", type="string", nullable=true)
+     */
+    public $namePt;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="description_nl", type="string", nullable=true)
+     */
+    public $descriptionNl;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="description_en", type="string", nullable=true)
+     */
+    public $descriptionEn;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="description_pt", type="string", nullable=true)
+     */
+    public $descriptionPt;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="display_name_nl", type="string", nullable=true)
+     */
+    public $displayNameNl;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="display_name_en", type="string", nullable=true)
+     */
+    public $displayNameEn;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="display_name_pt", type="string", nullable=true)
+     */
+    public $displayNamePt;
+
+    /**
+     * @var null|Logo
+     *
+     * @ORM\Column(name="logo", type="engineblock_logo", nullable=true)
+     */
+    public $logo;
+
+    /**
+     * @var null|Organization
+     *
+     * @ORM\Column(name="organization_nl_name",type="engineblock_organization", nullable=true)
+     */
+    public $organizationNl;
+
+    /**
+     * @var null|Organization
+     *
+     * @ORM\Column(name="organization_en_name",type="engineblock_organization", nullable=true)
+     */
+    public $organizationEn;
+
+    /**
+     * @var null|Organization
+     *
+     * @ORM\Column(name="organization_pt_name",type="engineblock_organization", nullable=true)
+     */
+    public $organizationPt;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="keywords_nl", type="string", nullable=true)
+     */
+    public $keywordsNl;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="keywords_en", type="string", nullable=true)
+     */
+    public $keywordsEn;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="keywords_pt", type="string", nullable=true)
+     */
+    public $keywordsPt;
+
+    /**
+     * @var X509Certificate[]
+     *
+     * @ORM\Column(name="certificates", type="engineblock_certificate_array")
+     */
+    public $certificates = array();
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="workflow_state", type="string")
+     */
+    public $workflowState = self::WORKFLOW_STATE_DEFAULT;
+
+    /**
+     * @var ContactPerson[]
+     *
+     * @ORM\Column(name="contact_persons", type="engineblock_contact_person_array")
+     */
+    public $contactPersons;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="name_id_format", type="string", nullable=true)
+     */
+    public $nameIdFormat;
+
+    /**
+     * @var null|string[]
+     *
+     * @ORM\Column(name="name_id_formats", type="json", nullable=true)
+     */
+    public $supportedNameIdFormats;
+
+    /**
+     * @var null|Service
+     *
+     * @ORM\Column(name="single_logout_service", type="engineblock_service", nullable=true)
+     */
+    public $singleLogoutService;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="requests_must_be_signed", type="boolean")
+     */
+    public $requestsMustBeSigned = false;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="manipulation", type="text", nullable=true)
+     */
+    public $manipulation;
+
+    /**
+     * @var Coins
+     *
+     * @ORM\Column(name="coins", type="engineblock_metadata_coins")
+     */
+    protected $coins = array();
+
+    /**
+     * @param $entityId
+     * @param Organization $organizationEn
+     * @param Organization $organizationNl
+     * @param Organization $organizationPt
+     * @param Service $singleLogoutService
+     * @param array $certificates
+     * @param array $contactPersons
+     * @param string $descriptionEn
+     * @param string $descriptionNl
+     * @param string $descriptionPt
+     * @param string $displayNameEn
+     * @param string $displayNameNl
+     * @param string $displayNamePt
+     * @param string $keywordsEn
+     * @param string $keywordsNl
+     * @param string $keywordsPt
+     * @param Logo $logo
+     * @param string $nameEn
+     * @param string $nameNl
+     * @param string $namePt
+     * @param null $nameIdFormat
+     * @param array $supportedNameIdFormats
+     * @param bool $requestsMustBeSigned
+     * @param string $workflowState
+     * @param string $manipulation
+     */
+    public function __construct(
+        $entityId,
+        Organization $organizationEn = null,
+        Organization $organizationNl = null,
+        Organization $organizationPt = null,
+        Service $singleLogoutService = null,
+        array $certificates = array(),
+        array $contactPersons = array(),
+        $descriptionEn = '',
+        $descriptionNl = '',
+        $descriptionPt = '',
+        $displayNameEn = '',
+        $displayNameNl = '',
+        $displayNamePt = '',
+        $keywordsEn = '',
+        $keywordsNl = '',
+        $keywordsPt = '',
+        Logo $logo = null,
+        $nameEn = '',
+        $nameNl = '',
+        $namePt = '',
+        $nameIdFormat = null,
+        $supportedNameIdFormats = array(
+            Constants::NAMEID_TRANSIENT,
+            Constants::NAMEID_PERSISTENT,
+        ),
+        $requestsMustBeSigned = false,
+        $workflowState = self::WORKFLOW_STATE_DEFAULT,
+        $manipulation = ''
+    ) {
+        $this->certificates = $certificates;
+        $this->contactPersons = $contactPersons;
+        $this->descriptionEn = $descriptionEn;
+        $this->descriptionNl = $descriptionNl;
+        $this->descriptionPt = $descriptionPt;
+        $this->displayNameEn = $displayNameEn;
+        $this->displayNameNl = $displayNameNl;
+        $this->displayNamePt = $displayNamePt;
+        $this->entityId = $entityId;
+        $this->keywordsEn = $keywordsEn;
+        $this->keywordsNl = $keywordsNl;
+        $this->keywordsPt = $keywordsPt;
+        $this->logo = $logo;
+        $this->nameEn = $nameEn;
+        $this->nameNl = $nameNl;
+        $this->namePt = $namePt;
+        $this->nameIdFormat = $nameIdFormat;
+        $this->supportedNameIdFormats = $supportedNameIdFormats;
+        $this->organizationEn = $organizationEn;
+        $this->organizationNl = $organizationNl;
+        $this->organizationPt = $organizationPt;
+        $this->requestsMustBeSigned = $requestsMustBeSigned;
+        $this->singleLogoutService = $singleLogoutService;
+        $this->workflowState = $workflowState;
+        $this->manipulation = $manipulation;
+    }
+
+    /**
+     * @param VisitorInterface $visitor
+     * @return null|AbstractRole
+     */
+    abstract public function accept(VisitorInterface $visitor);
+
+    /**
+     * @return string
+     */
+    public function getManipulation()
+    {
+        return $this->manipulation;
+    }
+
+    /**
+     * @return $this
+     */
+    public function toggleWorkflowState()
+    {
+        if ($this->workflowState === static::WORKFLOW_STATE_PROD) {
+            $this->workflowState = static::WORKFLOW_STATE_TEST;
+            return $this;
+        }
+
+        if ($this->workflowState === static::WORKFLOW_STATE_TEST) {
+            $this->workflowState = static::WORKFLOW_STATE_PROD;
+            return $this;
+        }
+
+        throw new RuntimeException('Unknown workflow state');
+    }
+
+    /**
+     * @return Coins
+     */
+    public function getCoins()
+    {
+        return $this->coins;
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProviderEb6.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProviderEb6.php
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ConsentSettings;
+use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
+use OpenConext\EngineBlock\Metadata\MfaEntityCollection;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\StepupConnections;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Constants;
+
+/**
+ * This class has been added to temporary push to both sso_provider_roles_eb5
+ * and sso_provider_roles_eb6
+ *
+ * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+ *
+ * @package OpenConext\EngineBlock\Metadata\Entity
+ * @ORM\Entity
+ * @SuppressWarnings(PHPMD.CamelCasePropertyName)
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ *
+ * WARNING: Please don't use this entity directly but use the dedicated factory instead.
+ * @see \OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory
+ */
+class IdentityProviderEb6 extends AbstractRoleEb6
+{
+    const GUEST_QUALIFIER_ALL = 'All';
+    const GUEST_QUALIFIER_SOME = 'Some';
+    const GUEST_QUALIFIER_NONE = 'None';
+
+    /**
+     * In all-caps to indicate that though the language doesn't allow it, this should be an array constant.
+     *
+     * @var string[]
+     */
+    public static $GUEST_QUALIFIERS = array(
+        self::GUEST_QUALIFIER_ALL,
+        self::GUEST_QUALIFIER_SOME,
+        self::GUEST_QUALIFIER_NONE
+    );
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="enabled_in_wayf", type="boolean")
+     */
+    public $enabledInWayf = true;
+
+    /**
+     * @var Service[]
+     *
+     * @ORM\Column(name="single_sign_on_services", type="engineblock_service_array")
+     */
+    public $singleSignOnServices = array();
+
+    /**
+     * @var ConsentSettings
+     *
+     * @ORM\Column(name="consent_settings", type="json_array")
+     */
+    private $consentSettings;
+
+    /**
+     * @var ShibMdScope[]
+     *
+     * @ORM\Column(name="shib_md_scopes", type="engineblock_shib_md_scope_array")
+     */
+    public $shibMdScopes = array();
+
+    /**
+     * WARNING: Please don't use this entity directly but use the dedicated factory instead.
+     * @see \OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory
+     *
+     * @param string $entityId
+     * @param Organization $organizationEn
+     * @param Organization $organizationNl
+     * @param Organization $organizationPt
+     * @param Service $singleLogoutService
+     * @param bool $additionalLogging
+     * @param array $certificates
+     * @param array $contactPersons
+     * @param string $descriptionEn
+     * @param string $descriptionNl
+     * @param string $descriptionPt
+     * @param bool $disableScoping
+     * @param string $displayNameEn
+     * @param string $displayNameNl
+     * @param string $displayNamePt
+     * @param string $keywordsEn
+     * @param string $keywordsNl
+     * @param string $keywordsPt
+     * @param Logo $logo
+     * @param string $nameEn
+     * @param string $nameNl
+     * @param string $namePt
+     * @param null $nameIdFormat
+     * @param array $supportedNameIdFormats
+     * @param bool $requestsMustBeSigned
+     * @param string $signatureMethod
+     * @param string $workflowState
+     * @param string $manipulation
+     * @param bool $enabledInWayf
+     * @param string $guestQualifier
+     * @param bool $hidden
+     * @param null $schacHomeOrganization
+     * @param array $shibMdScopes
+     * @param array $singleSignOnServices
+     * @param ConsentSettings $consentSettings
+     * @param StepupConnections|null $stepupConnections
+     * @param MfaEntityCollection|null $mfaEntities
+     * @param bool $disableUidHashing
+     * @param bool $importedIdp
+     */
+    public function __construct(
+        $entityId,
+        Organization $organizationEn = null,
+        Organization $organizationNl = null,
+        Organization $organizationPt = null,
+        Service $singleLogoutService = null,
+        $additionalLogging = false,
+        array $certificates = array(),
+        array $contactPersons = array(),
+        $descriptionEn = '',
+        $descriptionNl = '',
+        $descriptionPt = '',
+        $disableScoping = false,
+        $displayNameEn = '',
+        $displayNameNl = '',
+        $displayNamePt = '',
+        $keywordsEn = '',
+        $keywordsNl = '',
+        $keywordsPt = '',
+        Logo $logo = null,
+        $nameEn = '',
+        $nameNl = '',
+        $namePt = '',
+        $nameIdFormat = null,
+        $supportedNameIdFormats = array(
+            Constants::NAMEID_TRANSIENT,
+            Constants::NAMEID_PERSISTENT,
+        ),
+        $requestsMustBeSigned = false,
+        $signatureMethod = XMLSecurityKey::RSA_SHA256,
+        $workflowState = self::WORKFLOW_STATE_DEFAULT,
+        $manipulation = '',
+        $enabledInWayf = true,
+        $guestQualifier = self::GUEST_QUALIFIER_ALL,
+        $hidden = false,
+        $schacHomeOrganization = null,
+        $shibMdScopes = array(),
+        $singleSignOnServices = array(),
+        ConsentSettings $consentSettings = null,
+        StepupConnections $stepupConnections = null,
+        MfaEntityCollection $mfaEntities = null
+    ) {
+        parent::__construct(
+            $entityId,
+            $organizationEn,
+            $organizationNl,
+            $organizationPt,
+            $singleLogoutService,
+            $certificates,
+            $contactPersons,
+            $descriptionEn,
+            $descriptionNl,
+            $descriptionPt,
+            $displayNameEn,
+            $displayNameNl,
+            $displayNamePt,
+            $keywordsEn,
+            $keywordsNl,
+            $keywordsPt,
+            $logo,
+            $nameEn,
+            $nameNl,
+            $namePt,
+            $nameIdFormat,
+            $supportedNameIdFormats,
+            $requestsMustBeSigned,
+            $workflowState,
+            $manipulation
+        );
+
+        $this->enabledInWayf = $enabledInWayf;
+        $this->shibMdScopes = $shibMdScopes;
+        $this->singleSignOnServices = $singleSignOnServices;
+        $this->consentSettings = $consentSettings;
+
+        $this->coins = Coins::createForIdentityProvider(
+            $guestQualifier,
+            $schacHomeOrganization,
+            $hidden,
+            $stepupConnections,
+            $disableScoping,
+            $additionalLogging,
+            $signatureMethod,
+            $mfaEntities
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function accept(VisitorInterface $visitor)
+    {
+        $visitor->visitIdentityProvider($this);
+    }
+
+    /**
+     * @param string $preferredLocale
+     * @return string
+     */
+    public function getDisplayName($preferredLocale = '')
+    {
+        $idpName = '';
+        if ($preferredLocale === 'nl') {
+            $idpName = $this->nameNl;
+        } elseif ($preferredLocale === 'en') {
+            $idpName = $this->nameEn;
+        } elseif ($preferredLocale === 'pt') {
+            $idpName = $this->namePt;
+        }
+        if (empty($idpName)) {
+            $idpName = $this->entityId;
+        }
+        return $idpName;
+    }
+
+    /**
+     * @param ConsentSettings $settings
+     * @return IdentityProvider
+     */
+    public function setConsentSettings(ConsentSettings $settings)
+    {
+        $this->consentSettings = $settings;
+
+        return $this;
+    }
+
+    /**
+     * @return ConsentSettings
+     */
+    public function getConsentSettings()
+    {
+        if (!$this->consentSettings instanceof ConsentSettings) {
+            $this->setConsentSettings(
+                new ConsentSettings(
+                    (array)$this->consentSettings
+                )
+            );
+        }
+
+        return $this->consentSettings;
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProviderEb6.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProviderEb6.php
@@ -1,0 +1,409 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use OpenConext\EngineBlock\Metadata\Factory\ServiceProviderEntityInterface;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\Visitor\VisitorInterface;
+use OpenConext\EngineBlock\Metadata\Organization;
+use OpenConext\EngineBlock\Metadata\RequestedAttribute;
+use OpenConext\EngineBlock\Metadata\IndexedService;
+use OpenConext\EngineBlock\Metadata\Service;
+use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Constants;
+
+/**
+ * This class has been added to temporary push to both sso_provider_roles_eb5
+ * and sso_provider_roles_eb6
+ *
+ * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+ *
+ * @package OpenConext\EngineBlock\Metadata\Entity
+ * @ORM\Entity
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ *
+ * WARNING: Please don't use this entity directly but use the dedicated factory instead.
+ * @see \OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory
+ */
+class ServiceProviderEb6 extends AbstractRoleEb6
+{
+    /**
+     * @var null|AttributeReleasePolicy
+     *
+     * @ORM\Column(name="attribute_release_policy", type="engineblock_attribute_release_policy", nullable=true)
+     */
+    public $attributeReleasePolicy;
+
+    /**
+     * @var IndexedService[]
+     *
+     * @ORM\Column(name="assertion_consumer_services", type="engineblock_indexed_service_array")
+     */
+    public $assertionConsumerServices;
+
+    /**
+     * @var null|string[]
+     *
+     * @ORM\Column(name="allowed_idp_entity_ids", type="json", nullable=true)
+     */
+    public $allowedIdpEntityIds;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="allow_all", type="boolean")
+     */
+    public $allowAll;
+
+    /**
+     * @var null|RequestedAttribute[]
+     *
+     * @ORM\Column(name="requested_attributes", type="engineblock_requested_attribute_array", nullable=true)
+     */
+    public $requestedAttributes;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="support_url_en", type="string", nullable=true)
+     */
+    public $supportUrlEn;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="support_url_nl", type="string", nullable=true)
+     */
+    public $supportUrlNl;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="support_url_pt", type="string", nullable=true)
+     */
+    public $supportUrlPt;
+
+    /**
+     * WARNING: Please don't use this entity directly but use the dedicated factory instead.
+     * @see \OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory
+     *
+     * @param string $entityId
+     * @param Organization $organizationEn
+     * @param Organization $organizationNl
+     * @param Organization $organizationPt
+     * @param Service $singleLogoutService
+     * @param bool $additionalLogging
+     * @param X509Certificate[] $certificates
+     * @param ContactPerson[] $contactPersons
+     * @param string $descriptionEn
+     * @param string $descriptionNl
+     * @param string $descriptionPt
+     * @param bool $disableScoping
+     * @param string $displayNameEn
+     * @param string $displayNameNl
+     * @param string $displayNamePt
+     * @param string $keywordsEn
+     * @param string $keywordsNl
+     * @param string $keywordsPt
+     * @param Logo $logo
+     * @param string $nameEn
+     * @param string $nameNl
+     * @param string $namePt
+     * @param null $nameIdFormat
+     * @param array $supportedNameIdFormats
+     * @param bool $requestsMustBeSigned
+     * @param string $signatureMethod
+     * @param string $workflowState
+     * @param array $allowedIdpEntityIds
+     * @param bool $allowAll
+     * @param array $assertionConsumerServices
+     * @param bool $displayUnconnectedIdpsWayf
+     * @param null $termsOfServiceUrl
+     * @param bool $isConsentRequired
+     * @param bool $isTransparentIssuer
+     * @param bool $isTrustedProxy
+     * @param null $requestedAttributes
+     * @param bool $skipDenormalization
+     * @param bool $policyEnforcementDecisionRequired
+     * @param bool $requesteridRequired
+     * @param bool $signResponse
+     * @param string $manipulation
+     * @param AttributeReleasePolicy $attributeReleasePolicy
+     * @param string|null $supportUrlEn
+     * @param string|null $supportUrlNl
+     * @param string|null $supportUrlPt
+     * @param bool|null $stepupAllowNoToken
+     * @param bool|null $stepupRequireLoa
+     */
+    public function __construct(
+        $entityId,
+        Organization $organizationEn = null,
+        Organization $organizationNl = null,
+        Organization $organizationPt = null,
+        Service $singleLogoutService = null,
+        $additionalLogging = false,
+        array $certificates = array(),
+        array $contactPersons = array(),
+        $descriptionEn = '',
+        $descriptionNl = '',
+        $descriptionPt = '',
+        $disableScoping = false,
+        $displayNameEn = '',
+        $displayNameNl = '',
+        $displayNamePt = '',
+        $keywordsEn = '',
+        $keywordsNl = '',
+        $keywordsPt = '',
+        Logo $logo = null,
+        $nameEn = '',
+        $nameNl = '',
+        $namePt = '',
+        $nameIdFormat = null,
+        $supportedNameIdFormats = array(
+            Constants::NAMEID_TRANSIENT,
+            Constants::NAMEID_PERSISTENT,
+        ),
+        $requestsMustBeSigned = false,
+        $signatureMethod = XMLSecurityKey::RSA_SHA256,
+        $workflowState = self::WORKFLOW_STATE_DEFAULT,
+        array $allowedIdpEntityIds = array(),
+        $allowAll = false,
+        array $assertionConsumerServices = array(),
+        $displayUnconnectedIdpsWayf = false,
+        $termsOfServiceUrl = null,
+        $isConsentRequired = true,
+        $isTransparentIssuer = false,
+        $isTrustedProxy = false,
+        $requestedAttributes = null,
+        $skipDenormalization = false,
+        $policyEnforcementDecisionRequired = false,
+        $requesteridRequired = false,
+        $signResponse = false,
+        $manipulation = '',
+        AttributeReleasePolicy $attributeReleasePolicy = null,
+        $supportUrlEn = null,
+        $supportUrlNl = null,
+        $supportUrlPt = null,
+        $stepupAllowNoToken = null,
+        $stepupRequireLoa = null
+    ) {
+        parent::__construct(
+            $entityId,
+            $organizationEn,
+            $organizationNl,
+            $organizationPt,
+            $singleLogoutService,
+            $certificates,
+            $contactPersons,
+            $descriptionEn,
+            $descriptionNl,
+            $descriptionPt,
+            $displayNameEn,
+            $displayNameNl,
+            $displayNamePt,
+            $keywordsEn,
+            $keywordsNl,
+            $keywordsPt,
+            $logo,
+            $nameEn,
+            $nameNl,
+            $namePt,
+            $nameIdFormat,
+            $supportedNameIdFormats,
+            $requestsMustBeSigned,
+            $workflowState,
+            $manipulation
+        );
+
+        $this->attributeReleasePolicy = $attributeReleasePolicy;
+        $this->allowedIdpEntityIds = $allowedIdpEntityIds;
+        $this->allowAll = $allowAll;
+        $this->assertionConsumerServices = $assertionConsumerServices;
+        $this->requestedAttributes = $requestedAttributes;
+        $this->supportUrlEn = $supportUrlEn;
+        $this->supportUrlNl = $supportUrlNl;
+        $this->supportUrlPt = $supportUrlPt;
+
+        $this->coins = Coins::createForServiceProvider(
+            $isConsentRequired,
+            $isTransparentIssuer,
+            $isTrustedProxy,
+            $displayUnconnectedIdpsWayf,
+            $termsOfServiceUrl,
+            $skipDenormalization,
+            $policyEnforcementDecisionRequired,
+            $requesteridRequired,
+            $signResponse,
+            $stepupAllowNoToken,
+            $stepupRequireLoa,
+            $disableScoping,
+            $additionalLogging,
+            $signatureMethod
+        );
+    }
+
+    /**
+     * This is a factory method to convert the immutable ServiceProviderEntityInterface to the legacy domain entity.
+     *
+     * @param ServiceProviderEntityInterface $serviceProvider
+     * @return ServiceProvider
+     */
+    public static function fromServiceProviderEntity(ServiceProviderEntityInterface $serviceProvider): ServiceProvider
+    {
+        $entity = new self($serviceProvider->getEntityId());
+        $entity->id = $serviceProvider->getId();
+        $entity->entityId = $serviceProvider->getEntityId();
+        $entity->nameNl = $serviceProvider->getName('nl');
+        $entity->nameEn = $serviceProvider->getName('en');
+        $entity->namePt = $serviceProvider->getName('pt');
+        $entity->descriptionNl = $serviceProvider->getDescription('nl');
+        $entity->descriptionEn = $serviceProvider->getDescription('en');
+        $entity->descriptionPt = $serviceProvider->getDescription('pt');
+        $entity->displayNameNl = $serviceProvider->getDisplayName('nl');
+        $entity->displayNameEn = $serviceProvider->getDisplayName('en');
+        $entity->displayNamePt = $serviceProvider->getDisplayName('pt');
+        $entity->logo = $serviceProvider->getLogo();
+        $entity->organizationNl = $serviceProvider->getOrganization('nl');
+        $entity->organizationEn = $serviceProvider->getOrganization('en');
+        $entity->organizationPt = $serviceProvider->getOrganization('pt');
+        $entity->keywordsNl = $serviceProvider->getKeywords('nl');
+        $entity->keywordsEn = $serviceProvider->getKeywords('en');
+        $entity->keywordsPt = $serviceProvider->getKeywords('pt');
+        $entity->certificates = $serviceProvider->getCertificates();
+        $entity->workflowState = $serviceProvider->getWorkflowState();
+        $entity->contactPersons = $serviceProvider->getContactPersons();
+        $entity->nameIdFormat = $serviceProvider->getNameIdFormat();
+        $entity->supportedNameIdFormats = $serviceProvider->getSupportedNameIdFormats();
+        $entity->singleLogoutService = $serviceProvider->getSingleLogoutService();
+        $entity->requestsMustBeSigned = $serviceProvider->isRequestsMustBeSigned();
+        $entity->manipulation = $serviceProvider->getManipulation();
+        $entity->coins = $serviceProvider->getCoins();
+        $entity->attributeReleasePolicy = $serviceProvider->getAttributeReleasePolicy();
+        $entity->assertionConsumerServices = $serviceProvider->getAssertionConsumerServices();
+        $entity->allowedIdpEntityIds = $serviceProvider->getAllowedIdpEntityIds();
+        $entity->allowAll = $serviceProvider->isAllowAll();
+        $entity->requestedAttributes = $serviceProvider->getRequestedAttributes();
+        $entity->supportUrlNl = $serviceProvider->getSupportUrl('nl');
+        $entity->supportUrlEn = $serviceProvider->getSupportUrl('en');
+        $entity->supportUrlPt = $serviceProvider->getSupportUrl('pt');
+
+        return $entity;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function accept(VisitorInterface $visitor)
+    {
+        $visitor->visitServiceProvider($this);
+    }
+
+    /**
+     * @return null|AttributeReleasePolicy
+     */
+    public function getAttributeReleasePolicy()
+    {
+        return $this->attributeReleasePolicy;
+    }
+
+    /**
+     * @param string $idpEntityId
+     * @return bool
+     */
+    public function isAllowed($idpEntityId)
+    {
+        return $this->allowAll || in_array($idpEntityId, $this->allowedIdpEntityIds);
+    }
+
+    /**
+     * Algorithm for display name is:
+     * 1. Display name in preferred locale
+     * 2. Name in preferred locale
+     * 3. Display name in English
+     * 4. Name in English
+     * 5. EntityID (should never happen)
+     */
+    public function getDisplayName(string $preferredLocale = 'en'): string
+    {
+        $preferredName = 'displayName' . ucfirst($preferredLocale);
+        $fallback = 'name' . ucfirst($preferredLocale);
+        $spName = !empty($this->$preferredName) ? $this->$preferredName : $this->$fallback;
+
+        if ($preferredLocale !== 'en' & empty($spName)) {
+            $spName = !empty($this->displayNameEn) ? $this->displayNameEn : $this->nameEn;
+        }
+
+        if (empty($spName)) {
+            $spName = $this->entityId;
+        }
+
+        return $spName;
+    }
+
+    /**
+     * Algorithm for organization name is
+     * 1. Organization display name in preferred locale
+     * 2. Organization name in preferred locale
+     * 3. English organization display name
+     * 4. English organization name
+     * 5. Empty string (will be set to the locale-specific variant of 'unknown' in the template)
+     */
+    public function getOrganizationName(string $preferredLocale = 'en'): string
+    {
+        $orgLocale = 'organization' . ucfirst($preferredLocale);
+        // Load the preferred locale org. display name, falling back on org. name
+        $orgName = !empty($this->$orgLocale->displayName)
+            ? $this->$orgLocale->displayName
+            : $this->$orgLocale->name;
+
+        // Fallback to EN naming preferences when the preferred locale was not set or yielded no value
+        if (($preferredLocale !== 'en' && empty($orgName)) || empty($orgName)) {
+            $orgName = !empty($this->organizationEn->displayName) ? $this->organizationEn->displayName : $this->organizationEn->name;
+        }
+
+        // Show empty string when no translation was found (virtually impossible)
+        if (empty($orgName)) {
+            $orgName = '';
+        }
+
+        return $orgName;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAttributeAggregationRequired()
+    {
+        if (is_null($this->attributeReleasePolicy)) {
+            return false;
+        }
+
+        $rules = $this->attributeReleasePolicy->getRulesWithSourceSpecification();
+
+        return count($rules) > 0;
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/IndexedService.php
+++ b/src/OpenConext/EngineBlock/Metadata/IndexedService.php
@@ -49,4 +49,18 @@ class IndexedService extends Service
 
         parent::__construct($location, $binding);
     }
+
+    /**
+     * A convenience static constructor for the IndexedService.
+     * @param array $indexedService
+     * @return IndexedService
+     */
+    public static function indexedServiceFromArray(array $indexedService): IndexedService
+    {
+        return new self($indexedService["location"],
+            $indexedService["binding"],
+            $indexedService["serviceIndex"],
+            $indexedService["isDefault"]
+        );
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Logo.php
+++ b/src/OpenConext/EngineBlock/Metadata/Logo.php
@@ -24,15 +24,28 @@ namespace OpenConext\EngineBlock\Metadata;
  */
 class Logo
 {
-    public $height = null;
-    public $width = null;
-    public $url = null;
+    public $height;
+    public $width;
+    public $url;
 
     /**
      * @param string $url
      */
-    public function __construct($url)
+    public function __construct($url, $height = null, $width = null)
     {
         $this->url = $url;
+        $this->height = $height;
+        $this->width = $width;
+    }
+
+
+    /**
+     * A convenience static constructor for the Logo.
+     * @param array $logo
+     * @return Logo
+     */
+    public static function fromArray(array $logo): Logo
+    {
+        return new self($logo["url"], $logo["height"], $logo["width"]);
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/DoctrineMetadataPushRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/DoctrineMetadataPushRepository.php
@@ -25,9 +25,19 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProviderEb6;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProviderEb6;
 use RuntimeException;
 
+/**
+ * This class has added to temporary extra objects to push to both sso_provider_roles_eb5
+ * and sso_provider_roles_eb6
+ *
+ * TODO: Remove this suppression after sso_provider_roles_eb5 has been phased out
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class DoctrineMetadataPushRepository
 {
     /**
@@ -45,8 +55,35 @@ class DoctrineMetadataPushRepository
      */
     private $idpMetadata;
 
+    /**
+     * This field has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     *
+     * @var ClassMetadata
+     */
+    private $spMetadataUpdated;
+
+    /**
+     * This field has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     *
+     * @var ClassMetadata
+     */
+    private $idpMetadataUpdated;
 
     const ROLES_TABLE_NAME = 'sso_provider_roles_eb5';
+
+    /**
+     * This field has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
+    const ROLES_TABLE_NAME_EB6 = 'sso_provider_roles_eb6';
 
     const FIELD_VALUE = 0;
     const FIELD_TYPE = 1;
@@ -58,6 +95,15 @@ class DoctrineMetadataPushRepository
 
         $this->spMetadata = $entityManager->getClassMetadata(ServiceProvider::class);
         $this->idpMetadata = $entityManager->getClassMetadata(IdentityProvider::class);
+
+        /**
+         * This code below has been added to temporary push to both sso_provider_roles_eb5
+         * and sso_provider_roles_eb6
+         *
+         * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+         */
+        $this->spMetadataUpdated = $entityManager->getClassMetadata(ServiceProviderEb6::class);
+        $this->idpMetadataUpdated = $entityManager->getClassMetadata(IdentityProviderEb6::class);
     }
 
     /**
@@ -133,11 +179,25 @@ class DoctrineMetadataPushRepository
 
             if ($idpsToBeRemoved) {
                 $this->deleteRolesByIds(array_keys($idpsToBeRemoved), $this->idpMetadata);
+                /**
+                 * This call {deleteRolesByEntityId} has been added to temporary push to both sso_provider_roles_eb5
+                 * and sso_provider_roles_eb6
+                 *
+                 * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+                 */
+                $this->deleteRolesByEntityId(array_values($idpsToBeRemoved), $this->idpMetadata);
                 $result->removedIdentityProviders = array_values($idpsToBeRemoved);
             }
 
             if ($spsToBeRemoved) {
                 $this->deleteRolesByIds(array_keys($spsToBeRemoved), $this->spMetadata);
+                /**
+                 * This call {deleteRolesByEntityId} has been added to temporary push to both sso_provider_roles_eb5
+                 * and sso_provider_roles_eb6
+                 *
+                 * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+                 */
+                $this->deleteRolesByEntityId(array_values($spsToBeRemoved), $this->spMetadata);
                 $result->removedServiceProviders = array_values($spsToBeRemoved);
             }
         });
@@ -150,7 +210,21 @@ class DoctrineMetadataPushRepository
         $query = $this->connection->createQueryBuilder()
             ->insert(self::ROLES_TABLE_NAME);
 
-        $normalized = $this->addInsertQueryParameters($role, $query, $metadata);
+        $normalized = $this->addInsertQueryParameters($role, $query, $metadata, false);
+
+        $stmt = $this->connection->prepare($query->getSQL());
+        $this->bindParameters($normalized, $stmt);
+        $stmt->execute();
+
+        /**
+         * This code below has been added to temporary push to both sso_provider_roles_eb5 and sso_provider_roles_eb6
+         *
+         * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+         */
+        $query = $this->connection->createQueryBuilder()
+            ->insert(self::ROLES_TABLE_NAME_EB6);
+
+        $normalized = $this->addInsertQueryParameters($role, $query, $metadata, true);
 
         $stmt = $this->connection->prepare($query->getSQL());
         $this->bindParameters($normalized, $stmt);
@@ -162,7 +236,21 @@ class DoctrineMetadataPushRepository
         $query = $this->connection->createQueryBuilder()
             ->update(self::ROLES_TABLE_NAME);
 
-        $normalized = $this->addUpdateQueryParameters($role, $query, $metadata);
+        $normalized = $this->addUpdateQueryParameters($role, $query, $metadata, false);
+
+        $stmt = $this->connection->prepare($query->getSQL());
+        $this->bindParameters($normalized, $stmt);
+        $stmt->execute();
+
+        /**
+         * This code below has been added to temporary push to both sso_provider_roles_eb5 and sso_provider_roles_eb6
+         *
+         * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+         */
+        $query = $this->connection->createQueryBuilder()
+            ->update(self::ROLES_TABLE_NAME_EB6);
+
+        $normalized = $this->addUpdateQueryParameters($role, $query, $metadata, true);
 
         $stmt = $this->connection->prepare($query->getSQL());
         $this->bindParameters($normalized, $stmt);
@@ -182,6 +270,22 @@ class DoctrineMetadataPushRepository
         return $result;
     }
 
+    /**
+     * This function has been added to temporary push to both sso_provider_roles_eb5 and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
+    private function deleteRolesByEntityId(array $entityIds, ClassMetadata $metadata)
+    {
+        $query = $this->connection->createQueryBuilder()
+            ->delete(self::ROLES_TABLE_NAME_EB6)
+            ->where('entity_id IN (:entity_ids)')
+            ->setParameter('entity_ids', $entityIds, Connection::PARAM_STR_ARRAY);
+
+        $this->addDiscriminatorQuery($query, $metadata);
+        return $query->execute();
+    }
+
     private function findAllRoleEntityIds(ClassMetadata $metadata)
     {
         $query = $this->connection->createQueryBuilder()
@@ -198,18 +302,30 @@ class DoctrineMetadataPushRepository
         return $results;
     }
 
-    private function addInsertQueryParameters(AbstractRole $role, QueryBuilder $query, ClassMetadata $metadata)
+    /**
+     * The code {$isInsertForDuplicateTable} has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
+    private function addInsertQueryParameters(AbstractRole $role, QueryBuilder $query, ClassMetadata $metadata, bool $isInsertForDuplicateTable)
     {
-        $normalized = $this->normalizeData($role, $metadata);
+        $normalized = $this->normalizeData($role, $metadata, $isInsertForDuplicateTable);
         foreach (array_keys($normalized) as $id) {
             $query->setValue($id, ":$id");
         }
         return $normalized;
     }
 
-    private function addUpdateQueryParameters(AbstractRole $role, QueryBuilder $query, ClassMetadata $metadata)
+    /**
+     * The code {$isUpdateForDuplicateTable} has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
+    private function addUpdateQueryParameters(AbstractRole $role, QueryBuilder $query, ClassMetadata $metadata, bool $isUpdateForDuplicateTable)
     {
-        $normalized = $this->normalizeData($role, $metadata);
+        $normalized = $this->normalizeData($role, $metadata, $isUpdateForDuplicateTable);
         foreach (array_keys($normalized) as $id) {
             $query->set($id, ":$id");
         }
@@ -229,18 +345,48 @@ class DoctrineMetadataPushRepository
 
     private function addDiscriminatorQuery(QueryBuilder $queryBuilder, ClassMetadata $metadata)
     {
-        $queryBuilder->andWhere(sprintf('%s = :%s', $metadata->discriminatorColumn['fieldName'], $metadata->discriminatorColumn['name']))
-            ->setParameter($metadata->discriminatorColumn['name'], $metadata->discriminatorValue, $metadata->discriminatorColumn['type']);
+        $queryBuilder->andWhere(
+            sprintf('%s = :%s', $metadata->discriminatorColumn['fieldName'], $metadata->discriminatorColumn['name'])
+        )->setParameter(
+            $metadata->discriminatorColumn['name'],
+            $metadata->discriminatorValue,
+            $metadata->discriminatorColumn['type']
+        );
     }
 
-    private function normalizeData(AbstractRole $role, ClassMetadata $metadata)
+    private function normalizeData(AbstractRole $role, ClassMetadata $metadata, bool $isNormalizeForDuplicateTable)
     {
         $result = [];
-        foreach ($metadata->fieldMappings as $id => $columnInfo) {
-            $result[$columnInfo['columnName']] = [
-                self::FIELD_VALUE => $metadata->reflFields[$id]->getValue($role),
-                self::FIELD_TYPE => $columnInfo['type'],
-            ];
+        /**
+         * The code {$isNormalizeForDuplicateTable} has been added to temporary push to both sso_provider_roles_eb5
+         * and sso_provider_roles_eb6
+         *
+         * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+         */
+        if ($isNormalizeForDuplicateTable) {
+            if ($role instanceof IdentityProvider) {
+                foreach ($metadata->fieldMappings as $id => $columnInfo) {
+                    $result[$columnInfo['columnName']] = [
+                        self::FIELD_VALUE => $metadata->reflFields[$id]->getValue($role),
+                        self::FIELD_TYPE => $this->idpMetadataUpdated->fieldMappings[$id]['type'],
+                    ];
+                }
+            }
+            if ($role instanceof ServiceProvider) {
+                foreach ($metadata->fieldMappings as $id => $columnInfo) {
+                    $result[$columnInfo['columnName']] = [
+                        self::FIELD_VALUE => $metadata->reflFields[$id]->getValue($role),
+                        self::FIELD_TYPE => $this->spMetadataUpdated->fieldMappings[$id]['type'],
+                    ];
+                }
+            }
+        } else {
+            foreach ($metadata->fieldMappings as $id => $columnInfo) {
+                $result[$columnInfo['columnName']] = [
+                    self::FIELD_VALUE => $metadata->reflFields[$id]->getValue($role),
+                    self::FIELD_TYPE => $columnInfo['type'],
+                ];
+            }
         }
 
         // The primary id field is autogenerated and should not be added to the SQL statement.

--- a/src/OpenConext/EngineBlock/Metadata/Organization.php
+++ b/src/OpenConext/EngineBlock/Metadata/Organization.php
@@ -35,4 +35,14 @@ class Organization
         $this->name = $name;
         $this->url = $url;
     }
+
+    /**
+     * A convenience static constructor for the Organization.
+     * @param array $organization
+     * @return Organization
+     */
+    public static function fromArray(array $organization): Organization
+    {
+        return new self($organization["name"], $organization["displayName"], $organization["url"]);
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/RequestedAttribute.php
+++ b/src/OpenConext/EngineBlock/Metadata/RequestedAttribute.php
@@ -52,4 +52,14 @@ class RequestedAttribute
         $this->nameFormat = $nameFormat;
         $this->required = $isRequired;
     }
+
+    /**
+     * A convenience static constructor for the RequestedAttribute.
+     * @param array $requestedAttribute
+     * @return RequestedAttribute
+     */
+    public static function fromArray(array $requestedAttribute): RequestedAttribute
+    {
+        return new self($requestedAttribute["name"], $requestedAttribute["required"], $requestedAttribute["nameFormat"]);
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Service.php
+++ b/src/OpenConext/EngineBlock/Metadata/Service.php
@@ -43,4 +43,14 @@ class Service
         $this->binding  = $binding;
         $this->location = $location;
     }
+
+    /**
+     * A convenience static constructor for the Service.
+     * @param array $service
+     * @return Service
+     */
+    public static function fromArray(array $service): Service
+    {
+        return new self($service["location"], $service["binding"]);
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/ShibMdScope.php
+++ b/src/OpenConext/EngineBlock/Metadata/ShibMdScope.php
@@ -33,4 +33,25 @@ class ShibMdScope
      * @var string
      */
     public $regexp;
+
+    /**
+     * @param string|null $allowed
+     * @param string|null $regexp
+     */
+    public function __construct(string $allowed = null, string $regexp = null)
+    {
+        $this->allowed = $allowed;
+        $this->regexp = $regexp;
+    }
+
+
+    /**
+     * A convenience static constructor for the ShibMdScope.
+     * @param array $shibMdScope
+     * @return ShibMdScope
+     */
+    public static function fromArray(array $shibMdScope): ShibMdScope
+    {
+        return new self($shibMdScope["allowed"], $shibMdScope["regexp"]);
+    }
 }

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/AttributeReleasePolicyType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/AttributeReleasePolicyType.php
@@ -61,7 +61,17 @@ class AttributeReleasePolicyType extends Type
         }
 
         try {
-            $arp = new AttributeReleasePolicy(json_decode($value, true));
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $decoded,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            $arp = AttributeReleasePolicy::fromArray($decoded);
         } catch (InvalidArgumentException | TypeError $e) {
             // get nice standard message, so we can throw it keeping the exception chain
             throw ConversionException::conversionFailedFormat(

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/CertificateArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/CertificateArrayType.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\X509\X509CertificateFactory;
+use OpenConext\EngineBlock\Metadata\X509\X509CertificateLazyProxy;
+use TypeError;
+
+class CertificateArrayType extends Type
+{
+    const NAME = 'engineblock_certificate_array';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", "array"]
+            );
+        }
+
+        $certificates = [];
+        foreach ($value as $certificate) {
+            if (!$certificate instanceof X509CertificateLazyProxy) {
+                throw ConversionException::conversionFailedInvalidType(
+                    $certificate,
+                    $this->getName(),
+                    [X509CertificateLazyProxy::class]
+                );
+            }
+            array_push($certificates, $certificate->toCertData());
+        }
+
+        return json_encode($certificates);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $certificates = [];
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $decoded,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            foreach ($decoded as $metaData) {
+                array_push($certificates, new X509CertificateLazyProxy(new X509CertificateFactory(), $metaData));
+            }
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                X509CertificateLazyProxy::class
+            );
+        }
+
+        return $certificates;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/ContactPersonArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/ContactPersonArrayType.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+
+class ContactPersonArrayType extends Type
+{
+    const NAME = 'engineblock_contact_person_array';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", "array"]
+            );
+        }
+
+        foreach ($value as $contactPerson) {
+            if (!$contactPerson instanceof ContactPerson) {
+                throw ConversionException::conversionFailedInvalidType(
+                    $value,
+                    $this->getName(),
+                    [ContactPerson::class]
+                );
+            }
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $value,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            $contactPersons = [];
+            foreach ($decoded as $contactPerson) {
+                array_push($contactPersons, ContactPerson::from(
+                    $contactPerson["contactType"],
+                    $contactPerson["givenName"],
+                    $contactPerson["surName"],
+                    $contactPerson["emailAddress"],
+                    $contactPerson["telephoneNumber"]
+                ));
+            }
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                ContactPerson::class
+            );
+        }
+
+        return $contactPersons;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/ContactPersonArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/ContactPersonArrayType.php
@@ -85,13 +85,15 @@ class ContactPersonArrayType extends Type
 
             $contactPersons = [];
             foreach ($decoded as $contactPerson) {
-                array_push($contactPersons, ContactPerson::from(
-                    $contactPerson["contactType"],
-                    $contactPerson["givenName"],
-                    $contactPerson["surName"],
-                    $contactPerson["emailAddress"],
-                    $contactPerson["telephoneNumber"]
-                ));
+                if (!is_array($contactPerson)) {
+                    throw ConversionException::conversionFailedFormat(
+                        $contactPerson,
+                        $this->getName(),
+                        "array"
+                    );
+                }
+
+                array_push($contactPersons, ContactPerson::fromArray($contactPerson));
             }
         } catch (InvalidArgumentException $e) {
             throw ConversionException::conversionFailedFormat(

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/IndexedServiceArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/IndexedServiceArrayType.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\IndexedService;
+
+class IndexedServiceArrayType extends Type
+{
+    const NAME = 'engineblock_indexed_service_array';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", "array"]
+            );
+        }
+
+        foreach ($value as $indexService) {
+            if (!$indexService instanceof IndexedService) {
+                throw ConversionException::conversionFailedInvalidType(
+                    $value,
+                    $this->getName(),
+                    [IndexedService::class]
+                );
+            }
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $value,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            $indexedServices = [];
+            foreach ($decoded as $indexedService) {
+                array_push($indexedServices, new IndexedService(
+                    $indexedService["location"],
+                    $indexedService["binding"],
+                    $indexedService["serviceIndex"],
+                    $indexedService["isDefault"]
+                ));
+            }
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                IndexedService::class
+            );
+        }
+
+        return $indexedServices;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/IndexedServiceArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/IndexedServiceArrayType.php
@@ -85,12 +85,15 @@ class IndexedServiceArrayType extends Type
 
             $indexedServices = [];
             foreach ($decoded as $indexedService) {
-                array_push($indexedServices, new IndexedService(
-                    $indexedService["location"],
-                    $indexedService["binding"],
-                    $indexedService["serviceIndex"],
-                    $indexedService["isDefault"]
-                ));
+                if (!is_array($indexedService)) {
+                    throw ConversionException::conversionFailedFormat(
+                        $indexedService,
+                        $this->getName(),
+                        "array"
+                    );
+                }
+
+                array_push($indexedServices, IndexedService::indexedServiceFromArray($indexedService));
             }
         } catch (InvalidArgumentException $e) {
             throw ConversionException::conversionFailedFormat(

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/LogoType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/LogoType.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\Logo;
+
+class LogoType extends Type
+{
+    const NAME = 'engineblock_logo';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!$value instanceof Logo) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", Logo::class]
+            );
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Logo
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $value,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            $logo = new Logo($decoded["url"]);
+            $logo->height = $decoded["height"];
+            $logo->width = $decoded["width"];
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                Logo::class
+            );
+        }
+
+        return $logo;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/LogoType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/LogoType.php
@@ -73,9 +73,7 @@ class LogoType extends Type
                 );
             }
 
-            $logo = new Logo($decoded["url"]);
-            $logo->height = $decoded["height"];
-            $logo->width = $decoded["width"];
+            $logo = Logo::fromArray($decoded);
         } catch (InvalidArgumentException $e) {
             throw ConversionException::conversionFailedFormat(
                 $value,

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/OrganizationType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/OrganizationType.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\Organization;
+
+class OrganizationType extends Type
+{
+    const NAME = 'engineblock_organization';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!$value instanceof Organization) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", Organization::class]
+            );
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Organization
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $value,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            $organization = new Organization($decoded["name"], $decoded["displayName"], $decoded["url"]);
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                Organization::class
+            );
+        }
+
+        return $organization;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/OrganizationType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/OrganizationType.php
@@ -73,7 +73,7 @@ class OrganizationType extends Type
                 );
             }
 
-            $organization = new Organization($decoded["name"], $decoded["displayName"], $decoded["url"]);
+            $organization = Organization::fromArray($decoded);
         } catch (InvalidArgumentException $e) {
             throw ConversionException::conversionFailedFormat(
                 $value,

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/RequestedAttributeArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/RequestedAttributeArrayType.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\RequestedAttribute;
+
+class RequestedAttributeArrayType extends Type
+{
+    const NAME = 'engineblock_requested_attribute_array';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", "array"]
+            );
+        }
+
+        foreach ($value as $requestedAttribute) {
+            if (!$requestedAttribute instanceof RequestedAttribute) {
+                throw ConversionException::conversionFailedInvalidType(
+                    $value,
+                    $this->getName(),
+                    [RequestedAttribute::class]
+                );
+            }
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $value,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            $requestedAttributes = [];
+            foreach ($decoded as $requestedAttribute) {
+                array_push($requestedAttributes, new RequestedAttribute(
+                    $requestedAttribute["name"],
+                    $requestedAttribute["required"],
+                    $requestedAttribute["nameFormat"]
+                ));
+            }
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                RequestedAttribute::class
+            );
+        }
+
+        return $requestedAttributes;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/RequestedAttributeArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/RequestedAttributeArrayType.php
@@ -85,11 +85,15 @@ class RequestedAttributeArrayType extends Type
 
             $requestedAttributes = [];
             foreach ($decoded as $requestedAttribute) {
-                array_push($requestedAttributes, new RequestedAttribute(
-                    $requestedAttribute["name"],
-                    $requestedAttribute["required"],
-                    $requestedAttribute["nameFormat"]
-                ));
+                if (!is_array($requestedAttribute)) {
+                    throw ConversionException::conversionFailedFormat(
+                        $requestedAttribute,
+                        $this->getName(),
+                        "array"
+                    );
+                }
+
+                array_push($requestedAttributes, RequestedAttribute::fromArray($requestedAttribute));
             }
         } catch (InvalidArgumentException $e) {
             throw ConversionException::conversionFailedFormat(

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceArrayType.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\Service;
+
+class ServiceArrayType extends Type
+{
+    const NAME = 'engineblock_service_array';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", "array"]
+            );
+        }
+
+        foreach ($value as $service) {
+            if (!$service instanceof Service) {
+                throw ConversionException::conversionFailedInvalidType(
+                    $value,
+                    $this->getName(),
+                    [Service::class]
+                );
+            }
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $value,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            $services = [];
+            foreach ($decoded as $service) {
+                array_push($services, new Service(
+                    $service["location"],
+                    $service["binding"]
+                ));
+            }
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                Service::class
+            );
+        }
+
+        return $services;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceArrayType.php
@@ -85,10 +85,15 @@ class ServiceArrayType extends Type
 
             $services = [];
             foreach ($decoded as $service) {
-                array_push($services, new Service(
-                    $service["location"],
-                    $service["binding"]
-                ));
+                if (!is_array($service)) {
+                    throw ConversionException::conversionFailedFormat(
+                        $service,
+                        $this->getName(),
+                        "array"
+                    );
+                }
+
+                array_push($services, Service::fromArray($service));
             }
         } catch (InvalidArgumentException $e) {
             throw ConversionException::conversionFailedFormat(

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceType.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\Service;
+
+class ServiceType extends Type
+{
+    const NAME = 'engineblock_service';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!$value instanceof Service) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", Service::class]
+            );
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Service
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $value,
+                    $this->getName(),
+                    "array"
+                );
+            }
+            $service = new Service($decoded["location"], $decoded["binding"]);
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                Service::class
+            );
+        }
+
+        return $service;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceType.php
@@ -72,7 +72,7 @@ class ServiceType extends Type
                     "array"
                 );
             }
-            $service = new Service($decoded["location"], $decoded["binding"]);
+            $service = Service::fromArray($decoded);
         } catch (InvalidArgumentException $e) {
             throw ConversionException::conversionFailedFormat(
                 $value,

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/ShibMdScopeArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/ShibMdScopeArrayType.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use OpenConext\EngineBlock\Exception\InvalidArgumentException;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
+
+class ShibMdScopeArrayType extends Type
+{
+    const NAME = 'engineblock_shib_md_scope_array';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ConversionException::conversionFailedInvalidType(
+                $value,
+                $this->getName(),
+                ["null", "array"]
+            );
+        }
+
+        foreach ($value as $shibMdScope) {
+            if (!$shibMdScope instanceof ShibMdScope) {
+                throw ConversionException::conversionFailedInvalidType(
+                    $value,
+                    $this->getName(),
+                    [ShibMdScope::class]
+                );
+            }
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true);
+
+            if (!is_array($decoded)) {
+                throw ConversionException::conversionFailedFormat(
+                    $value,
+                    $this->getName(),
+                    "array"
+                );
+            }
+
+            $shibMdScopes = [];
+            foreach ($decoded as $shibMdScope) {
+                $result = new ShibMdScope();
+                $result->allowed = $shibMdScope["allowed"];
+                $result->regexp = $shibMdScope["regexp"];
+                array_push($shibMdScopes, $result);
+            }
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                ShibMdScope::class
+            );
+        }
+
+        return $shibMdScopes;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/ShibMdScopeArrayType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/ShibMdScopeArrayType.php
@@ -85,10 +85,15 @@ class ShibMdScopeArrayType extends Type
 
             $shibMdScopes = [];
             foreach ($decoded as $shibMdScope) {
-                $result = new ShibMdScope();
-                $result->allowed = $shibMdScope["allowed"];
-                $result->regexp = $shibMdScope["regexp"];
-                array_push($shibMdScopes, $result);
+                if (!is_array($shibMdScope)) {
+                    throw ConversionException::conversionFailedFormat(
+                        $shibMdScope,
+                        $this->getName(),
+                        "array"
+                    );
+                }
+
+                array_push($shibMdScopes, ShibMdScope::fromArray($shibMdScope));
             }
         } catch (InvalidArgumentException $e) {
             throw ConversionException::conversionFailedFormat(

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -116,6 +116,12 @@ class ServiceRegistryFixture
         $this->entityManager->flush();
     }
 
+    /**
+     * This call duplicate database call has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
     public function reset()
     {
         $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
@@ -123,14 +129,31 @@ class ServiceRegistryFixture
             ->delete('sso_provider_roles_eb5')
             ->execute();
 
+        $this->entityManager->getConnection()->createQueryBuilder()
+            ->delete('sso_provider_roles_eb6')
+            ->execute();
+
         return $this;
     }
 
+    /**
+     * This call duplicate database call has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
     public function remove($entityId, $role)
     {
         $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
         $queryBuilder
             ->delete('sso_provider_roles_eb5', 'roles')
+            ->where('roles.entity_id = :entityId')
+            ->andWhere('roles.type = :type')
+            ->setParameter('entityId', $entityId)
+            ->setParameter('type', $role)
+            ->execute();
+        $this->entityManager->getConnection()->createQueryBuilder()
+            ->delete('sso_provider_roles_eb6', 'roles')
             ->where('roles.entity_id = :entityId')
             ->andWhere('roles.type = :type')
             ->setParameter('entityId', $entityId)

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyControllerApiTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyControllerApiTest.php
@@ -478,11 +478,20 @@ class AttributeReleasePolicyControllerApiTest extends WebTestCase
         $em->flush();
     }
 
+    /**
+     * This call {->delete('sso_provider_roles_eb5')} has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
     private function clearMetadataFixtures()
     {
         $queryBuilder = $this->getContainer()->get('doctrine')->getConnection()->createQueryBuilder();
         $queryBuilder
             ->delete('sso_provider_roles_eb5')
+            ->execute();
+        $this->getContainer()->get('doctrine')->getConnection()->createQueryBuilder()
+            ->delete('sso_provider_roles_eb6')
             ->execute();
     }
 }

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
@@ -394,11 +394,20 @@ class ConnectionsControllerTest extends WebTestCase
         $client->getContainer()->set('engineblock.features', $featureToggles);
     }
 
+    /**
+     * This call {->delete('sso_provider_roles_eb5')} has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
     private function clearMetadataFixtures()
     {
         $queryBuilder = $this->getContainer()->get('doctrine')->getConnection()->createQueryBuilder();
         $queryBuilder
             ->delete('sso_provider_roles_eb5')
+            ->execute();
+        $this->getContainer()->get('doctrine')->getConnection()->createQueryBuilder()
+            ->delete('sso_provider_roles_eb6')
             ->execute();
     }
 

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
@@ -297,11 +297,20 @@ final class ConsentControllerTest extends WebTestCase
         $em->flush();
     }
 
+    /**
+     * This call {->delete('sso_provider_roles_eb5')} has been added to temporary push to both sso_provider_roles_eb5
+     * and sso_provider_roles_eb6
+     *
+     * TODO: Remove this code after sso_provider_roles_eb5 has been phased out
+     */
     private function clearMetadataFixtures()
     {
         $queryBuilder = $this->getContainer()->get('doctrine')->getConnection()->createQueryBuilder();
         $queryBuilder
             ->delete('sso_provider_roles_eb5')
+            ->execute();
+        $this->getContainer()->get('doctrine')->getConnection()->createQueryBuilder()
+            ->delete('sso_provider_roles_eb6')
             ->execute();
     }
 

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/AttributeReleasePolicyTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/AttributeReleasePolicyTypeTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use PHPUnit\Framework\TestCase;
+
+class AttributeReleasePolicyTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(AttributeReleasePolicyType::NAME)) {
+            Type::addType(AttributeReleasePolicyType::NAME, AttributeReleasePolicyType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $arpType = Type::getType(AttributeReleasePolicyType::NAME);
+
+        $value = $arpType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function attribute_release_policy_converted_to_json()
+    {
+        $arpType = Type::getType(AttributeReleasePolicyType::NAME);
+        $arp = array();
+        $arp["uid"] = ["value" => "*", "motiviation" => ""];
+        $arp["givenName"] = ["value" => "*", "motiviation" => ""];
+        $arp["attribute"] = ["value" => "*", "motiviation" => ""];
+        $attributeReleasePolicy = new AttributeReleasePolicy($arp);
+
+        $value = $arpType->convertToDatabaseValue($attributeReleasePolicy, $this->platform);
+
+        $this->assertEquals(json_encode($attributeReleasePolicy->getAttributeRules()), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $arpType = Type::getType(AttributeReleasePolicyType::NAME);
+
+        $value = $arpType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $arpType = Type::getType(AttributeReleasePolicyType::NAME);
+
+        $arp = array();
+        $arp["uid"] = ["value" => "*", "motiviation" => ""];
+        $arp["givenName"] = ["value" => "*", "motiviation" => ""];
+        $arp["attribute"] = ["value" => "*", "motiviation" => ""];
+        $attributeReleasePolicy = new AttributeReleasePolicy($arp);
+
+        $value = $arpType->convertToPHPValue($arpType->convertToDatabaseValue($attributeReleasePolicy, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($attributeReleasePolicy, $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $arpType = Type::getType(AttributeReleasePolicyType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $arpType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $arpType = Type::getType(AttributeReleasePolicyType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $arpType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/CertificateArrayTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/CertificateArrayTypeTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\X509\X509CertificateFactory;
+use OpenConext\EngineBlock\Metadata\X509\X509CertificateLazyProxy;
+use PHPUnit\Framework\TestCase;
+
+class CertificateArrayTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    private $certData = "MIIEJTCCAw2gAwIBAgIJANug+o++1X5IMA0GCSqGSIb3DQEBCwUAMIGoMQswCQYDVQQGEwJOTDEQMA4GA1UECAwHVXRyZWNodDEQMA4GA1UEBwwHVXRyZWNodDEVMBMGA1UECgwMU1VSRm5ldCBCLlYuMRMwEQYDVQQLDApTVVJGY29uZXh0MRwwGgYDVQQDDBNTVVJGbmV0IERldmVsb3BtZW50MSswKQYJKoZIhvcNAQkBFhxzdXJmY29uZXh0LWJlaGVlckBzdXJmbmV0Lm5sMB4XDTE0MTAyMDEyMzkxMVoXDTE0MTExOTEyMzkxMVowgagxCzAJBgNVBAYTAk5MMRAwDgYDVQQIDAdVdHJlY2h0MRAwDgYDVQQHDAdVdHJlY2h0MRUwEwYDVQQKDAxTVVJGbmV0IEIuVi4xEzARBgNVBAsMClNVUkZjb25leHQxHDAaBgNVBAMME1NVUkZuZXQgRGV2ZWxvcG1lbnQxKzApBgkqhkiG9w0BCQEWHHN1cmZjb25leHQtYmVoZWVyQHN1cmZuZXQubmwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDXuSSBeNJY3d4p060oNRSuAER5nLWT6AIVbv3XrXhcgSwc9m2b8u3ksp14pi8FbaNHAYW3MjlKgnLlopYIylzKD/6Ut/clEx67aO9Hpqsc0HmIP0It6q2bf5yUZ71E4CN2HtQceO5DsEYpe5M7D5i64kS2A7e2NYWVdA5Z01DqUpQGRBc+uMzOwyif6StBiMiLrZH3n2r5q5aVaXU4Vy5EE4VShv3Mp91sgXJj/v155fv0wShgl681v8yf2u2ZMb7NKnQRA4zM2Ng2EUAyy6PQ+Jbn+rALSm1YgiJdVuSlTLhvgwbiHGO2XgBi7bTHhlqSrJFK3Gs4zwIsop/XqQRBAgMBAAGjUDBOMB0GA1UdDgQWBBQCJmcoa/F7aM3jIFN7Bd4uzWRgzjAfBgNVHSMEGDAWgBQCJmcoa/F7aM3jIFN7Bd4uzWRgzjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBd80GpWKjp1J+Dgp0blVAox1s/WPWQlex9xrx1GEYbc5elp3svS+S82s7dFm2llHrrNOBt1HZVC+TdW4f+MR1xq8O5lOYjDRsosxZc/u9jVsYWYc3M9bQAx8VyJ8VGpcAK+fLqRNabYlqTnj/t9bzX8fS90sp8JsALV4g84Aj0G8RpYJokw+pJUmOpuxsZN5U84MmLPnVfmrnuCVh/HkiLNV2c8Pk8LSomg6q1M1dQUTsz/HVxcOhHLj/owwh3IzXf/KXV/E8vSYW8o4WWCAnruYOWdJMI4Z8NG1Mfv7zvb7U3FL1C/KLV04DqzALXGj+LVmxtDvuxqC042apoIDQV";
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(CertificateArrayType::NAME)) {
+            Type::addType(CertificateArrayType::NAME, CertificateArrayType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $certType = Type::getType(CertificateArrayType::NAME);
+
+        $value = $certType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function certificate_array_type_converted_to_json()
+    {
+        $certType = Type::getType(CertificateArrayType::NAME);
+        $certificateArray = [new X509CertificateLazyProxy(new X509CertificateFactory(), $this->certData)];
+
+        $value = $certType->convertToDatabaseValue($certificateArray, $this->platform);
+
+        $this->assertEquals(json_encode([$certificateArray[0]->toCertData()]), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $certType = Type::getType(CertificateArrayType::NAME);
+
+        $value = $certType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $certType = Type::getType(CertificateArrayType::NAME);
+
+        $certificateArray = [new X509CertificateLazyProxy(new X509CertificateFactory(), $this->certData)];
+
+        $value = $certType->convertToPHPValue($certType->convertToDatabaseValue($certificateArray, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($certificateArray[0]->toCertData(), $value[0]->toCertData());
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $certType = Type::getType(CertificateArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $certType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $certType = Type::getType(CertificateArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $certType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/ContactPersonArrayTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/ContactPersonArrayTypeTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\ContactPerson;
+use PHPUnit\Framework\TestCase;
+
+class ContactPersonArrayTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(ContactPersonArrayType::NAME)) {
+            Type::addType(ContactPersonArrayType::NAME, ContactPersonArrayType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $contactPersonType = Type::getType(ContactPersonArrayType::NAME);
+
+        $value = $contactPersonType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function contact_person_array_type_converted_to_json()
+    {
+        $contactPersonType = Type::getType(ContactPersonArrayType::NAME);
+        $contactPerson = [new ContactPerson("support")];
+        $contactPerson[0]->givenName = "givenName";
+        $contactPerson[0]->telephoneNumber = "telephoneNumber";
+        $contactPerson[0]->surName = "surName";
+        $contactPerson[0]->emailAddress = "emailAddress";
+
+        $value = $contactPersonType->convertToDatabaseValue($contactPerson, $this->platform);
+
+        $this->assertEquals(json_encode($contactPerson), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $contactPersonType = Type::getType(ContactPersonArrayType::NAME);
+
+        $value = $contactPersonType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $contactPersonType = Type::getType(ContactPersonArrayType::NAME);
+        $contactPerson = [new ContactPerson("support")];
+        $contactPerson[0]->givenName = "givenName";
+        $contactPerson[0]->telephoneNumber = "telephoneNumber";
+        $contactPerson[0]->surName = "surName";
+        $contactPerson[0]->emailAddress = "emailAddress";
+
+        $value = $contactPersonType->convertToPHPValue($contactPersonType->convertToDatabaseValue($contactPerson, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($contactPerson, $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $contactPersonType = Type::getType(ContactPersonArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $contactPersonType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $contactPersonType = Type::getType(ContactPersonArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $contactPersonType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/IndexedServiceArrayTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/IndexedServiceArrayTypeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\IndexedService;
+use PHPUnit\Framework\TestCase;
+
+class IndexedServiceArrayTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(IndexedServiceArrayType::NAME)) {
+            Type::addType(IndexedServiceArrayType::NAME, IndexedServiceArrayType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $indexedServiceArrayType = Type::getType(IndexedServiceArrayType::NAME);
+
+        $value = $indexedServiceArrayType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function indexed_service_array_type_converted_to_json()
+    {
+        $indexedServiceArrayType = Type::getType(IndexedServiceArrayType::NAME);
+        $serviceIndex = [new IndexedService("location", "binding", 0)];
+        $value = $indexedServiceArrayType->convertToDatabaseValue($serviceIndex, $this->platform);
+
+        $this->assertEquals(json_encode($serviceIndex), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $indexedServiceArrayType = Type::getType(IndexedServiceArrayType::NAME);
+
+        $value = $indexedServiceArrayType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $indexedServiceArrayType = Type::getType(IndexedServiceArrayType::NAME);
+        $serviceIndex = [new IndexedService("location", "binding", 0)];
+
+        $value = $indexedServiceArrayType->convertToPHPValue($indexedServiceArrayType->convertToDatabaseValue($serviceIndex, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($serviceIndex, $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $indexedServiceArrayType = Type::getType(IndexedServiceArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $indexedServiceArrayType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $indexedServiceArrayType = Type::getType(IndexedServiceArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $indexedServiceArrayType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/LogoTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/LogoTypeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Logo;
+use PHPUnit\Framework\TestCase;
+
+class LogoTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(LogoType::NAME)) {
+            Type::addType(LogoType::NAME, LogoType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $logoType = Type::getType(LogoType::NAME);
+
+        $value = $logoType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function logo_type_converted_to_json()
+    {
+        $logoType = Type::getType(LogoType::NAME);
+        $logo = new Logo("location");
+        $value = $logoType->convertToDatabaseValue($logo, $this->platform);
+
+        $this->assertEquals(json_encode($logo), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $logoType = Type::getType(LogoType::NAME);
+
+        $value = $logoType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $logoType = Type::getType(LogoType::NAME);
+        $logo = new Logo("location");
+
+        $value = $logoType->convertToPHPValue($logoType->convertToDatabaseValue($logo, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($logo, $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $logoType = Type::getType(LogoType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $logoType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $logoType = Type::getType(LogoType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $logoType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/OrganizationTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/OrganizationTypeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Organization;
+use PHPUnit\Framework\TestCase;
+
+class OrganizationTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(OrganizationType::NAME)) {
+            Type::addType(OrganizationType::NAME, OrganizationType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $organizationType = Type::getType(OrganizationType::NAME);
+
+        $value = $organizationType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function organization_type_converted_to_json()
+    {
+        $organizationType = Type::getType(OrganizationType::NAME);
+        $organization = new Organization("name", "displayName", "url");
+        $value = $organizationType->convertToDatabaseValue($organization, $this->platform);
+
+        $this->assertEquals(json_encode($organization), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $organizationType = Type::getType(OrganizationType::NAME);
+
+        $value = $organizationType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $organizationType = Type::getType(OrganizationType::NAME);
+        $organization = new Organization("name", "displayName", "url");
+
+        $value = $organizationType->convertToPHPValue($organizationType->convertToDatabaseValue($organization, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($organization, $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $organizationType = Type::getType(OrganizationType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $organizationType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $organizationType = Type::getType(OrganizationType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $organizationType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/RequestedAttributeArrayTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/RequestedAttributeArrayTypeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\RequestedAttribute;
+use PHPUnit\Framework\TestCase;
+
+class RequestedAttributeArrayTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(RequestedAttributeArrayType::NAME)) {
+            Type::addType(RequestedAttributeArrayType::NAME, RequestedAttributeArrayType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $requestedAttributeArrayType = Type::getType(RequestedAttributeArrayType::NAME);
+
+        $value = $requestedAttributeArrayType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function requested_attribute_array_type_converted_to_json()
+    {
+        $requestedAttributeArrayType = Type::getType(RequestedAttributeArrayType::NAME);
+        $requestedAttribute = [new RequestedAttribute("name")];
+        $value = $requestedAttributeArrayType->convertToDatabaseValue($requestedAttribute, $this->platform);
+
+        $this->assertEquals(json_encode($requestedAttribute), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $requestedAttributeArrayType = Type::getType(RequestedAttributeArrayType::NAME);
+
+        $value = $requestedAttributeArrayType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $requestedAttributeArrayType = Type::getType(RequestedAttributeArrayType::NAME);
+        $requestedAttribute = [new RequestedAttribute("name")];
+
+        $value = $requestedAttributeArrayType->convertToPHPValue($requestedAttributeArrayType->convertToDatabaseValue($requestedAttribute, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($requestedAttribute, $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $requestedAttributeArrayType = Type::getType(RequestedAttributeArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $requestedAttributeArrayType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $requestedAttributeArrayType = Type::getType(RequestedAttributeArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $requestedAttributeArrayType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceArrayTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceArrayTypeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Service;
+use PHPUnit\Framework\TestCase;
+
+class ServiceArrayTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(ServiceArrayType::NAME)) {
+            Type::addType(ServiceArrayType::NAME, ServiceArrayType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $serviceArrayType = Type::getType(ServiceArrayType::NAME);
+
+        $value = $serviceArrayType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function service_array_type_converted_to_json()
+    {
+        $serviceArrayType = Type::getType(ServiceArrayType::NAME);
+        $serviceArray = [new Service("location", "binding")];
+        $value = $serviceArrayType->convertToDatabaseValue($serviceArray, $this->platform);
+
+        $this->assertEquals(json_encode($serviceArray), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $serviceArrayType = Type::getType(ServiceArrayType::NAME);
+
+        $value = $serviceArrayType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $serviceArrayType = Type::getType(ServiceArrayType::NAME);
+        $serviceArray = [new Service("location", "binding")];
+
+        $value = $serviceArrayType->convertToPHPValue($serviceArrayType->convertToDatabaseValue($serviceArray, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($serviceArray, $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $serviceArrayType = Type::getType(ServiceArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $serviceArrayType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $serviceArrayType = Type::getType(ServiceArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $serviceArrayType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/ServiceTypeTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Service;
+use PHPUnit\Framework\TestCase;
+
+class ServiceTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(ServiceType::NAME)) {
+            Type::addType(ServiceType::NAME, ServiceType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $serviceType = Type::getType(ServiceType::NAME);
+
+        $value = $serviceType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function service_converted_to_json()
+    {
+        $serviceType = Type::getType(ServiceType::NAME);
+        $service = new Service("location", "binding");
+
+        $value = $serviceType->convertToDatabaseValue($service, $this->platform);
+
+        $this->assertEquals(json_encode($service), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $serviceType = Type::getType(ServiceType::NAME);
+
+        $value = $serviceType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $serviceType = Type::getType(ServiceType::NAME);
+        $serviceComplete = new Service("location", "binding");
+        $serviceLocation = new Service("location", null);
+        $serviceBinding = new Service(null, "binding");
+
+
+        $valueComplete = $serviceType->convertToPHPValue(
+            $serviceType->convertToDatabaseValue($serviceComplete, $this->platform),
+            $this->platform);
+        $valueLocation = $serviceType->convertToPHPValue(
+            $serviceType->convertToDatabaseValue($serviceLocation, $this->platform),
+            $this->platform);
+        $valueBinding = $serviceType->convertToPHPValue(
+            $serviceType->convertToDatabaseValue($serviceBinding, $this->platform),
+            $this->platform);
+
+
+        $this->assertEquals($serviceComplete, $valueComplete);
+        $this->assertEquals($serviceLocation, $valueLocation);
+        $this->assertEquals($serviceBinding, $valueBinding);
+        $this->assertNotEquals($valueBinding, $valueLocation);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $serviceType = Type::getType(ServiceType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $serviceType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $serviceType = Type::getType(ServiceType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $serviceType->convertToPHPValue(false, $this->platform);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/ShibMdScopeArrayTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/ShibMdScopeArrayTypeTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Copyright 2021 Stichting Kennisnet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\ShibMdScope;
+use PHPUnit\Framework\TestCase;
+
+class ShibMdScopeArrayTypeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     * @throws DBALException
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType(ShibMdScopeArrayType::NAME)) {
+            Type::addType(ShibMdScopeArrayType::NAME, ShibMdScopeArrayType::class);
+        }
+    }
+
+    public function setUp()
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_remains_null_in_to_sql_conversion()
+    {
+        $shibMdScopeArrayType = Type::getType(ShibMdScopeArrayType::NAME);
+
+        $value = $shibMdScopeArrayType->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function shib_md_scope_array_type_converted_to_json()
+    {
+        $shibMdScopeArrayType = Type::getType(ShibMdScopeArrayType::NAME);
+        $shibMdScopeArray = [new ShibMdScope()];
+        $shibMdScopeArray[0]->regexp = true;
+        $shibMdScopeArray[0]->allowed = "query";
+
+        $value = $shibMdScopeArrayType->convertToDatabaseValue($shibMdScopeArray, $this->platform);
+
+        $this->assertEquals(json_encode($shibMdScopeArray), $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function a_null_value_is_converted_to_null()
+    {
+        $shibMdScopeArrayType = Type::getType(ShibMdScopeArrayType::NAME);
+
+        $value = $shibMdScopeArrayType->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function saved_object_equals_result()
+    {
+        $shibMdScopeArrayType = Type::getType(ShibMdScopeArrayType::NAME);
+        $shibMdScopeArray = [new ShibMdScope()];
+        $shibMdScopeArray[0]->regexp = true;
+        $shibMdScopeArray[0]->allowed = "query";
+
+        $value = $shibMdScopeArrayType->convertToPHPValue($shibMdScopeArrayType->convertToDatabaseValue($shibMdScopeArray, $this->platform),
+            $this->platform);
+
+        $this->assertEquals($shibMdScopeArray, $value);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_php_value_causes_an_exception_upon_conversion()
+    {
+        $shibMdScopeArrayType = Type::getType(ShibMdScopeArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $shibMdScopeArrayType->convertToDatabaseValue(false, $this->platform);
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBundle
+     * @group Doctrine
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion()
+    {
+        $shibMdScopeArrayType = Type::getType(ShibMdScopeArrayType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $shibMdScopeArrayType->convertToPHPValue(false, $this->platform);
+    }
+}


### PR DESCRIPTION
Instead of the generic types “array” and “object” we have created custom Doctrine types that will handle the conversion to and from database value and PHP value. With implementing this change the database is more adaptable to possible changes, is more readable and it is usable by other languages than PHP. 

In the current pull request we have only adjusted on how these types are saved and read from the base, there have been no functional changes. 

Work that remains to clean the database further contains the following items:
- X509CertificateLazyProxy should not take factory from the constructor, but should rather create its own factory when initialized. 
- Organization names (nl / en / pt) should not be default be created without any values. Currently the database contains many ‘{"name":null,"displayName":null,"url":null}’ values, these should be replaced with null values
- allowed_idp_entity_ids should be of type string[] as defined. Currently the object is saved as both array and dictionary.

**This pull request requires a migration of the database. Since values are stored and retrieved in a different manner, the table _sso_providers_roles_eb5_ needs to be emptied and filled with new values (Aka push from Manage).**

_Take special note to column ‘logo’ in table ‘sso_providers_roles_eb5’ since ‘nullable=true’ was missing from the declaration in abstract.php it is likely that the column contains a NOT NULL constraint. This needs to be removed._

 