### PR TITLE
Display correct information in error message for unknown proxied SP

### DIFF
--- a/library/EngineBlock/SamlHelper.php
+++ b/library/EngineBlock/SamlHelper.php
@@ -119,6 +119,8 @@ class EngineBlock_SamlHelper
         // The filters will log any additional information that is available.
         $lastRequesterEntity = $repository->findServiceProviderByEntityId($lastRequesterEntityId, $logger);
         if (!$lastRequesterEntity) {
+            $_SESSION['currentServiceProvider'] = $lastRequesterEntityId;
+            $_SESSION['proxyServiceProvider'] = $serviceProvider->entityId;
             throw new EngineBlock_Exception_UnknownServiceProvider(
                 'Invalid RequesterID specified',
                 $lastRequesterEntityId,

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/SpProxy.feature
@@ -16,6 +16,7 @@ Feature:
       And a Service Provider named "Far SP"
       And a Service Provider named "Test SP"
       And a Service Provider named "Second SP"
+      And an unregistered Service Provider named "Unregistered SP"
       And SP "Far SP" is not connected to IdP "CombinedAuth"
       And SP "Far SP" is not connected to IdP "LoaOnlyAuth"
       And SP "Far SP" is not connected to IdP "StepUpOnlyAuth"
@@ -222,6 +223,7 @@ Feature:
       And SP "Step Up" uses the Unspecified NameID format
     When I log in at "Step Up"
     Then I should see "Error - Unknown service"
+     And I should see "Proxy SP:"
 
   Scenario: User logs in via misconfigured trusted proxy and sees error
     Given SP "Step Up" is authenticating for misconfigured SP "Far SP"
@@ -229,6 +231,17 @@ Feature:
     And SP "Step Up" signs its requests
     When I log in at "Step Up"
     Then I should see "Error - Unknown service"
+
+  Scenario: User logs in via trusted proxy which requests unknown SP and sees error
+    Given SP "Step Up" is authenticating for SP "Unregistered SP"
+    And SP "Step Up" is a trusted proxy
+    And SP "Step Up" signs its requests
+    When I log in at "Step Up"
+    Then I should see "Error - Unknown service"
+     And I should see "UR ID:"
+     And I should see "EC:"
+     And I should see "SP:"
+     And I should see "Proxy SP:"
 
   Scenario: User logs in to two SPs via trusted proxy
    Given SP "Step Up" is authenticating for SP "Loa SP"


### PR DESCRIPTION
If the end-SP behind the trusted proxy is unknown, an error message was shown that the trusted proxy itself was unknown. This corrects that in the same fashion as already used in [SingleSignOn::receive()](https://github.com/OpenConext/OpenConext-engineblock/blob/24c1f3dc4ae3b36a49f2a2e33e442379ae113180/library/EngineBlock/Corto/Module/Service/SingleSignOn.php#L178-L179).

https://www.pivotaltracker.com/story/show/178698658