### PR TITLE
Disable the Consent-related API endpoints if EB's consent feature is off

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConsentController.php
@@ -70,6 +70,10 @@ final class ConsentController
             throw ApiMethodNotAllowedHttpException::methodNotAllowed($request->getMethod(), [Request::METHOD_GET]);
         }
 
+        if (!$this->featureConfiguration->isEnabled('eb.feature_enable_consent')) {
+            throw new ApiNotFoundHttpException('Consent feature is disabled');
+        }
+
         if (!$this->featureConfiguration->isEnabled('api.consent_listing')) {
             throw new ApiNotFoundHttpException('Consent listing API is disabled');
         }
@@ -100,6 +104,10 @@ final class ConsentController
     {
         if (!$request->isMethod(Request::METHOD_POST)) {
             throw ApiMethodNotAllowedHttpException::methodNotAllowed($request->getMethod(), [Request::METHOD_POST]);
+        }
+
+        if (!$this->featureConfiguration->isEnabled('eb.feature_enable_consent')) {
+            throw new ApiNotFoundHttpException('Consent feature is disabled');
         }
 
         if (!$this->featureConfiguration->isEnabled('api.consent_remove')) {

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConsentControllerTest.php
@@ -408,7 +408,8 @@ final class ConsentControllerTest extends WebTestCase
     private function disableRemoveConsentApiFeatureFor(Client $client)
     {
         $featureToggles = new FeatureConfiguration([
-            'api.consent_remove' => new Feature('api.consent_remove', false)
+            'api.consent_remove' => new Feature('api.consent_remove', false),
+            'eb.feature_enable_consent' => new Feature('eb.feature_enable_consent', true),
         ]);
         $client->getContainer()->set('engineblock.features', $featureToggles);
     }
@@ -501,7 +502,8 @@ final class ConsentControllerTest extends WebTestCase
     private function disableConsentApiFeatureFor(Client $client)
     {
         $featureToggles = new FeatureConfiguration([
-            'api.consent_listing' => new Feature('api.consent_listing', false)
+            'api.consent_listing' => new Feature('api.consent_listing', false),
+            'eb.feature_enable_consent' => new Feature('eb.feature_enable_consent', false),
         ]);
         $container = $client->getContainer();
         $container->set('engineblock.features', $featureToggles);


### PR DESCRIPTION
Makes behaviour more explicit and does not expose code paths that are not needed.