### PR TITLE
Set IdP name on the wayf__idp row

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
@@ -13,6 +13,7 @@
     {% if idp['isDefaultIdp'] %}id="defaultIdp"{% endif %}
     tabindex="0"
     data-entityid="{{ idp['entityId'] }}"
+    data-title="{{ idp['displayTitle'] }}"
 >
     <div class="idp__logo">
         {% if idp.logo is not null %}


### PR DESCRIPTION
This display name is assumed to be set on the idp row when sending the request access mail message. Not having it set here will result in the mail message not being sent.

See point 3 of: https://www.pivotaltracker.com/story/show/180935719