### PR TITLE
Support removal of consent by collab person id and SP entity id

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -17,6 +17,7 @@ open_conext_engine_block:
     features:
         api.metadata_push:   "%feature_api_metadata_push%"
         api.consent_listing: "%feature_api_consent_listing%"
+        api.consent_remove: "%feature_api_consent_remove%"
         api.metadata_api:    "%feature_api_metadata_api%"
         api.deprovision:     "%feature_api_deprovision%"
         eb.encrypted_assertions: "%feature_eb_encrypted_assertions%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -212,6 +212,7 @@ parameters:
     feature_eb_encrypted_assertions_require_outer_signature: true
     feature_api_metadata_push: true
     feature_api_consent_listing: true
+    feature_api_consent_remove: true
     feature_api_metadata_api: true
     feature_api_deprovision: true
     feature_run_all_manipulations_prior_to_consent: false

--- a/database/DoctrineMigrations/Version20220425090852.php
+++ b/database/DoctrineMigrations/Version20220425090852.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220425090852 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE consent DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE consent ADD deleted_at DATETIME NOT NULL');
+        $this->addSql('CREATE INDEX deleted_at ON consent (deleted_at)');
+        $this->addSql('ALTER TABLE consent ADD PRIMARY KEY (hashed_user_id, service_id, deleted_at)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX deleted_at ON consent');
+        $this->addSql('ALTER TABLE consent DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE consent DROP deleted_at');
+        $this->addSql('ALTER TABLE consent ADD PRIMARY KEY (hashed_user_id, service_id)');
+    }
+}

--- a/library/EngineBlock/Corto/Model/Consent.php
+++ b/library/EngineBlock/Corto/Model/Consent.php
@@ -149,8 +149,8 @@ class EngineBlock_Corto_Model_Consent
             return false;
         }
 
-        $query = "INSERT INTO consent (hashed_user_id, service_id, attribute, consent_type, consent_date)
-                  VALUES (?, ?, ?, ?, NOW())
+        $query = "INSERT INTO consent (hashed_user_id, service_id, attribute, consent_type, consent_date, deleted_at)
+                  VALUES (?, ?, ?, ?, NOW(), '0000-00-00 00:00:00')
                   ON DUPLICATE KEY UPDATE attribute=VALUES(attribute), consent_type=VALUES(consent_type), consent_date=NOW()";
         $parameters = array(
             sha1($this->_getConsentUid()),
@@ -174,7 +174,6 @@ class EngineBlock_Corto_Model_Consent
                 EngineBlock_Exception::CODE_CRITICAL
             );
         }
-
         return true;
     }
 
@@ -188,7 +187,15 @@ class EngineBlock_Corto_Model_Consent
 
             $attributesHash = $this->_getAttributesHash($this->_responseAttributes);
 
-            $query = "SELECT * FROM {$this->_tableName} WHERE hashed_user_id = ? AND service_id = ? AND attribute = ? AND consent_type = ?";
+            $query = "
+                SELECT *
+                FROM {$this->_tableName}
+                WHERE hashed_user_id = ?
+                  AND service_id = ?
+                  AND attribute = ?
+                  AND consent_type = ?
+                  AND ISNULL(deleted_at)
+            ";
             $hashedUserId = sha1($this->_getConsentUid());
             $parameters = array(
                 $hashedUserId,

--- a/library/EngineBlock/Corto/Model/Consent.php
+++ b/library/EngineBlock/Corto/Model/Consent.php
@@ -194,7 +194,7 @@ class EngineBlock_Corto_Model_Consent
                   AND service_id = ?
                   AND attribute = ?
                   AND consent_type = ?
-                  AND ISNULL(deleted_at)
+                  AND deleted_at IS NULL
             ";
             $hashedUserId = sha1($this->_getConsentUid());
             $parameters = array(

--- a/library/EngineBlock/User.php
+++ b/library/EngineBlock/User.php
@@ -59,7 +59,8 @@ class EngineBlock_User
     {
         $pdo = $this->_getDatabaseConnection();
         $query = 'SELECT service_id FROM consent
-                    WHERE hashed_user_id = ?';
+                    WHERE hashed_user_id = ?
+                    AND ISNULL(deleted_at)';
         $parameters = array(
             sha1($this->getUid())
         );

--- a/library/EngineBlock/User.php
+++ b/library/EngineBlock/User.php
@@ -60,7 +60,7 @@ class EngineBlock_User
         $pdo = $this->_getDatabaseConnection();
         $query = 'SELECT service_id FROM consent
                     WHERE hashed_user_id = ?
-                    AND ISNULL(deleted_at)';
+                    AND deleted_at IS NULL';
         $parameters = array(
             sha1($this->getUid())
         );

--- a/src/OpenConext/EngineBlock/Authentication/Repository/ConsentRepository.php
+++ b/src/OpenConext/EngineBlock/Authentication/Repository/ConsentRepository.php
@@ -35,4 +35,6 @@ interface ConsentRepository
      * @return Consent[]
      */
     public function deleteAllFor($userId);
+
+    public function deleteOneFor(string $userId, string $serviceProviderEntityId): bool;
 }

--- a/src/OpenConext/EngineBlock/Service/ConsentService.php
+++ b/src/OpenConext/EngineBlock/Service/ConsentService.php
@@ -96,11 +96,16 @@ final class ConsentService implements ConsentServiceInterface
 
     public function deleteOneConsentFor(CollabPersonId $id, string $serviceProviderEntityId): bool
     {
+        $collabPersonId = $id->getCollabPersonId();
         try {
-            return $this->consentRepository->deleteOneFor($id->getCollabPersonId(), $serviceProviderEntityId);
+            return $this->consentRepository->deleteOneFor($collabPersonId, $serviceProviderEntityId);
         } catch (Exception $e) {
             throw new RuntimeException(
-                sprintf('An exception occurred while removing consent for a service provider("%s")', $e->getMessage()),
+                sprintf(
+                    'An exception occurred while removing consent for a service provider("%s") and user ("%s").',
+                    $serviceProviderEntityId,
+                    $collabPersonId
+                ),
                 0,
                 $e
             );

--- a/src/OpenConext/EngineBlock/Service/ConsentService.php
+++ b/src/OpenConext/EngineBlock/Service/ConsentService.php
@@ -23,9 +23,11 @@ use OpenConext\EngineBlock\Authentication\Dto\Consent;
 use OpenConext\EngineBlock\Authentication\Dto\ConsentList;
 use OpenConext\EngineBlock\Authentication\Model\Consent as ConsentEntity;
 use OpenConext\EngineBlock\Authentication\Repository\ConsentRepository;
+use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
 use OpenConext\EngineBlock\Exception\RuntimeException;
 use OpenConext\Value\Saml\EntityId;
 use Psr\Log\LoggerInterface;
+use function sprintf;
 
 final class ConsentService implements ConsentServiceInterface
 {
@@ -90,6 +92,19 @@ final class ConsentService implements ConsentServiceInterface
         }
 
         return count($consents);
+    }
+
+    public function deleteOneConsentFor(CollabPersonId $id, string $serviceProviderEntityId): bool
+    {
+        try {
+            return $this->consentRepository->deleteOneFor($id->getCollabPersonId(), $serviceProviderEntityId);
+        } catch (Exception $e) {
+            throw new RuntimeException(
+                sprintf('An exception occurred while removing consent for a service provider("%s")', $e->getMessage()),
+                0,
+                $e
+            );
+        }
     }
 
     /**

--- a/src/OpenConext/EngineBlock/Service/ConsentService.php
+++ b/src/OpenConext/EngineBlock/Service/ConsentService.php
@@ -48,7 +48,7 @@ final class ConsentService implements ConsentServiceInterface
 
     public function __construct(
         ConsentRepository $consentRepository,
-        MetadataService $metadataService,
+        MetadataServiceInterface $metadataService,
         LoggerInterface $logger
     ) {
         $this->consentRepository = $consentRepository;

--- a/src/OpenConext/EngineBlock/Service/ConsentServiceInterface.php
+++ b/src/OpenConext/EngineBlock/Service/ConsentServiceInterface.php
@@ -19,6 +19,7 @@
 namespace OpenConext\EngineBlock\Service;
 
 use OpenConext\EngineBlock\Authentication\Dto\ConsentList;
+use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
 
 interface ConsentServiceInterface
 {
@@ -33,4 +34,6 @@ interface ConsentServiceInterface
      * @return int
      */
     public function countAllFor($userId);
+
+    public function deleteOneConsentFor(CollabPersonId $id, string $serviceProviderEntityId): bool;
 }

--- a/src/OpenConext/EngineBlock/Service/DeprovisionService.php
+++ b/src/OpenConext/EngineBlock/Service/DeprovisionService.php
@@ -18,12 +18,15 @@
 
 namespace OpenConext\EngineBlock\Service;
 
+use Exception;
 use OpenConext\EngineBlock\Authentication\Model\User;
 use OpenConext\EngineBlock\Authentication\Repository\ConsentRepository;
 use OpenConext\EngineBlock\Authentication\Repository\UserDirectory;
 use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
+use OpenConext\EngineBlock\Exception\RuntimeException;
 use OpenConext\EngineBlockBundle\Authentication\Repository\SamlPersistentIdRepository;
 use OpenConext\EngineBlockBundle\Authentication\Repository\ServiceProviderUuidRepository;
+use function sprintf;
 
 final class DeprovisionService implements DeprovisionServiceInterface
 {
@@ -138,6 +141,20 @@ final class DeprovisionService implements DeprovisionServiceInterface
         if ($user) {
             $this->deleteSamlPersistentId($user);
             $this->deleteUser($user);
+        }
+    }
+
+
+    public function deleteOneConsentFor(CollabPersonId $id, string $serviceProviderEntityId): bool
+    {
+        try {
+            return $this->consentRepository->deleteOneFor($id->getCollabPersonId(), $serviceProviderEntityId);
+        } catch (Exception $e) {
+            throw new RuntimeException(
+                sprintf('An exception occurred while removing consent for a service provider("%s")', $e->getMessage()),
+                0,
+                $e
+            );
         }
     }
 

--- a/src/OpenConext/EngineBlock/Service/DeprovisionService.php
+++ b/src/OpenConext/EngineBlock/Service/DeprovisionService.php
@@ -144,20 +144,6 @@ final class DeprovisionService implements DeprovisionServiceInterface
         }
     }
 
-
-    public function deleteOneConsentFor(CollabPersonId $id, string $serviceProviderEntityId): bool
-    {
-        try {
-            return $this->consentRepository->deleteOneFor($id->getCollabPersonId(), $serviceProviderEntityId);
-        } catch (Exception $e) {
-            throw new RuntimeException(
-                sprintf('An exception occurred while removing consent for a service provider("%s")', $e->getMessage()),
-                0,
-                $e
-            );
-        }
-    }
-
     /**
      * @param CollabPersonId $id
      */

--- a/src/OpenConext/EngineBlock/Service/DeprovisionServiceInterface.php
+++ b/src/OpenConext/EngineBlock/Service/DeprovisionServiceInterface.php
@@ -32,4 +32,6 @@ interface DeprovisionServiceInterface
      * @param CollabPersonId $id
      */
     public function delete(CollabPersonId $id);
+
+    public function deleteOneConsentFor(CollabPersonId $id, string $serviceProviderEntityId): bool;
 }

--- a/src/OpenConext/EngineBlock/Service/DeprovisionServiceInterface.php
+++ b/src/OpenConext/EngineBlock/Service/DeprovisionServiceInterface.php
@@ -32,6 +32,4 @@ interface DeprovisionServiceInterface
      * @param CollabPersonId $id
      */
     public function delete(CollabPersonId $id);
-
-    public function deleteOneConsentFor(CollabPersonId $id, string $serviceProviderEntityId): bool;
 }

--- a/src/OpenConext/EngineBlock/Service/MetadataService.php
+++ b/src/OpenConext/EngineBlock/Service/MetadataService.php
@@ -25,7 +25,7 @@ use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\Value\Saml\EntityId;
 
-final class MetadataService
+final class MetadataService implements MetadataServiceInterface
 {
     /**
      * @var MetadataRepositoryInterface
@@ -37,11 +37,7 @@ final class MetadataService
         $this->metadataRepository = $metadataRepository;
     }
 
-    /**
-     * @param EntityId $entityId
-     * @return null|IdentityProvider
-     */
-    public function findIdentityProvider(EntityId $entityId)
+    public function findIdentityProvider(EntityId $entityId): ?IdentityProvider
     {
         try {
             $identityProvider = $this->metadataRepository->fetchIdentityProviderByEntityId($entityId->getEntityId());
@@ -52,11 +48,7 @@ final class MetadataService
         return $identityProvider;
     }
 
-    /**
-     * @param EntityId $entityId
-     * @return null|ServiceProvider
-     */
-    public function findServiceProvider(EntityId $entityId)
+    public function findServiceProvider(EntityId $entityId): ?ServiceProvider
     {
         try {
             $serviceProvider = $this->metadataRepository->fetchServiceProviderByEntityId($entityId->getEntityId());
@@ -67,11 +59,7 @@ final class MetadataService
         return $serviceProvider;
     }
 
-    /**
-     * @param EntityId $entityId
-     * @return null|AttributeReleasePolicy
-     */
-    public function findArpForServiceProviderByEntityId(EntityId $entityId)
+    public function findArpForServiceProviderByEntityId(EntityId $entityId): ?AttributeReleasePolicy
     {
         $serviceProvider = $this->findServiceProvider($entityId);
 

--- a/src/OpenConext/EngineBlock/Service/MetadataServiceInterface.php
+++ b/src/OpenConext/EngineBlock/Service/MetadataServiceInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\Value\Saml\EntityId;
+
+interface MetadataServiceInterface
+{
+    public function findIdentityProvider(EntityId $entityId): ?IdentityProvider;
+
+    public function findServiceProvider(EntityId $entityId): ?ServiceProvider;
+
+    public function findArpForServiceProviderByEntityId(EntityId $entityId): ?AttributeReleasePolicy;
+}

--- a/src/OpenConext/EngineBlockBundle/Authentication/Entity/Consent.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Entity/Consent.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlockBundle\Authentication\Entity;
 
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -29,13 +30,13 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Table(indexes={
  *     @ORM\Index(name="hashed_user_id", columns={"hashed_user_id"}),
  *     @ORM\Index(name="service_id", columns={"service_id"}),
+ *     @ORM\Index(name="deleted_at", columns={"deleted_at"}),
  * })
  */
 class Consent
 {
     /**
      * @var DateTime
-     *
      * @ORM\Column(name="consent_date", type="datetime", nullable=false)
      */
     public $date;
@@ -69,4 +70,11 @@ class Consent
      * @ORM\Column(name="consent_type", type="string", nullable=true, length=20, options={"default": "explicit"})
      */
     public $type;
+
+    /**
+     * @ORM\Id
+     * @var DateTime
+     * @ORM\Column(name="deleted_at", type="datetime", nullable=true, options={"default": NULL}))
+     */
+    public $deletedAt;
 }

--- a/src/OpenConext/EngineBlockBundle/Authentication/Repository/DbalConsentRepository.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Repository/DbalConsentRepository.php
@@ -67,6 +67,8 @@ final class DbalConsentRepository implements ConsentRepository
                 consent
             WHERE
                 hashed_user_id=:hashed_user_id
+            AND
+                ISNULL(deleted_at)
         ';
 
         try {
@@ -119,9 +121,17 @@ final class DbalConsentRepository implements ConsentRepository
      */
     public function deleteOneFor(string $userId, string $serviceProviderEntityId): bool
     {
-        # Todo: change to soft delete
-        $sql = 'DELETE FROM consent WHERE hashed_user_id = :hashed_user_id AND service_id = :service_id ';
-
+        $sql = '
+            UPDATE
+                consent
+            SET
+                deleted_at = NOW()
+            WHERE
+                hashed_user_id = :hashed_user_id
+            AND
+                service_id = :service_id
+            AND ISNULL(deleted_at)
+        ';
         try {
             $result = $this->connection->executeQuery(
                 $sql,

--- a/src/OpenConext/EngineBlockBundle/Authentication/Repository/DbalConsentRepository.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Repository/DbalConsentRepository.php
@@ -25,7 +25,6 @@ use OpenConext\EngineBlock\Authentication\Model\Consent;
 use OpenConext\EngineBlock\Authentication\Repository\ConsentRepository;
 use OpenConext\EngineBlock\Authentication\Value\ConsentType;
 use OpenConext\EngineBlock\Exception\RuntimeException;
-use PDepend\Util\Log;
 use PDO;
 use Psr\Log\LoggerInterface;
 use function sha1;
@@ -141,7 +140,8 @@ final class DbalConsentRepository implements ConsentRepository
                 ]
             );
             $this->logger->info(
-                sprintf('Removed (soft delete) consent for hashed user id %s (%s), for service %s',
+                sprintf(
+                    'Removed (soft delete) consent for hashed user id %s (%s), for service %s',
                     sha1($userId),
                     $userId,
                     $serviceProviderEntityId

--- a/src/OpenConext/EngineBlockBundle/Authentication/Repository/DbalConsentRepository.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Repository/DbalConsentRepository.php
@@ -67,7 +67,7 @@ final class DbalConsentRepository implements ConsentRepository
             WHERE
                 hashed_user_id=:hashed_user_id
             AND
-                ISNULL(deleted_at)
+                deleted_at IS NULL
         ';
 
         try {
@@ -129,7 +129,7 @@ final class DbalConsentRepository implements ConsentRepository
                 hashed_user_id = :hashed_user_id
             AND
                 service_id = :service_id
-            AND ISNULL(deleted_at)
+            AND deleted_at IS NULL
         ';
         try {
             $result = $this->connection->executeQuery(

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -37,6 +37,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('api.deprovision', true));
         $this->setFeature(new Feature('api.metadata_push', true));
         $this->setFeature(new Feature('api.consent_listing', true));
+        $this->setFeature(new Feature('api.consent_remove', true));
         $this->setFeature(new Feature('eb.run_all_manipulations_prior_to_consent', false));
         $this->setFeature(new Feature('eb.block_user_on_violation', true));
         $this->setFeature(new Feature('eb.encrypted_assertions', true));

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/AttributeReleasePolicyController.php
@@ -19,7 +19,7 @@
 namespace OpenConext\EngineBlockBundle\Controller\Api;
 
 use EngineBlock_Arp_AttributeReleasePolicyEnforcer;
-use OpenConext\EngineBlock\Service\MetadataService;
+use OpenConext\EngineBlock\Service\MetadataServiceInterface;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiAccessDeniedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiMethodNotAllowedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\BadApiRequestHttpException;
@@ -37,7 +37,7 @@ final class AttributeReleasePolicyController
     private $authorizationChecker;
 
     /**
-     * @var MetadataService
+     * @var MetadataServiceInterface
      */
     private $metadataService;
 
@@ -48,7 +48,7 @@ final class AttributeReleasePolicyController
 
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,
-        MetadataService $metadataService,
+        MetadataServiceInterface $metadataService,
         EngineBlock_Arp_AttributeReleasePolicyEnforcer $arpEnforcer
     ) {
         $this->authorizationChecker = $authorizationChecker;

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
@@ -33,6 +33,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use function sprintf;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 final class ConsentController
 {
     /**

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
@@ -19,21 +19,22 @@
 namespace OpenConext\EngineBlockBundle\Controller\Api;
 
 use OpenConext\EngineBlock\Exception\RuntimeException;
+use OpenConext\EngineBlock\Service\ConsentServiceInterface;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiAccessDeniedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiInternalServerErrorHttpException;
-use OpenConext\EngineBlock\Service\ConsentService;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiMethodNotAllowedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiNotFoundHttpException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use function sprintf;
 
 final class ConsentController
 {
     /**
-     * @var ConsentService
+     * @var ConsentServiceInterface
      */
     private $consentService;
 
@@ -50,7 +51,7 @@ final class ConsentController
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,
         FeatureConfigurationInterface $featureConfiguration,
-        ConsentService $consentService
+        ConsentServiceInterface $consentService
     ) {
         $this->authorizationChecker = $authorizationChecker;
         $this->featureConfiguration = $featureConfiguration;

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
@@ -116,7 +116,7 @@ final class ConsentController
 
         try {
             $user = CollabPersonIdFactory::create($userId);
-            $removed = $this->deprovisionService->deleteOneConsentFor($user, $serviceProviderEntityId);
+            $removed = $this->consentService->deleteOneConsentFor($user, $serviceProviderEntityId);
         } catch (RuntimeException $e) {
             throw new ApiInternalServerErrorHttpException(
                 sprintf(

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use function array_key_exists;
 use function sprintf;
 
 /**
@@ -110,12 +111,16 @@ final class ConsentController
                 'Access to the consent removal API requires the role ROLE_API_USER_PROFILE'
             );
         }
-
-        $userId = $request->get('collabPersonId', false);
-        $serviceProviderEntityId = $request->get('serviceProviderEntityId', false);
-        if (!$userId || !$serviceProviderEntityId) {
-            throw new EngineBlockInvalidArgumentException('The required data for removing the consent is not present in the request parameters');
+        // The data is posted json encoded from EngineBlock
+        $data = json_decode($request->getContent(), true);
+        if (!$data || !array_key_exists('collabPersonId', $data) || !array_key_exists('serviceProviderEntityId', $data)) {
+            throw new EngineBlockInvalidArgumentException(
+                'The required data for removing the consent is not present in the request parameters json'
+            );
         }
+
+        $userId = $data['collabPersonId'];
+        $serviceProviderEntityId = $data['serviceProviderEntityId'];
 
         try {
             $user = CollabPersonIdFactory::create($userId);

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionController.php
@@ -22,6 +22,7 @@ use InvalidArgumentException;
 use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
 use OpenConext\EngineBlock\Exception\RuntimeException;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
+use OpenConext\EngineBlockBundle\Exception\InvalidArgumentException as EngineBlockInvalidArgumentException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiAccessDeniedHttpException;
 use OpenConext\EngineBlock\Service\DeprovisionService;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiInternalServerErrorHttpException;
@@ -117,10 +118,10 @@ final class DeprovisionController
     }
 
 
-    public function removeAction(string $userId, string $serviceProviderEntityId, Request $request): JsonResponse
+    public function removeAction(Request $request): JsonResponse
     {
-        if (!$request->isMethod(Request::METHOD_GET)) {
-            throw ApiMethodNotAllowedHttpException::methodNotAllowed($request->getMethod(), [Request::METHOD_GET]);
+        if (!$request->isMethod(Request::METHOD_POST)) {
+            throw ApiMethodNotAllowedHttpException::methodNotAllowed($request->getMethod(), [Request::METHOD_POST]);
         }
 
         if (!$this->featureConfiguration->isEnabled('api.consent_remove')) {
@@ -131,6 +132,12 @@ final class DeprovisionController
             throw new ApiAccessDeniedHttpException(
                 'Access to the consent removal API requires the role ROLE_API_USER_DEPROVISION'
             );
+        }
+
+        $userId = $request->get('collabPersonId', false);
+        $serviceProviderEntityId = $request->get('serviceProviderEntityId', false);
+        if (!$userId || !$serviceProviderEntityId) {
+            throw new EngineBlockInvalidArgumentException('The required data for removing the consent is not present in the request parameters');
         }
 
         try {

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionController.php
@@ -128,9 +128,9 @@ final class DeprovisionController
             throw new ApiNotFoundHttpException('Consent remove API is disabled');
         }
 
-        if (!$this->authorizationChecker->isGranted('ROLE_API_USER_DEPROVISION')) {
+        if (!$this->authorizationChecker->isGranted('ROLE_API_USER_PROFILE')) {
             throw new ApiAccessDeniedHttpException(
-                'Access to the consent removal API requires the role ROLE_API_USER_DEPROVISION'
+                'Access to the consent removal API requires the role ROLE_API_USER_PROFILE'
             );
         }
 

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/MetadataController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/MetadataController.php
@@ -18,13 +18,13 @@
 
 namespace OpenConext\EngineBlockBundle\Controller\Api;
 
+use OpenConext\EngineBlock\Service\MetadataServiceInterface;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiAccessDeniedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiMethodNotAllowedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiNotFoundHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\BadApiRequestHttpException;
 use OpenConext\EngineBlockBundle\Http\Response\JsonResponse;
-use OpenConext\EngineBlock\Service\MetadataService;
 use OpenConext\EngineBlockBundle\Http\Response\JsonHelper;
 use OpenConext\Value\Exception\InvalidArgumentException;
 use OpenConext\Value\Saml\EntityId;
@@ -38,7 +38,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 final class MetadataController
 {
     /**
-     * @var MetadataService
+     * @var MetadataServiceInterface
      */
     private $metadataService;
 
@@ -55,7 +55,7 @@ final class MetadataController
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,
         FeatureConfiguration $featureConfiguration,
-        MetadataService $metadataService
+        MetadataServiceInterface $metadataService
     ) {
         $this->authorizationChecker = $authorizationChecker;
         $this->featureConfiguration = $featureConfiguration;

--- a/src/OpenConext/EngineBlockBundle/Factory/CollabPersonIdFactory.php
+++ b/src/OpenConext/EngineBlockBundle/Factory/CollabPersonIdFactory.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Factory;
+
+use InvalidArgumentException;
+use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
+use OpenConext\EngineBlockBundle\Http\Exception\ApiNotFoundHttpException;
+use function sprintf;
+
+class CollabPersonIdFactory
+{
+    /**
+     * @throws ApiNotFoundHttpException
+     */
+    public static function create(string $id): CollabPersonId
+    {
+        try {
+            return new CollabPersonId($id);
+        } catch (InvalidArgumentException $e) {
+            throw new ApiNotFoundHttpException(
+                sprintf(
+                    'User ID is not valid: "%s"',
+                    $e->getMessage()
+                )
+            );
+        }
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Resources/config/repositories.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/repositories.yml
@@ -4,6 +4,7 @@ services:
         class: OpenConext\EngineBlockBundle\Authentication\Repository\DbalConsentRepository
         arguments:
             - "@engineblock.compat.doctrine.dbal_connection"
+            - "@logger"
 
     engineblock.repository.user:
         public: false

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
@@ -25,7 +25,7 @@ api_consent_user:
 api_remove_consent_user:
     path:    /remove-consent
     defaults:
-        _controller: engineblock.controller.api.deprovision:removeAction
+        _controller: engineblock.controller.api.consent:removeAction
         _format: json
 
 api_deprovision_delete_user_data_dry_run:

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
@@ -23,9 +23,7 @@ api_consent_user:
         _format: json
 
 api_remove_consent_user:
-    path:    /remove-consent/{userId}/{serviceProviderEntityId}
-    requirements:
-        serviceProviderEntityId: .+
+    path:    /remove-consent
     defaults:
         _controller: engineblock.controller.api.deprovision:removeAction
         _format: json

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing_api.yml
@@ -22,6 +22,14 @@ api_consent_user:
         _controller: engineblock.controller.api.consent:userAction
         _format: json
 
+api_remove_consent_user:
+    path:    /remove-consent/{userId}/{serviceProviderEntityId}
+    requirements:
+        serviceProviderEntityId: .+
+    defaults:
+        _controller: engineblock.controller.api.deprovision:removeAction
+        _format: json
+
 api_deprovision_delete_user_data_dry_run:
     path:    /deprovision/{collabPersonId}/dry-run
     requirements:

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/DeprovisionControllerTest.php
@@ -223,8 +223,8 @@ final class DeprovisionControllerTest extends WebTestCase
     public function no_consent_is_removed_if_request_parameters_are_missing_or_incorrect()
     {
         $client = static::createClient([], [
-            'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.deprovision.username'),
-            'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.deprovision.password'),
+            'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.profile.username'),
+            'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.profile.password'),
         ]);
 
         $client->request(
@@ -245,8 +245,8 @@ final class DeprovisionControllerTest extends WebTestCase
     public function no_consent_is_removed_if_collab_person_id_is_unknown()
     {
         $client = static::createClient([], [
-            'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.deprovision.username'),
-            'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.deprovision.password'),
+            'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.profile.username'),
+            'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.profile.password'),
         ]);
 
         $client->request(
@@ -418,8 +418,8 @@ final class DeprovisionControllerTest extends WebTestCase
         $consentDate = '2017-04-18 13:37:00';
 
         $client = static::createClient([], [
-            'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.deprovision.username'),
-            'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.deprovision.password'),
+            'PHP_AUTH_USER' => $this->getContainer()->getParameter('api.users.profile.username'),
+            'PHP_AUTH_PW' => $this->getContainer()->getParameter('api.users.profile.password'),
         ]);
 
         $this->addServiceProviderUuidFixture($spUuid1, $spEntityId1);

--- a/tests/unit/OpenConext/EngineBlock/Service/ConsentServiceTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/ConsentServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Authentication\Model\User;
+use OpenConext\EngineBlock\Authentication\Repository\ConsentRepository;
+use OpenConext\EngineBlock\Authentication\Value\CollabPersonId;
+use OpenConext\EngineBlock\Authentication\Value\CollabPersonUuid;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ConsentServiceTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var ConsentRepository
+     */
+    private $consentRepository;
+
+    /**
+     * @var MetadataService
+     */
+    private $metadataService;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var User
+     */
+    private $user;
+
+    public function setUp()
+    {
+        $this->consentRepository = m::mock(ConsentRepository::class);
+        $this->metadataService = m::mock(MetadataServiceInterface::class);
+        $this->logger = m::mock(LoggerInterface::class);
+
+        $this->user = new User(
+            new CollabPersonId('urn:collab:person:test'),
+            new CollabPersonUuid('550e8400-e29b-41d4-a716-446655440000')
+        );
+    }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Consent
+     */
+    public function remove_consent_by_collab_person_id_and_sp_entity_id()
+    {
+        $this->consentRepository->shouldReceive('deleteOneFor')
+            ->with($this->user->getCollabPersonId()->getCollabPersonId(), 'https://sp1.example.org');
+
+        $service = new ConsentService(
+            $this->consentRepository,
+            $this->metadataService,
+            $this->logger
+        );
+
+        $service->deleteOneConsentFor(new CollabPersonId('urn:collab:person:test'), 'https://sp1.example.org');
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Service/DeprovisionServiceTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/DeprovisionServiceTest.php
@@ -236,4 +236,24 @@ class DeprovisionServiceTest extends TestCase
             new CollabPersonId('urn:collab:person:test')
         );
     }
+
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Deprovision
+     */
+    public function remove_consent_by_collab_person_id_and_sp_entity_id()
+    {
+        $this->consentRepository->shouldReceive('deleteOneFor')
+            ->with($this->user->getCollabPersonId()->getCollabPersonId(), 'https://sp1.example.org');
+
+        $service = new DeprovisionService(
+            $this->consentRepository,
+            $this->userDirectory,
+            $this->persistentIdRepository,
+            $this->serviceProviderUuidRepository
+        );
+
+        $service->deleteOneConsentFor(new CollabPersonId('urn:collab:person:test'), 'https://sp1.example.org');
+    }
 }

--- a/tests/unit/OpenConext/EngineBlock/Service/DeprovisionServiceTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/DeprovisionServiceTest.php
@@ -236,24 +236,4 @@ class DeprovisionServiceTest extends TestCase
             new CollabPersonId('urn:collab:person:test')
         );
     }
-
-    /**
-     * @test
-     * @group EngineBlock
-     * @group Deprovision
-     */
-    public function remove_consent_by_collab_person_id_and_sp_entity_id()
-    {
-        $this->consentRepository->shouldReceive('deleteOneFor')
-            ->with($this->user->getCollabPersonId()->getCollabPersonId(), 'https://sp1.example.org');
-
-        $service = new DeprovisionService(
-            $this->consentRepository,
-            $this->userDirectory,
-            $this->persistentIdRepository,
-            $this->serviceProviderUuidRepository
-        );
-
-        $service->deleteOneConsentFor(new CollabPersonId('urn:collab:person:test'), 'https://sp1.example.org');
-    }
 }


### PR DESCRIPTION
An API endpoint is created to remove a single consent row based on a user id and a SP entity id. This allows the profile end user to retract consent for services they have previously granted consent to.

https://www.pivotaltracker.com/story/show/179490276