### PR TITLE
Initially sort the displayed IdPs in WAYF correctly.

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
@@ -1,4 +1,4 @@
-{% set previousSelectionList = connectedIdps.formattedPreviousSelectionList %}
+{% set previousSelectionList = connectedIdps.formattedPreviousSelectionList|sort((a, b) => b.count <=> a.count) %}
 <section class="wayf__previousSelection {% if previousSelectionList is empty %}hidden{% endif %}">
     <h2 id="previousSelection__title" class="previousSelection__title">
         {{ 'wayf_your_accounts'|trans }}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/remainingIdps.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/remainingIdps.html.twig
@@ -8,6 +8,7 @@
     </h2>
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/search.html.twig' %}
 
+    {% set idpListSorted = connectedIdps.formattedIdpList|sort((a, b) => a.displayTitle|lower <=> b.displayTitle|lower) %}
     {% if showIdPBanner is defined and showIdPBanner %}
         {% set requestUri %}
             {% if '?' in app.request.requestUri %}
@@ -28,12 +29,12 @@
     {% endif %}
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/rememberChoice.html.twig' %}
     {% if showIdPBanner is defined and showIdPBanner %}
-        {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig' with { idpList: connectedIdps.formattedIdpList, delete: false, listName: 'remaining', id: 'remainingIdps__title', showIdPBanner: showIdPBanner } %}
+        {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig' with { idpList: idpListSorted, delete: false, listName: 'remaining', id: 'remainingIdps__title', showIdPBanner: showIdPBanner } %}
     {% else %}
-        {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig' with { idpList: connectedIdps.formattedIdpList, delete: false, listName: 'remaining', id: 'remainingIdps__title', showIdPBanner: false } %}
+        {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpList.html.twig' with { idpList: idpListSorted, delete: false, listName: 'remaining', id: 'remainingIdps__title', showIdPBanner: false } %}
     {% endif %}
 
     <div id="idpTemplate" class="hidden">
-        {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig' with { idp: connectedIdps.formattedIdpList.0, delete: false, listName: 'template', loop: {index: 1} } %}
+        {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig' with { idp: idpListSorted.0, delete: false, listName: 'template', loop: {index: 1} } %}
     </div>
 </section>


### PR DESCRIPTION
The IdPs in the WAYF are supposedly sorted: by count (when used before)
or by name (remaining IdPs). This happens in JS and happens correctly
when you use the sort field or clear it. However, the initial state
(the screen as shown when not searching for anything yet) is unsorted.

This is solved in the twig template by sorting the used IdPs (by
count, descending - most often used first) and the remainig IdPs by
displayTitle(lowercase). This is the same algorithm as JS used. Solving
this in the template/HTML means it's also solved for non-JS scenarios.
and there's no need to 'resort' the initial screen before it can be
displayed.