### PR TITLE
Support LoA 1.5

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -236,13 +236,16 @@ parameters:
     ## The integer after the mapping field indicates the LoA level (1, 2 or 3 are supported).
     ## The engineblock or gateway keys specify the LoAs identifier as will be carried in the AuthnContextClassRef of an assertion.
     stepup.loa.mapping:
-        1:
+        10:
             engineblock: 'http://vm.openconext.org/assurance/loa1'
             gateway: 'http://stepup.vm.openconext.org/assurance/loa1'
-        2:
+        15:
+            engineblock: 'http://vm.openconext.org/assurance/loa1_5'
+            gateway: 'http://stepup.vm.openconext.org/assurance/loa1_5'
+        20:
             engineblock: 'http://vm.openconext.org/assurance/loa2'
             gateway: 'http://stepup.vm.openconext.org/assurance/loa2'
-        3:
+        30:
             engineblock: 'http://vm.openconext.org/assurance/loa3'
             gateway: 'http://stepup.vm.openconext.org/assurance/loa3'
     ## The fallback LoA to return when the Stepup authentication fails but is not required

--- a/src/OpenConext/EngineBlock/Metadata/Loa.php
+++ b/src/OpenConext/EngineBlock/Metadata/Loa.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2010 SURFnet B.V.
@@ -28,9 +28,10 @@ class Loa
     /**
      * The different levels
      */
-    const LOA_1 = 1;
-    const LOA_2 = 2;
-    const LOA_3 = 3;
+    const LOA_1 = 10;
+    const LOA_1_5 = 15;
+    const LOA_2 = 20;
+    const LOA_3 = 30;
 
     /**
      * @var int
@@ -42,15 +43,9 @@ class Loa
      */
     private $identifier;
 
-    /**
-     * @param int $level
-     * @param string $identifier
-     */
-    public static function create($level, $identifier)
+    public static function create(int $level, string $identifier)
     {
-        $possibleLevels = [self::LOA_1, self::LOA_2, self::LOA_3];
-
-        Assertion::integer($level, 'The LoA level must be an integer value');
+        $possibleLevels = [self::LOA_1, self::LOA_1_5, self::LOA_2, self::LOA_3];
         Assertion::inArray(
             $level,
             $possibleLevels,
@@ -66,28 +61,18 @@ class Loa
         return $loa;
     }
 
-    /**
-     * @param Loa $loa
-     * @return bool
-     */
-    public function levelIsHigherOrEqualTo(Loa $loa)
+    public function levelIsHigherOrEqualTo(Loa $loa): bool
     {
         $isHigherOrEqualTo = $this->level >= $loa->getLevel();
         return $isHigherOrEqualTo;
     }
 
-    /**
-     * @return int
-     */
-    public function getLevel()
+    public function getLevel(): int
     {
         return $this->level;
     }
 
-    /**
-     * @return string
-     */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }

--- a/src/OpenConext/EngineBlock/Metadata/Loa.php
+++ b/src/OpenConext/EngineBlock/Metadata/Loa.php
@@ -49,7 +49,7 @@ class Loa
         Assertion::inArray(
             $level,
             $possibleLevels,
-            sprintf('Please provide a valid level. Accpetable LoA levels are "%s"', implode(', ', $possibleLevels))
+            sprintf('Please provide a valid level. Acceptable LoA levels are "%s"', implode(', ', $possibleLevels))
         );
         Assertion::nonEmptyString($identifier, 'The LoA identifier must be of type string, and can not be empty');
 

--- a/src/OpenConext/EngineBlock/Metadata/LoaRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/LoaRepository.php
@@ -42,9 +42,10 @@ class LoaRepository
         foreach ($loaMapping as $level => $mapping) {
             Assertion::integer(
                 $level,
-                'The stepup.loa.mapping should be followed by an integer value, indicating the LoA level. ' .
-                'Example: stepup.loa.mapping.3'
+                'The stepup.loa.mapping should be keyed on an integer value, indicating the LoA level. ' .
+                'Example: 30 => [stepup.loa.mapping.3]'
             );
+
             Assertion::keysExist(
                 $mapping,
                 ['engineblock', 'gateway'],

--- a/src/OpenConext/EngineBlock/Stepup/StepupDecision.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupDecision.php
@@ -83,7 +83,7 @@ class StepupDecision
     {
         // If the highest level is 1, no step up callout is required.
         $isLoaAsked = $this->getStepupLoa();
-        if ($isLoaAsked && $isLoaAsked->getLevel() === 1) {
+        if ($isLoaAsked && $isLoaAsked->getLevel() === Loa::LOA_1) {
             return false;
         }
         return $isLoaAsked instanceof Loa;
@@ -92,7 +92,7 @@ class StepupDecision
     private function isLoaRequirementSet(): bool
     {
         // If the highest level is 1, no step up callout is requred.
-        if ($this->getStepupLoa() && $this->getStepupLoa()->getLevel() === 1) {
+        if ($this->getStepupLoa() && $this->getStepupLoa()->getLevel() === Loa::LOA_1) {
             return false;
         }
         return ($this->spLoa || $this->idpLoa || count($this->authnRequestLoas) > 0 || count($this->pdpLoas) > 0);

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -24,6 +24,17 @@ Feature:
       And I pass through EngineBlock
     Then the url should match "/functional-testing/SSO-SP/acs"
 
+  Scenario: LoA 1.5 (self-asserted token) should be supported
+     Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa1_5"
+      When I log in at "SSO-SP"
+       And I select "SSO-IdP" on the WAYF
+       And I pass through EngineBlock
+       And I pass through the IdP
+       And Stepup will successfully verify a user
+       And I give my consent
+       And I pass through EngineBlock
+      Then the url should match "/functional-testing/SSO-SP/acs"
+
     Scenario: Stepup authentication should be supported if set through IdP configuration mapping
       Given the IdP "SSO-IdP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2" for SP "SSO-SP"
       When I log in at "SSO-SP"

--- a/tests/unit/OpenConext/EngineBlock/Metadata/LoaRepositoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/LoaRepositoryTest.php
@@ -83,23 +83,26 @@ class LoaRepositoryTest extends TestCase
 
     private function getValidConfigAsArray()
     {
-        $validConfig = '{"1":{"engineblock":"http:\/\/vm.openconext.org\/assurance\/loa1","gateway":"https:\/\/gateway.tld\/authentication\/loa1"},"2":{"engineblock":"http:\/\/vm.openconext.org\/assurance\/loa2","gateway":"https:\/\/gateway.tld\/authentication\/loa2"},"3":{"engineblock":"http:\/\/vm.openconext.org\/assurance\/loa3","gateway":"https:\/\/gateway.tld\/authentication\/loa3"}}';
-        return json_decode($validConfig, true);
+        return [
+            10 => ["engineblock" => "http://vm.openconext.org/assurance/loa1", "gateway" => "https://gateway.tld/authentication/loa1"],
+            15 => ["engineblock" => "http://vm.openconext.org/assurance/loa1_5", "gateway" => "https://gateway.tld/authentication/loa1_5"],
+            20 => ["engineblock" => "http://vm.openconext.org/assurance/loa2", "gateway" => "https://gateway.tld/authentication/loa2"],
+            30 => ["engineblock" => "http://vm.openconext.org/assurance/loa3", "gateway" => "https://gateway.tld/authentication/loa3"]
+        ];
     }
 
     public function provideInvalidConfig()
     {
         return [
-            [['loa1' => ['engineblock' => 'loa1', 'gateway' => 'loa1']], 'The stepup.loa.mapping should be followed by an integer value, indicating the LoA level. Example: stepup.loa.mapping.3'],
-            [[1 => ['engineBlock' => 'loa1', 'gateway' => 'loa1']], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
-            [[1 => ['gateway' => 'loa1']], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
-            [[1 => []], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
-            [[2 => ['engineblock' => null, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
-            [[2 => ['engineblock' => 3, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
-            [[2 => ['engineblock' => false, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
-            [[3 => ['engineblock' => 'loa1', 'gateway' => null]], 'The Gateway LoA must be a string value'],
-            [[3 => ['engineblock' => 'loa1', 'gateway' => 4]], 'The Gateway LoA must be a string value'],
-            [[3 => ['engineblock' => 'loa1', 'gateway' => true]], 'The Gateway LoA must be a string value'],
+            [[10 => ['engineBlock' => 'loa1', 'gateway' => 'loa1']], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
+            [[10 => ['gateway' => 'loa1']], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
+            [[10 => []], 'Both the engineblock and gateway keys must be present in every LoA mapping.'],
+            [[20 => ['engineblock' => null, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
+            [[20 => ['engineblock' => 3, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
+            [[20 => ['engineblock' => false, 'gateway' => 'loa1']], 'The EngineBlock LoA must be a string value'],
+            [[30 => ['engineblock' => 'loa1', 'gateway' => null]], 'The Gateway LoA must be a string value'],
+            [[30 => ['engineblock' => 'loa1', 'gateway' => 4]], 'The Gateway LoA must be a string value'],
+            [[30 => ['engineblock' => 'loa1', 'gateway' => true]], 'The Gateway LoA must be a string value'],
         ];
     }
 }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/LoaTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/LoaTest.php
@@ -20,6 +20,7 @@ namespace OpenConext\EngineBlock\Metadata;
 
 use OpenConext\EngineBlock\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 class LoaTest extends TestCase
 {
@@ -43,12 +44,21 @@ class LoaTest extends TestCase
         $this->expectExceptionMessage($expectedException);
         Loa::create($level, $identifier);
     }
+    /**
+     * @dataProvider provideErrorneousLoaParameters
+     */
+    public function test_loa_errors($level, $identifier)
+    {
+        $this->expectException(TypeError::class);
+        Loa::create($level, $identifier);
+    }
 
     public function test_loa_can_be_compared_to_other_loa()
     {
-        $loa1 = Loa::create(1, 'https://vm.openconext.org/assurance/loa1');
-        $loa2 = Loa::create(2, 'https://vm.openconext.org/assurance/loa2');
-        $loa3 = Loa::create(3, 'https://vm.openconext.org/assurance/loa3');
+        $loa1 = Loa::create(10, 'https://vm.openconext.org/assurance/loa1');
+        $loa15 = Loa::create(15, 'https://vm.openconext.org/assurance/loa1_5');
+        $loa2 = Loa::create(20, 'https://vm.openconext.org/assurance/loa2');
+        $loa3 = Loa::create(30, 'https://vm.openconext.org/assurance/loa3');
 
         $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa3));
         $this->assertTrue($loa3->levelIsHigherOrEqualTo($loa2));
@@ -58,6 +68,11 @@ class LoaTest extends TestCase
         $this->assertTrue($loa2->levelIsHigherOrEqualTo($loa1));
         $this->assertFalse($loa2->levelIsHigherOrEqualTo($loa3));
 
+        $this->assertTrue($loa15->levelIsHigherOrEqualTo($loa1));
+        $this->assertTrue($loa15->levelIsHigherOrEqualTo($loa15));
+        $this->assertFalse($loa15->levelIsHigherOrEqualTo($loa2));
+        $this->assertFalse($loa15->levelIsHigherOrEqualTo($loa3));
+
         $this->assertTrue($loa1->levelIsHigherOrEqualTo($loa1));
         $this->assertFalse($loa1->levelIsHigherOrEqualTo($loa2));
         $this->assertFalse($loa1->levelIsHigherOrEqualTo($loa3));
@@ -66,34 +81,30 @@ class LoaTest extends TestCase
     public function provideValidLoaParameters()
     {
         return [
-            [1, 'https://vm.openconext.nl/loa1', 'A level 1 LoA'],
-            [2, 'https://vm.openconext.nl/loa2', 'A level 2 LoA'],
-            [3, 'https://vm.openconext.nl/loa3', 'A level 3 LoA'],
+            [10, 'https://vm.openconext.nl/loa1', 'A level 1 LoA'],
+            [15, 'https://vm.openconext.nl/loa1_5', 'A level 1.5 LoA'],
+            [20, 'https://vm.openconext.nl/loa2', 'A level 2 LoA'],
+            [30, 'https://vm.openconext.nl/loa3', 'A level 3 LoA'],
         ];
     }
 
     public function provideInvalidLoaParameters()
     {
         return [
-            ['1', 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
-            [null, 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
-            [false, 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
-            [1.5, 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
-            [[1], 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
+            [0, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "10, 15, 20, 30"'],
+            [-1, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "10, 15, 20, 30"'],
+            [4, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "10, 15, 20, 30"'],
+
+            [10, '', 'The LoA identifier must be of type string, and can not be empty'],
+        ];
+    }
+
+    public function provideErrorneousLoaParameters()
+    {
+        return [
             [9999999999999999999999999999, 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
-
             [new \stdClass(), 'https://vm.openconext.nl/loa1', 'The LoA level must be an integer value'],
-            [0, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "1, 2, 3"'],
-            [-1, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "1, 2, 3"'],
-            [4, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "1, 2, 3"'],
-
-            [1, '', 'The LoA identifier must be of type string, and can not be empty'],
-            [1, 1, 'The LoA identifier must be of type string, and can not be empty'],
-            [1, -1, 'The LoA identifier must be of type string, and can not be empty'],
-            [1, 1.1, 'The LoA identifier must be of type string, and can not be empty'],
-            [1, false, 'The LoA identifier must be of type string, and can not be empty'],
-            [1, true, 'The LoA identifier must be of type string, and can not be empty'],
-            [1, ['https://vm.openconext.nl/loa1'], 'The LoA identifier must be of type string, and can not be empty'],
+            [10, ['https://vm.openconext.nl/loa1'], 'The LoA identifier must be of type string, and can not be empty'],
         ];
     }
 }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/LoaTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/LoaTest.php
@@ -91,9 +91,9 @@ class LoaTest extends TestCase
     public function provideInvalidLoaParameters()
     {
         return [
-            [0, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "10, 15, 20, 30"'],
-            [-1, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "10, 15, 20, 30"'],
-            [4, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Accpetable LoA levels are "10, 15, 20, 30"'],
+            [0, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Acceptable LoA levels are "10, 15, 20, 30"'],
+            [-1, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Acceptable LoA levels are "10, 15, 20, 30"'],
+            [4, 'https://vm.openconext.nl/loa1', 'Please provide a valid level. Acceptable LoA levels are "10, 15, 20, 30"'],
 
             [10, '', 'The LoA identifier must be of type string, and can not be empty'],
         ];

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
@@ -91,7 +91,7 @@ class StepupDecisionTest extends TestCase
             $repo
                 ->shouldReceive('getByIdentifier')
                 ->with($input[1])
-                ->andReturn(Loa::create((int)substr($input[1],-1), $input[1]))
+                ->andReturn(Loa::create((int)substr($input[1],-2), $input[1]))
             ;
         }
 
@@ -100,7 +100,7 @@ class StepupDecisionTest extends TestCase
             $repo
                 ->shouldReceive('getByIdentifier')
                 ->with($input[0])
-                ->andReturn(Loa::create((int)substr($input[0],-1), $input[0]))
+                ->andReturn(Loa::create((int)substr($input[0],-2), $input[0]))
             ;
         }
 
@@ -109,7 +109,7 @@ class StepupDecisionTest extends TestCase
                 $repo
                     ->shouldReceive('getByIdentifier')
                     ->with($loa)
-                    ->andReturn(Loa::create((int)substr($loa,-1), $loa))
+                    ->andReturn(Loa::create((int)substr($loa,-2), $loa))
                  ;
             }
         }
@@ -121,32 +121,32 @@ class StepupDecisionTest extends TestCase
         return [
             'Use no stepup if no coins set for IdP and SP (do not allow no stepup)' => [[null, null, [], [], false], [false, '', false]],
             'Use no stepup if coins empty for IdP and SP (do not allow no stepup)' => [['', '', [], [], false], [false, '', false]],
-            'Use SP LoA if only SP LoA set (do not allow no stepup)' => [['loa2', '', [], [], false], [true, 'loa2', false]],
-            'Use IdP LoA if only IdP LoA set (do not allow no stepup)' => [['', 'loa3', [], [], false], [true, 'loa3', false]],
+            'Use SP LoA if only SP LoA set (do not allow no stepup)' => [['loa20', '', [], [], false], [true, 'loa20', false]],
+            'Use IdP LoA if only IdP LoA set (do not allow no stepup)' => [['', 'loa30', [], [], false], [true, 'loa30', false]],
 
             'Use no stepup if no coins set for IdP and SP (allow no stepup)' => [[null, null, [], [], true], [false, '', false]],
             'Use no stepup if coins empty for IdP and SP (allow no stepup)' => [['', '', [], [], true], [false, '', false]],
-            'Use SP LoA if only SP LoA set (allow no stepup)' => [['loa2', '', [], [], true], [true, 'loa2', true]],
-            'Use IdP LoA if only IdP LoA set (allow no stepup)' => [['', 'loa3', [], [], true], [true, 'loa3', true]],
+            'Use SP LoA if only SP LoA set (allow no stepup)' => [['loa20', '', [], [], true], [true, 'loa20', true]],
+            'Use IdP LoA if only IdP LoA set (allow no stepup)' => [['', 'loa30', [], [], true], [true, 'loa30', true]],
 
-            'Use SP LoA if SP LoA is higest (allow no stepup)' => [['loa3', 'loa2', [], [], true], [true, 'loa3', true]],
-            'Use IdP LoA if IdP LoA is highest (allow no stepup)' => [['loa2', 'loa3', [], [], true], [true, 'loa3', true]],
+            'Use SP LoA if SP LoA is highest (allow no stepup)' => [['loa30', 'loa20', [], [], true], [true, 'loa30', true]],
+            'Use IdP LoA if IdP LoA is highest (allow no stepup)' => [['loa20', 'loa30', [], [], true], [true, 'loa30', true]],
 
-            'Use PdP LoA if SP LoA and PdP LoA set and PDP LoA is highest (allow no stepup)' => [['loa2', '', [], ['loa3'], true], [true, 'loa3', true]],
-            'Use IdP LoA if IdP LoA is highest and PdP LoA set (allow no stepup)' => [['', 'loa3', [], ['loa2'], true], [true, 'loa3', true]],
-            'Use PdP LoA if PdP LoA set (allow no stepup)' => [['', '', [], ['loa3'], true], [true, 'loa3', true]],
-            'Use highest PdP LoA if multiple PdP LoA set (allow no stepup)' => [['', '', [], ['loa3', 'loa2'], true], [true, 'loa3', true]],
-            'Use highest PdP LoA if multiple PdP LoA set in different order (allow no stepup)' => [['', '', [], ['loa3', 'loa2'], true], [true, 'loa3', true]],
+            'Use PdP LoA if SP LoA and PdP LoA set and PDP LoA is highest (allow no stepup)' => [['loa20', '', [], ['loa30'], true], [true, 'loa30', true]],
+            'Use IdP LoA if IdP LoA is highest and PdP LoA set (allow no stepup)' => [['', 'loa30', [], ['loa20'], true], [true, 'loa30', true]],
+            'Use PdP LoA if PdP LoA set (allow no stepup)' => [['', '', [], ['loa30'], true], [true, 'loa30', true]],
+            'Use highest PdP LoA if multiple PdP LoA set (allow no stepup)' => [['', '', [], ['loa30', 'loa20'], true], [true, 'loa30', true]],
+            'Use highest PdP LoA if multiple PdP LoA set in different order (allow no stepup)' => [['', '', [], ['loa30', 'loa20'], true], [true, 'loa30', true]],
 
-            'Allow AuthnRequest (SP) LoA1, but take no action' => [['', '', [$this->buildLoa('loa1')], [], true], [false, 'loa1', false]],
-            'Use AuthnRequest (SP) LoA if SP LoA is lower' => [['loa2', '', [$this->buildLoa('loa3')], [], true], [true, 'loa3', true]],
-            'Use IdP LoA if IdP LoA is highest and AuthnRequest (SP) LoA set (allow no stepup)' => [['', 'loa3', [$this->buildLoa('loa2')], [], true], [true, 'loa3', true]],
-            'Use PdP LoA if  AuthnRequest (SP) LoA set (allow no stepup)' => [['', '', [$this->buildLoa('loa3')], [], true], [true, 'loa3', true]],
-            'Use highest AuthnRequest (SP) LoA if multiple LoA set (allow no stepup)' => [['', '', [$this->buildLoa('loa3'), $this->buildLoa('loa2')], [], true], [true, 'loa3', true]],
-            'Use highest AuthnRequest (SP) LoA if multiple LoA set (authn + pdp) in different order (allow no stepup)' => [['', '', [$this->buildLoa('loa2'), $this->buildLoa('loa3')], ['loa2'], true], [true, 'loa3', true]],
+            'Allow AuthnRequest (SP) LoA1, but take no action' => [['', '', [$this->buildLoa('loa10')], [], true], [false, 'loa10', false]],
+            'Use AuthnRequest (SP) LoA if SP LoA is lower' => [['loa20', '', [$this->buildLoa('loa30')], [], true], [true, 'loa30', true]],
+            'Use IdP LoA if IdP LoA is highest and AuthnRequest (SP) LoA set (allow no stepup)' => [['', 'loa30', [$this->buildLoa('loa20')], [], true], [true, 'loa30', true]],
+            'Use PdP LoA if  AuthnRequest (SP) LoA set (allow no stepup)' => [['', '', [$this->buildLoa('loa30')], [], true], [true, 'loa30', true]],
+            'Use highest AuthnRequest (SP) LoA if multiple LoA set (allow no stepup)' => [['', '', [$this->buildLoa('loa30'), $this->buildLoa('loa20')], [], true], [true, 'loa30', true]],
+            'Use highest AuthnRequest (SP) LoA if multiple LoA set (authn + pdp) in different order (allow no stepup)' => [['', '', [$this->buildLoa('loa20'), $this->buildLoa('loa30')], ['loa20'], true], [true, 'loa30', true]],
 
-            'Use highest LoA from many options (allow no stepup)' => [['loa2', 'loa3', [], ['loa2', 'loa2', 'loa3'], true], [true, 'loa3', true]],
-            'Use highest LoA from many different options (allow no stepup)' => [['loa3', 'loa2', [$this->buildLoa('loa2'), $this->buildLoa('loa2'), $this->buildLoa('loa3')], [], true], [true, 'loa3', true]],
+            'Use highest LoA from many options (allow no stepup)' => [['loa20', 'loa30', [], ['loa20', 'loa20', 'loa30'], true], [true, 'loa30', true]],
+            'Use highest LoA from many different options (allow no stepup)' => [['loa30', 'loa20', [$this->buildLoa('loa20'), $this->buildLoa('loa20'), $this->buildLoa('loa30')], [], true], [true, 'loa30', true]],
        ];
     }
 

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupGatewayLoaMappingTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupGatewayLoaMappingTest.php
@@ -38,29 +38,29 @@ class StepupGatewayLoaMappingTest extends TestCase
     public function the_stepup_loa_mapping_object_should_be_successful_populated()
     {
         $mapping = [
-            1 => [
+            10 => [
                 'engineblock' => 'ebLoa1',
                 'gateway' => 'gatewayLoa1',
             ],
-            2 => [
+            20 => [
                 'engineblock' => 'ebLoa2',
                 'gateway' => 'gatewayLoa2',
             ],
         ];
 
-        $ebLoa1 = Loa::create(1, 'ebLoa1');
-        $ebLoa2 = Loa::create(2, 'ebLoa2');
+        $ebLoa1 = Loa::create(10, 'ebLoa1');
+        $ebLoa2 = Loa::create(20, 'ebLoa2');
 
         $loaRepository = m::mock(LoaRepository::class);
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa1')
-            ->andReturn(Loa::create(1, 'gatewayLoa1'));
+            ->andReturn(Loa::create(10, 'gatewayLoa1'));
 
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa2')
-            ->andReturn(Loa::create(2, 'gatewayLoa2'));
+            ->andReturn(Loa::create(20, 'gatewayLoa2'));
 
         $loaRepository
             ->shouldReceive('getByIdentifier')
@@ -81,8 +81,7 @@ class StepupGatewayLoaMappingTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to find the EngineBlock LoA in the configured stepup LoA mapping');
 
-        $stepupLoaMapping->transformToGatewayLoa(Loa::create(2, 'loa2'));
-
+        $stepupLoaMapping->transformToGatewayLoa(Loa::create(20, 'loa2'));
     }
 
     /**
@@ -92,28 +91,28 @@ class StepupGatewayLoaMappingTest extends TestCase
     public function the_stepup_loa_mapping_object_should_successful_map_back()
     {
         $mapping = [
-            1 => [
+            10 => [
                 'engineblock' => 'ebLoa1',
                 'gateway' => 'gatewayLoa1',
             ],
-            2 => [
+            20 => [
                 'engineblock' => 'ebLoa2',
                 'gateway' => 'gatewayLoa2',
             ],
-            3 => [
+            30 => [
                 'engineblock' => 'ebLoa3',
                 'gateway' => 'gatewayLoa3',
             ],
         ];
 
-        $gwLoa2 = Loa::create(2, 'gatewayLoa2');
-        $gwLoa3 = Loa::create(3, 'gatewayLoa3');
+        $gwLoa2 = Loa::create(20, 'gatewayLoa2');
+        $gwLoa3 = Loa::create(30, 'gatewayLoa3');
 
         $loaRepository = m::mock(LoaRepository::class);
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa1')
-            ->andReturn(Loa::create(1, 'gatewayLoa1'));
+            ->andReturn(Loa::create(10, 'gatewayLoa1'));
 
         $loaRepository
             ->shouldReceive('getByIdentifier')
@@ -128,17 +127,17 @@ class StepupGatewayLoaMappingTest extends TestCase
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('ebLoa1')
-            ->andReturn(Loa::create(1, 'ebLoa1'));
+            ->andReturn(Loa::create(10, 'ebLoa1'));
 
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('ebLoa2')
-            ->andReturn(Loa::create(2, 'ebLoa2'));
+            ->andReturn(Loa::create(20, 'ebLoa2'));
 
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('ebLoa3')
-            ->andReturn(Loa::create(3, 'ebLoa3'));
+            ->andReturn(Loa::create(30, 'ebLoa3'));
 
         $stepupLoaMapping = new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
 
@@ -153,7 +152,7 @@ class StepupGatewayLoaMappingTest extends TestCase
     public function the_stepup_loa_mapping_object_should_return_an_exception_when_unable_to_map_back()
     {
         $mapping = [
-            3 => [
+            30 => [
                 'engineblock' => 'ebLoa3',
                 'gateway' => 'gatewayLoa3',
             ],
@@ -164,24 +163,24 @@ class StepupGatewayLoaMappingTest extends TestCase
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa1')
-            ->andReturn(Loa::create(1, 'gatewayLoa1'));
+            ->andReturn(Loa::create(10, 'gatewayLoa1'));
 
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa3')
-            ->andReturn(Loa::create(3, 'gatewayLoa3'));
+            ->andReturn(Loa::create(30, 'gatewayLoa3'));
 
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('ebLoa3')
-            ->andReturn(Loa::create(3, 'ebLoa3'));
+            ->andReturn(Loa::create(30, 'ebLoa3'));
 
         $stepupLoaMapping = new StepupGatewayLoaMapping($mapping, 'gatewayLoa1', $loaRepository);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to find the received stepup LoA in the configured EngineBlock LoA');
 
-        $stepupLoaMapping->transformToEbLoa(Loa::create(2, 'loa2'));
+        $stepupLoaMapping->transformToEbLoa(Loa::create(20, 'loa2'));
     }
 
     /**
@@ -191,11 +190,11 @@ class StepupGatewayLoaMappingTest extends TestCase
     public function the_mapping_must_be_valid_no_duplicates_allowed()
     {
         $mapping = [
-            1 => [
+            10 => [
                 'engineblock' => 'ebLoa1',
                 'gateway' => 'gatewayLoa1',
             ],
-            2 => [
+            20 => [
                 'engineblock' => 'ebLoa1',
                 'gateway' => 'gatewayLoa2',
             ]
@@ -205,15 +204,15 @@ class StepupGatewayLoaMappingTest extends TestCase
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa1')
-            ->andReturn(Loa::create(1, 'gatewayLoa1'));
+            ->andReturn(Loa::create(10, 'gatewayLoa1'));
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa2')
-            ->andReturn(Loa::create(2, 'gatewayLoa2'));
+            ->andReturn(Loa::create(20, 'gatewayLoa2'));
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('ebLoa1')
-            ->andReturn(Loa::create(1, 'ebLoa1'));
+            ->andReturn(Loa::create(10, 'ebLoa1'));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Found a duplicate EngineBlock LoA identifier, this is not allowed.');
@@ -227,11 +226,11 @@ class StepupGatewayLoaMappingTest extends TestCase
     public function the_mapping_must_be_valid_no_duplicates_in_gw_config_allowed()
     {
         $mapping = [
-            1 => [
+            10 => [
                 'engineblock' => 'ebLoa1',
                 'gateway' => 'gatewayLoa2',
             ],
-            2 => [
+            20 => [
                 'engineblock' => 'ebLoa2',
                 'gateway' => 'gatewayLoa2',
             ]
@@ -241,19 +240,19 @@ class StepupGatewayLoaMappingTest extends TestCase
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa1')
-            ->andReturn(Loa::create(1, 'gatewayLoa1'));
+            ->andReturn(Loa::create(10, 'gatewayLoa1'));
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('gatewayLoa2')
-            ->andReturn(Loa::create(2, 'gatewayLoa2'));
+            ->andReturn(Loa::create(20, 'gatewayLoa2'));
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('ebLoa1')
-            ->andReturn(Loa::create(1, 'ebLoa1'));
+            ->andReturn(Loa::create(10, 'ebLoa1'));
         $loaRepository
             ->shouldReceive('getByIdentifier')
             ->with('ebLoa2')
-            ->andReturn(Loa::create(2, 'ebLoa2'));
+            ->andReturn(Loa::create(20, 'ebLoa2'));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Found a duplicate Gateway LoA identifier, this is not allowed.');


### PR DESCRIPTION
The config changed slightly to support loa 1.5. The array keys indicating the numeric portion of a loa (1, 1.5, 2 and 3) used to be an integer value. Well the index is now still integer, but multiplied by 10. This to support loa 1.5 (translate to 15 now)

Tests have been updated and extended with the new 1.5 loa.

The Loa and LoaRepository classes have been made more type-strict.

See: https://www.pivotaltracker.com/story/show/182769301