### PR TITLE
Fix build script for custom themes, add watch script and fail build on error

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -20,6 +20,13 @@ We use the following tools:
 - [Vanilla JS][vanilla.js] as our JS solution of choice.  It's lightning fast, easily blowing any rival framework out of the water.  It also allows anyone to jump in.  We compile it using [Babel][babel] to ensure we can use the latest&greatest features of choice.
 - [Cypress][cypress] for integration, end-to-end testing, visual-regression testing, accessibility-testing and html-validation.  We use plugins for the last two.
 
+To speed up development on changes to the theme run the following command for live updates on the selected theme;
+```
+npm run watch
+```
+This will detect changes to the javascript and stylesheet in the select theme and update the build accordingly. Do note that this script only watches
+the selected theme and not the base.
+
 ### Cross-browser support:
 
 We currently support the following browsers:

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -1353,6 +1353,14 @@
         "@jimp/utils": "^0.10.3",
         "core-js": "^3.4.1",
         "jpeg-js": "^0.3.4"
+      },
+      "dependencies": {
+        "jpeg-js": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.0.tgz",
+          "integrity": "sha512-960VHmtN1vTpasX/1LupLohdP5odwAT7oK/VSm6mW0M58LbrBnowLAPWAZhWGhDAGjzbMnPXZxzB/QYgBwkN0w==",
+          "dev": true
+        }
       }
     },
     "@jimp/plugin-blit": {
@@ -3337,6 +3345,14 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "20.2.9",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+              "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+              "dev": true
+            }
           }
         }
       }
@@ -4191,12 +4207,6 @@
         }
       }
     },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
-    },
     "diff2html": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-2.12.2.tgz",
@@ -4207,6 +4217,14 @@
         "hogan.js": "^3.0.2",
         "merge": "^1.2.1",
         "whatwg-fetch": "^3.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        }
       }
     },
     "diffie-hellman": {
@@ -6952,12 +6970,6 @@
         "core-js": "^3.4.1",
         "regenerator-runtime": "^0.13.3"
       }
-    },
-    "jpeg-js": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-      "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
-      "dev": true
     },
     "js-base64": {
       "version": "2.6.4",
@@ -10149,17 +10161,20 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^13.1.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "20.2.9",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+              "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+              "dev": true
+            }
           }
         },
         "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
     },
@@ -11035,6 +11050,14 @@
             "trim-newlines": "^3.0.0",
             "type-fest": "^0.18.0",
             "yargs-parser": "^20.2.3"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "20.2.9",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+              "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+              "dev": true
+            }
           }
         },
         "micromatch": {
@@ -11186,10 +11209,9 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "20.2.7",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
-          "dev": true
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
     },
@@ -11793,9 +11815,9 @@
       },
       "dependencies": {
         "diff": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
         }
       }
@@ -12597,22 +12619,12 @@
       },
       "dependencies": {
         "yargs-parser": {
-          "version": "18.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-          "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true
         }
       }
-    },
-    "yargs-parser": {
-      "version": "20.2.7",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
-      "dev": true
     },
     "yauzl": {
       "version": "2.10.0",

--- a/theme/package.json
+++ b/theme/package.json
@@ -19,7 +19,7 @@
     "lint:css": "stylelint ${EB_THEME:=openconext}/stylesheets/**/*.*ss",
     "clean": "rimraf ../web/images/* ../web/javascripts/* ../web/stylesheets/* ../web/fonts/*",
     "build": "node scripts/build.js",
-    "buildtheme": "npm run build:clean && npm run build:js && npm run build:css && npm run build:copy",
+    "buildtheme": "npm run build:clean && npm run build:js && npm run build:css && npm run build:copy:base && npm run build:copy:theme",
     "build:clean": "rimraf ../web/javascripts/* ../web/stylesheets/*",
     "build:js": "mkdir -p ../web/javascripts && npm run build:js:babelify",
     "build:js:debug": "mkdir -p ../web/javascripts && npm run build:js:babelify:debug",
@@ -28,8 +28,10 @@
     "build:css": "mkdir -p ../web/stylesheets && npm run build:css:sass && npm run build:css:postcss",
     "build:css:sass": "node-sass ${EB_THEME:=openconext}/stylesheets --error-bell -o ../web/stylesheets/",
     "build:css:postcss": "BROWSERSLIST_CONFIG=.browserslistrc postcss ../web/stylesheets/*.css --use autoprefixer --use cssnano --no-map --dir ../web/stylesheets",
-    "build:copy": "mkdir -p ../web/images && copyfiles --up 2 base/images/* ../web/images/ && mkdir -p ../web/fonts && copyfiles --up 2 -e base/stylesheets/fonts/*.txt -f base/stylesheets/fonts/* ../web/fonts && copyfiles --up 2 -e base/stylesheets/fonts/*.txt -f ${EB_THEME:=openconext}/stylesheets/fonts/* ../web/fonts && copyfiles --up 2 -e base/stylesheets/fonts/*.txt -f ${EB_THEME:=openconext}/stylesheets/fonts/* ../web/fonts",
+    "build:copy:base": "mkdir -p ../web/images && copyfiles --up 2 base/images/* ../web/images/ && mkdir -p ../web/fonts && copyfiles --up 2 -e base/stylesheets/fonts/*.txt -f base/stylesheets/fonts/* ../web/fonts",
+    "build:copy:theme": "copyfiles --up 2 ${EB_THEME:=openconext}/images/* ../web/images/ && copyfiles --up 2 -e {EB_THEME:=openconext}/stylesheets/fonts/*.txt -f ${EB_THEME:=openconext}/stylesheets/fonts/* ../web/fonts",
     "create-theme": "node scripts/create-theme.js",
+    "watch": "node scripts/watch.js",
     "watch:js": "watchify ${EB_THEME:=base}/javascripts/application.js --poll=100 --debug -t [ babelify ] ${EB_THEME:=base}/javascripts/application.js -o ../web/javascripts/application.min.js -v",
     "watch:css": "node-sass -r ${EB_THEME:=openconext}/stylesheets -w -o ../web/stylesheets",
     "release": "npm run build"
@@ -71,7 +73,7 @@
     "cypress": "5.6.0",
     "jpeg-js": "0.4.0",
     "minimist": "1.2.5",
-    "yargs-parser": "18.1.2",
+    "yargs-parser": "20.2.9",
     "diff": "3.5.0"
   }
 }

--- a/theme/scripts/build.js
+++ b/theme/scripts/build.js
@@ -30,7 +30,7 @@ function executeShellCommand(command) {
     exec(command, (error, stdOut, stdError) => {
         if (error) {
             console.log(`exec error: ${error}`);
-            return;
+            process.exit(1);
         }
 
         if (!stdOut && stdError) {
@@ -38,6 +38,6 @@ function executeShellCommand(command) {
         }
 
         console.log(stdOut);
-        return process.exit(0);
+        process.exit(0);
     });
 }

--- a/theme/scripts/watch.js
+++ b/theme/scripts/watch.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/** Simple script to watch based on CLI or chosen theme in parameters.yml
+ * Using library js-yaml, repo can be found at: https://github.com/nodeca/js-yaml
+ * Tutorial can be found at https://stackabuse.com/reading-and-writing-yaml-to-a-file-in-node-js-javascript/
+ *
+ * Everything else used is part of node
+ *
+ * Use: node build.js or  EB_THEME=skeune node build.js
+ * Replace "skeune" in the above by whatever theme you want to build.
+ **/
+const fs = require('fs');
+const yaml = require('js-yaml');
+const config = `${__dirname}/../../app/config/parameters.yml`;
+
+try {
+  console.log('Reading contents of parameters.yml.\n');
+  const fileContents = fs.readFileSync(config, 'utf8');
+  const parameters = yaml.safeLoadAll(fileContents);
+  const theme = process.env.EB_THEME || parameters[0].parameters['theme.name'] || 'skeune';
+
+  console.log(`Using theme ${theme} to run the watch.\n`);
+  executeShellCommand(`cd ${__dirname}/.. && EB_THEME=${theme} npm run watch:css`);
+  executeShellCommand(`cd ${__dirname}/.. && EB_THEME=${theme} npm run watch:js`);
+} catch (e) {
+  console.log(e);
+}
+
+function executeShellCommand(command) {
+  var exec = require('child_process').exec;
+  var process = exec(command);
+
+  process.stdout.on('data', function (data) {
+    console.log(data);
+  });
+  process.stderr.on('data', function (data) {
+    console.log(data);
+  });
+}


### PR DESCRIPTION
**The following changes have been implemented with this PR:**
- The build script now allows images and fonts to be loaded from custom themes instead of just from the base. To clarify this process we have split the copying in two steps 'copy the base' and 'copy the theme'
- To support our build processes we have upgraded yargs-parser from "18.1.2" to "20.2.9"
- We have added a watch script that will detect any changes to the selected theme and updates the web folder to speed up the development process 'npm run watch'
- The build script will now return error code 1 when a build has failed.

Please let us know if you have any questions.


_Failure with yargs-parser 18.1.2:_
```
exec error: Error: Command failed: cd XX/engineblock/theme/scripts/.. && EB_THEME=kennisnet npm run buildtheme
XX/engineblock/theme/node_modules/yargs/build/index.cjs:2804
            if (shim$1.Parser.looksLikeNumber(arg) &&
                              ^

TypeError: shim$1.Parser.looksLikeNumber is not a function
    at Object.Yargs.self._parsePositionalNumbers (XX/engineblock/theme/node_modules/yargs/build/index.cjs:2804:31)
    at Object.Yargs.self._postProcess (XX/engineblock/theme/node_modules/yargs/build/index.cjs:2787:25)
    at Object.parseArgs [as _parseArgs] (XX/engineblock/theme/node_modules/yargs/build/index.cjs:2774:21)
    at Function.get [as argv] (XX/engineblock/theme/node_modules/yargs/build/index.cjs:2651:25)
    at Object.<anonymous> (XX/engineblock/theme/node_modules/copyfiles/copyfiles:9:24)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
```

