### PR TITLE
Allow to specify a community Uuid in Manage.

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -202,6 +202,13 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
             ),
             'termsOfServiceUrl'
         );
+        $properties += $this->setPathFromObjectString(
+            array(
+                $connection,
+                'metadata:coin:communityUuid'
+            ),
+            'communityUuid'
+        );
         $properties += $this->setPathFromObjectBool(
             array(
                 $connection,

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -204,7 +204,8 @@ class ServiceProvider extends AbstractRole
         $supportUrlNl = null,
         $supportUrlPt = null,
         $stepupAllowNoToken = null,
-        $stepupRequireLoa = null
+        $stepupRequireLoa = null,
+        $communityUuid = null
     ) {
         parent::__construct(
             $entityId,
@@ -257,7 +258,8 @@ class ServiceProvider extends AbstractRole
             $stepupRequireLoa,
             $disableScoping,
             $additionalLogging,
-            $signatureMethod
+            $signatureMethod,
+            $communityUuid
         );
     }
 

--- a/src/OpenConext/EngineBlockBundle/Authentication/Entity/ServiceProviderUuid.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Entity/ServiceProviderUuid.php
@@ -28,7 +28,6 @@ class ServiceProviderUuid
     /**
      * @var string
      *
-     * @ORM\Id
      * @ORM\Column(type="string", length=36, options={"fixed": true})
      */
     public $uuid;

--- a/src/OpenConext/EngineBlockBundle/Authentication/Entity/ServiceProviderUuid.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Entity/ServiceProviderUuid.php
@@ -22,13 +22,6 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity(repositoryClass="OpenConext\EngineBlockBundle\Authentication\Repository\ServiceProviderUuidRepository")
- * @ORM\Table(indexes={
- *     @ORM\Index(
- *         name="service_provider_entity_id",
- *         columns={"service_provider_entity_id"},
- *         options={"lengths" = {255}}
- *     ),
- * })
  */
 class ServiceProviderUuid
 {
@@ -43,6 +36,7 @@ class ServiceProviderUuid
     /**
      * @var string
      *
+     * @ORM\Id
      * @ORM\Column(type="string", length=1024)
      */
     public $serviceProviderEntityId;

--- a/tests/library/EngineBlock/Test/Saml2/NameIdResolverMock.php
+++ b/tests/library/EngineBlock/Test/Saml2/NameIdResolverMock.php
@@ -49,14 +49,14 @@ class EngineBlock_Test_Saml2_NameIdResolverMock extends EngineBlock_Saml2_NameId
         $this->_persistentIds[$serviceProviderUuid][$userUuid] = $persistentId;
     }
 
-    protected function _fetchServiceProviderUuid($spEntityId)
+    protected function _fetchServiceProviderUuid(string $spEntityId)
     {
         return empty($this->_serviceProviderUuids[$spEntityId]) ?
             false:
             $this->_serviceProviderUuids[$spEntityId];
     }
 
-    protected function _storeServiceProviderUuid($spEntityId, $uuid)
+    protected function _storeServiceProviderUuid(string $spEntityId, string $uuid, bool $overwrite = false): void
     {
         $this->_serviceProviderUuids[$spEntityId] = $uuid;
     }


### PR DESCRIPTION
 All SPs in the community will get the same persistent NameID.

Example applications:
- A group of SP's is in fact the same logical service provider, divided over several technical SP entityIDs. They would all get different persistent IDs. Now they can be marked as a group and have a common ID, that is still scoped to this group and not relatable to IDs outside of the group.
- A service provider migrates to a different entityID. The second entity can keep the same persistent IDs that the first entity used to receive.

Use it by setting the field `coin:communityUuid` in Manage to a new Uuid, and set this same Uuid to any other entity that you want to be part of this community. For the migration case, set the Uuid to be the current Uuid of the SP in the service_provider_uuid table in Engineblock.

If an SP has this new metadata field, its identifiers will be based on this Uuid from now on. This means that:
- If you add the field to an SP, all current identifiers will change (if they exist), to become part of the new community. If you don't want this, choose the existing service_provider_uuid as the value.
- If you remove the field from an SP, nothing will change. If you want to split up a community, you need to explicitly assign a new Uuid as its community.

This requires also a (onliner) update to Manage to send the new field `coin:communityUuid` in the EB push.