### PR TITLE
Include organization names in Consent DTO

### DIFF
--- a/src/OpenConext/EngineBlock/Authentication/Dto/Consent.php
+++ b/src/OpenConext/EngineBlock/Authentication/Dto/Consent.php
@@ -37,20 +37,13 @@ final class Consent
      */
     private $serviceProvider;
 
-    /**
-     * @param ConsentEntity   $consent
-     * @param ServiceProvider $serviceProvider
-     */
     public function __construct(ConsentEntity $consent, ServiceProvider $serviceProvider)
     {
         $this->consent         = $consent;
         $this->serviceProvider = $serviceProvider;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $supportContacts = array_values(
             array_filter(
@@ -79,6 +72,7 @@ final class Consent
         ];
 
         $serviceProvider += $this->getDisplayNameFields();
+        $serviceProvider += $this->getOrganizationDisplayNameFields();
 
         return [
             'service_provider' => $serviceProvider,
@@ -87,7 +81,7 @@ final class Consent
         ];
     }
 
-    private function getDisplayNameFields()
+    private function getDisplayNameFields(): array
     {
         if (!empty($this->serviceProvider->displayNameEn)) {
             $fields['display_name']['en'] = $this->serviceProvider->displayNameEn;
@@ -111,6 +105,35 @@ final class Consent
             $fields['display_name']['pt'] = $this->serviceProvider->namePt;
         } else {
             $fields['display_name']['pt'] = $this->serviceProvider->entityId;
+        }
+
+        return $fields;
+    }
+
+    private function getOrganizationDisplayNameFields(): array
+    {
+        if (!empty($this->serviceProvider->organizationEn->displayName)) {
+            $fields['organization_display_name']['en'] = $this->serviceProvider->organizationEn->displayName;
+        } elseif (!empty($this->serviceProvider->organizationEn->name)) {
+            $fields['organization_display_name']['en'] = $this->serviceProvider->organizationEn->name;
+        } else {
+            $fields['organization_display_name']['en'] = "unknown";
+        }
+
+        if (!empty($this->serviceProvider->organizationNl->displayName)) {
+            $fields['organization_display_name']['nl'] = $this->serviceProvider->organizationNl->displayName;
+        } elseif (!empty($this->serviceProvider->organizationNl->name)) {
+            $fields['organization_display_name']['nl'] = $this->serviceProvider->organizationNl->name;
+        } else {
+            $fields['organization_display_name']['nl'] = $fields['organization_display_name']['en'];
+        }
+
+        if (!empty($this->serviceProvider->organizationPt->displayName)) {
+            $fields['organization_display_name']['pt'] = $this->serviceProvider->organizationPt->displayName;
+        } elseif (!empty($this->serviceProvider->organizationPt->name)) {
+            $fields['organization_display_name']['pt'] = $this->serviceProvider->organizationPt->name;
+        } else {
+            $fields['organization_display_name']['pt'] = $fields['organization_display_name']['en'];
         }
 
         return $fields;

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
@@ -21,6 +21,7 @@ namespace OpenConext\EngineBlockBundle\Tests;
 use DateTime;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Organization;
 use OpenConext\EngineBlockBundle\Configuration\Feature;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
 use OpenConext\Value\Saml\NameIdFormat;
@@ -186,6 +187,7 @@ final class ConsentControllerTest extends WebTestCase
         $serviceProvider->displayNameEn = 'My Test SP';
         $serviceProvider->displayNameNl = 'Mijn Test SP';
         $serviceProvider->displayNamePt = 'O Meu teste SP';
+        $serviceProvider->organizationEn = new Organization('Name', 'Organization Name', 'https://test.example.org');
         $serviceProvider->nameIdFormat = NameIdFormat::TRANSIENT_IDENTIFIER;
         $serviceProvider->supportUrlNl = 'https://my-test-sp.test/help-nl';
         $serviceProvider->supportUrlEn = 'https://my-test-sp.test/help-en';
@@ -227,6 +229,11 @@ final class ConsentControllerTest extends WebTestCase
                     'eula_url' => $serviceProvider->getCoins()->termsOfServiceUrl(),
                     'support_email' => $firstSupportContact->emailAddress,
                     'name_id_format' => $serviceProvider->nameIdFormat,
+                    'organization_display_name' => [
+                        'en' => $serviceProvider->organizationEn->displayName,
+                        'nl' => $serviceProvider->organizationEn->displayName,
+                        'pt' => $serviceProvider->organizationEn->displayName,
+                    ],
                 ],
                 'consent_type' => $consentType,
                 'consent_given_on' => (new DateTime($consentDate))->format(DATE_ATOM),


### PR DESCRIPTION
Retrieval of the right organization name is implemented to the following
algorithm:

```
    L = current language, "en" is English the global default language.
    If OrganizationDisplayName:L is set, return OrganizationDisplayName:L
    else if OrganizationName:L is set, returnOrganizationName:L
    else if OrganizationDisplayName:"en" is set, return OrganizationDisplayName:"en"
    else if OrganizationName:"en" is set, returnOrganizationName:"en"
    else return "unknown" (should not happen on production, Manage check will be added that always one of the fields is present)
```

This is to support Profile in showing the organization offering the
service on the 'my-services' page

More info and background: https://www.pivotaltracker.com/story/show/176872837