### PR TITLE
Improve Trused Proxy Behat test coverage

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeReleasePolicy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeReleasePolicy.feature
@@ -15,6 +15,9 @@ Feature:
     And a Service Provider named "Right Value ARP"
     And a Service Provider named "Specific Value ARP"
     And a Service Provider named "Two value ARP"
+    And a Service Provider named "Trusted Proxy"
+    And a Service Provider named "Stepup Gateway"
+    And a Service Provider named "Stepup SelfService"
     And SP "Empty ARP" allows no attributes
     And SP "Wildcard ARP" allows an attribute named "urn:mace:dir:attribute-def:uid"
     And SP "Wrong Value ARP" allows an attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization" with value "example.edu"
@@ -22,6 +25,10 @@ Feature:
     And SP "Specific Value ARP" allows an attribute named "urn:mace:dir:attribute-def:eduPersonAffiliation" with value "faculty"
     And SP "Two value ARP" allows an attribute named "urn:mace:dir:attribute-def:uid"
     And SP "Two value ARP" allows an attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    And SP "Stepup Gateway" allows an attribute named "urn:mace:dir:attribute-def:uid"
+    And SP "Stepup Gateway" allows an attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    And SP "Stepup Gateway" allows an attribute named "urn:mace:terena.org:attribute-def:eduPersonAffiliation"
+    And SP "Stepup SelfService" allows an attribute named "urn:mace:dir:attribute-def:uid"
     And feature "eb.run_all_manipulations_prior_to_consent" is disabled
 
   Scenario: As a user for an Idp SP without ARPs I get all attributes
@@ -104,3 +111,89 @@ Feature:
     And I pass through EngineBlock
     Then the response should contain "urn:mace:dir:attribute-def:uid"
     And the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+
+  Scenario: As a user for an SP behind TP without ARP I get all attributes
+    Given SP "Trusted Proxy" is authenticating for SP "No ARP"
+    And SP "Trusted Proxy" is a trusted proxy
+    And SP "Trusted Proxy" signs its requests
+    When I log in at "Trusted Proxy"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+
+  Scenario: As a user for an SP behind TP with an empty ARP I get no attributes
+    Given SP "Trusted Proxy" is authenticating for SP "Empty ARP"
+    And SP "Trusted Proxy" is a trusted proxy
+    And SP "Trusted Proxy" signs its requests
+    When I log in at "Trusted Proxy"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+
+  Scenario: As a user for an SP behind TP with a wildcard ARP I get all values for that attribute
+    Given SP "Trusted Proxy" is authenticating for SP "Wildcard ARP"
+    And SP "Trusted Proxy" is a trusted proxy
+    And SP "Trusted Proxy" signs its requests
+    When I log in at "Trusted Proxy"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+
+  Scenario: As a user for an SP behind TP with a specific value ARP I do not see the attribute with a wrong value
+    Given SP "Trusted Proxy" is authenticating for SP "Wrong Value ARP"
+    And SP "Trusted Proxy" is a trusted proxy
+    And SP "Trusted Proxy" signs its requests
+    When I log in at "Trusted Proxy"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+
+  Scenario: As a user for an SP behind TP with a specific value ARP I do see the attribute if it has the right value
+    Given SP "Trusted Proxy" is authenticating for SP "Right Value ARP"
+    And SP "Trusted Proxy" is a trusted proxy
+    And SP "Trusted Proxy" signs its requests
+    When I log in at "Trusted Proxy"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should not contain "urn:mace:dir:attribute-def:uid"
+    And the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+
+  Scenario: As a user for an SP behind TP both ARPs are applied leaving an intersection of the attributes
+    Given SP "Stepup Gateway" is authenticating for SP "Stepup SelfService"
+    And SP "Stepup Gateway" is a trusted proxy
+    And SP "Stepup Gateway" signs its requests
+    When I log in at "Stepup Gateway"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    And the response should not contain "urn:mace:terena.org:attribute-def:eduPersonAffiliation"
+    When I give my consent
+    And I pass through EngineBlock
+    Then the response should contain "urn:mace:dir:attribute-def:uid"
+    Then the response should not contain "urn:mace:dir:attribute-def:eduPersonAffiliation"
+    And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
@@ -47,7 +47,7 @@ Feature:
      When I log in at "Dummy SP"
       And I pass through EngineBlock
       And I pass through the IdP
-      And I should not see "Error - No access"
+      And I should not see "Error - Access denied"
 
   Scenario: Access is permitted because of a Not Applicable policy
     Given SP "Dummy SP" requires a policy enforcement decision
@@ -55,7 +55,7 @@ Feature:
      When I log in at "Dummy SP"
       And I pass through EngineBlock
       And I pass through the IdP
-      And I should not see "Error - No access"
+      And I should not see "Error - Access denied"
 
   Scenario: Access is denied because of a Deny policy, End-SP behind Trusted Proxy
     Given SP "Stepup SelfService" requires a policy enforcement decision
@@ -90,7 +90,7 @@ Feature:
     When I log in at "Stepup Gateway"
     And I pass through EngineBlock
     And I pass through the IdP
-    And I should not see "Error - No access"
+    And I should not see "Error - Access denied"
 
   Scenario: Access is permitted because of a Not Applicable policy, End-SP behind Trusted Proxy
     Given SP "Stepup SelfService" requires a policy enforcement decision
@@ -101,4 +101,4 @@ Feature:
     When I log in at "Stepup Gateway"
     And I pass through EngineBlock
     And I pass through the IdP
-    And I should not see "Error - No access"
+    And I should not see "Error - Access denied"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
@@ -9,6 +9,8 @@ Feature:
       And no registered Idps
       And an Identity Provider named "Dummy IdP" with logo "idp-logo.jpg"
       And a Service Provider named "Dummy SP"
+      And a Service Provider named "Stepup Gateway"
+      And a Service Provider named "Stepup SelfService"
 
   Scenario: Access is denied because of an IdP specific Deny policy a logo is shown
     Given SP "Dummy SP" requires a policy enforcement decision
@@ -54,3 +56,49 @@ Feature:
       And I pass through EngineBlock
       And I pass through the IdP
       And I should not see "Error - No access"
+
+  Scenario: Access is denied because of a Deny policy, End-SP behind Trusted Proxy
+    Given SP "Stepup SelfService" requires a policy enforcement decision
+    And SP "Stepup Gateway" is authenticating for SP "Stepup SelfService"
+    And SP "Stepup Gateway" is a trusted proxy
+    And SP "Stepup Gateway" signs its requests
+    And pdp gives a deny response
+    When I log in at "Stepup Gateway"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I should see "Error - Access denied"
+    And I should see "Message from your organisation:"
+
+  Scenario: Access is denied because of an Indeterminate policy, End-SP behind Trusted Proxy
+    Given SP "Stepup SelfService" requires a policy enforcement decision
+    And SP "Stepup Gateway" is authenticating for SP "Stepup SelfService"
+    And SP "Stepup Gateway" is a trusted proxy
+    And SP "Stepup Gateway" signs its requests
+    And pdp gives an indeterminate response
+    When I log in at "Stepup Gateway"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I should see "Error - Access denied"
+    And I should see "Message from your organisation:"
+
+  Scenario: Access is permitted because of a Permit policy, End-SP behind Trusted Proxy
+    Given SP "Stepup SelfService" requires a policy enforcement decision
+    And SP "Stepup Gateway" is authenticating for SP "Stepup SelfService"
+    And SP "Stepup Gateway" is a trusted proxy
+    And SP "Stepup Gateway" signs its requests
+    And pdp gives a permit response
+    When I log in at "Stepup Gateway"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I should not see "Error - No access"
+
+  Scenario: Access is permitted because of a Not Applicable policy, End-SP behind Trusted Proxy
+    Given SP "Stepup SelfService" requires a policy enforcement decision
+    And SP "Stepup Gateway" is authenticating for SP "Stepup SelfService"
+    And SP "Stepup Gateway" is a trusted proxy
+    And SP "Stepup Gateway" signs its requests
+    And pdp gives a not applicable response
+    When I log in at "Stepup Gateway"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I should not see "Error - No access"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
@@ -34,11 +34,21 @@ Feature:
      And I should not see "StepUpOnlyAuth"
 
   Scenario: User logs in to the proxy without a SP and wayf shows relevant Identity Providers
-     When I log in at "Step Up"
-     Then I should see "AlwaysAuth"
-      And I should see "CombinedAuth"
-      And I should see "StepUpOnlyAuth"
-      And I should not see "LoaOnlyAuth"
+    When I log in at "Step Up"
+    Then I should see "AlwaysAuth"
+    And I should see "CombinedAuth"
+    And I should see "StepUpOnlyAuth"
+    And I should not see "LoaOnlyAuth"
+
+  Scenario: User logs in to the trusted proxy, wayf shows relevant Identity Providers
+    Given SP "Step Up" is authenticating for SP "Loa SP"
+    And SP "Step Up" is a trusted proxy
+    And SP "Step Up" signs its requests
+    When I log in at "Step Up"
+    Then I should see "AlwaysAuth"
+    And I should see "CombinedAuth"
+    And I should not see "StepUpOnlyAuth"
+    And I should not see "LoaOnlyAuth"
 
   Scenario: User logs in via untrusted proxy accesses discovery for unknown SP
     Given SP "Step Up" is authenticating and uses RequesterID "https://example.edu/saml2/metadata"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
@@ -198,6 +198,22 @@ Feature:
      Then the response should not contain "urn:mace:dir:attribute-def:uid"
       And the response should not contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
 
+  Scenario: Stepup authentication should be supported if set through PDP when End-SP is behind TP
+    Given SP "Step Up" is authenticating for SP "Loa SP"
+    And SP "Step Up" is a trusted proxy
+    And SP "Step Up" signs its requests
+    And SP "Step Up" does not require consent
+    And SP "Loa SP" does not require consent
+    And SP "Loa SP" requires a policy enforcement decision
+    And pdp gives a stepup obligation response for "http://vm.openconext.org/assurance/loa3"
+    When I log in at "Step Up"
+    And I select "AlwaysAuth" on the WAYF
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And Stepup will successfully verify a user
+    And I pass through EngineBlock
+    Then the url should match "/functional-testing/Step%20Up/acs"
+
   Scenario: User logs in at test SP and via prod trusted proxy and is denied access
     Given SP "Step Up" is authenticating for SP "Test SP"
       And SP "Step Up" is a trusted proxy


### PR DESCRIPTION
Thanks to a good sit-down with @thijskh several relevant trusted proxy behavioral tests where identified. Most of which are variations on existing tests that are not TP related. The tests have been specified in the tasks of the story linked below. This PR adds these tests.