### PR TITLE
Return HTTP status code 400 on validation error

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -194,7 +194,7 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
                 $viewData
             );
 
-            return new Response($body);
+            return new Response($body, 400);
         }
 
         $postedVariables = $request->request;


### PR DESCRIPTION
Previously a 200 response was returned. Which was interpreted by the JS application as being a valid, all is good response. This was changed in this commit. A 400 status code coreesponds to 'Bad request' which seems most appropriate from a semantical point of view.

See task 2 of: https://www.pivotaltracker.com/story/show/180935719