### PR TITLE
GHA: Remove xdebug from the FPM images

### DIFF
--- a/docker/php-fpm/Dockerfile-php72
+++ b/docker/php-fpm/Dockerfile-php72
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     && docker-php-ext-install pdo_mysql exif gd \
     ## APCu
-    && pecl install xdebug \
     && pecl install apcu \
     && pecl install apcu_bc-1.0.3 \
     && docker-php-ext-enable apcu --ini-name 10-docker-php-ext-apcu.ini \

--- a/docker/php-fpm/Dockerfile-php74
+++ b/docker/php-fpm/Dockerfile-php74
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     && docker-php-ext-install pdo_mysql exif gd \
     ## APCu
-    && pecl install xdebug \
     && pecl install apcu \
     && pecl install apcu_bc-1.0.3 \
     && docker-php-ext-enable apcu --ini-name 10-docker-php-ext-apcu.ini \


### PR DESCRIPTION
xdebug is not needed during integration tests, and pecl will no longer install the latest version as the olders supported php version is 8.0. Since xdebug is not needed, it's better to remove it all together.