### PR TITLE
Remove broken sorting code

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -523,13 +523,6 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             $wayfIdps[] = $wayfIdp;
         }
 
-        $nameSort = function ($a, $b) use ($currentLocale) {
-            return strtolower($a['Name_' . $currentLocale]) > strtolower($b['Name_' . $currentLocale]);
-        };
-
-        // Sort the IdP entries by name
-        usort($wayfIdps, $nameSort);
-
         return $wayfIdps;
     }
 


### PR DESCRIPTION
The sorting is already done in [Twig](https://github.com/OpenConext/OpenConext-engineblock/blob/master/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/remainingIdps.html.twig#L11)

Also fixes:

```
app.ERROR: Undefined index: Name_nl [/apps/installation/OpenConext-engineblock/OpenConext-engineblock-6.9.0/library/EngineBlock/Corto/Module/Service/SingleSignOn.php:527
```