### PR TITLE
Prevent removal of form from IdP when previously removed

### DIFF
--- a/theme/base/javascripts/wayf/handleClickingDisabledIdp.js
+++ b/theme/base/javascripts/wayf/handleClickingDisabledIdp.js
@@ -22,8 +22,10 @@ export const handleClickingDisabledIdp = (element) => {
   cloneOfIdp.setAttribute('tabindex', '-1');
   // change titleText of clone to represent state of clone
   cloneOfIdp.querySelector(`#${noAccessIdpTitleId}`).firstElementChild.innerHTML = getData(li, 'titlestart');
-  // remove form so the login button is not there
-  cloneOfIdp.querySelector(idpFormSelector).remove();
+  // remove form so the login button is not there, but only while the form is still in the clone
+  if (cloneOfIdp.querySelector(idpFormSelector)) {
+    cloneOfIdp.querySelector(idpFormSelector).remove();
+  }
   // hide disabled idp button from screenreaders
   cloneOfIdp.querySelector(idpDeleteDisabledSelector).setAttribute('aria-hidden', 'true');
   const connectable = getData(target, 'connectable') === 'true';


### PR DESCRIPTION
**Description of issue:**
If you press an unconnected IdP the RA form is shown, but you click the greyed out IdP (which remains visible) again you get errors in the JS console

**Solution:**
Only remove the form from the IdP clone when the form still exists. Clicking on a disconnected idp triggers the script to handle the request access form interactions. One of these actions is to remove the form triggering SSO on the targetted IdP. When the form is already removed in a previous click, a successive click would trigger a console error.

**See:**
https://www.pivotaltracker.com/n/projects/1425900/stories/180935719