### PR TITLE
Log in log_logins if IDPList has been used

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/LogLogin.php
+++ b/library/EngineBlock/Corto/Filter/Command/LogLogin.php
@@ -56,7 +56,8 @@ class EngineBlock_Corto_Filter_Command_LogLogin extends EngineBlock_Corto_Filter
             $requesterChain,
             $this->_response->getNameIdValue(),
             $this->_response->getAssertion()->getAuthnContextClassRef(),
-            $this->_request->getDestination()
+            $this->_request->getDestination(),
+            $this->_request->getIDPList()
         );
     }
 }

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -401,8 +401,9 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             return array($presetIdP);
         }
 
-        // Add scoped IdPs (allowed IDPs for reply) from request to allowed IdPs for responding
-        $log->info('Request lists scoped IdPs', array('request_idps' => $scopedIdPs));
+        if (count($scopedIdPs) > 0) {
+            $log->info('Request lists scoped IdPs', ['request_idps' => $scopedIdPs]);
+        }
 
         return $scopedIdPs;
     }

--- a/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
+++ b/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
@@ -42,6 +42,8 @@ class AuthenticationLogger
     /**
      * KeyId is nullable in order to be able to differentiate between asking no specific key,
      * the default key KeyId('default') and a specific key.
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function logGrantedLogin(
         Entity $serviceProvider,
@@ -52,6 +54,7 @@ class AuthenticationLogger
         string $originalNameId,
         ?string $authnContextClassRef,
         ?string $engineSsoEndpointUsed,
+        ?array $requestedIdPlist,
         KeyId $keyId = null
     ) {
         $proxiedServiceProviderEntityIds = array_map(
@@ -75,6 +78,7 @@ class AuthenticationLogger
                 'workflow_state' => $workflowState,
                 'original_name_id' => $originalNameId,
                 'authncontextclassref' => $authnContextClassRef,
+                'requestedidps' => $requestedIdPlist,
                 'engine_sso_endpoint_used' => $engineSsoEndpointUsed,
             ]
         );

--- a/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
+++ b/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
@@ -47,7 +47,8 @@ class AuthenticationLoggerAdapter
         array $proxiedServiceProviders,
         string $originalNameId,
         ?string $authnContextClassRef,
-        ?string $engineSsoEndpointUsed
+        ?string $engineSsoEndpointUsed,
+        ?array $requestedIdPlist
     ) {
         $keyId = $keyId ? new KeyId($keyId) : null;
 
@@ -67,6 +68,7 @@ class AuthenticationLoggerAdapter
             $originalNameId,
             $authnContextClassRef,
             $engineSsoEndpointUsed,
+            $requestedIdPlist,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
@@ -55,7 +55,8 @@ class AuthenticationLoggerTest extends TestCase
         $spProxy2EntityId         = 'SpProxy2EntityId';
         $originalNameId           = 'urn:collab:person:original:some-person';
         $authnContextClassRef     = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
-        $ssoEndpointUsed = '/authentication/idp/single-sign-on';
+        $requestedIdPs            = ['aap', 'noot'];
+        $ssoEndpointUsed          = '/authentication/idp/single-sign-on';
 
         $serviceProvider       = new Entity(new EntityId($serviceProviderEntityId), EntityType::SP());
         $identityProvider      = new Entity(new EntityId($identityProviderEntityId), EntityType::IdP());
@@ -74,6 +75,7 @@ class AuthenticationLoggerTest extends TestCase
             'workflow_state' => AbstractRole::WORKFLOW_STATE_PROD,
             'original_name_id' => $originalNameId,
             'authncontextclassref' => $authnContextClassRef,
+            'requestedidps' => $requestedIdPs,
             'engine_sso_endpoint_used' => $ssoEndpointUsed
         ];
 
@@ -116,6 +118,7 @@ class AuthenticationLoggerTest extends TestCase
             $originalNameId,
             $authnContextClassRef,
             $ssoEndpointUsed,
+            $requestedIdPs,
             $keyId
         );
     }

--- a/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
@@ -54,7 +54,8 @@ class AuthenticationLoggerAdapterTest extends TestCase
         $spProxy2EntityId         = 'SpProxy2EntityId';
         $originalNameId           = 'urn:collab:person:original:some-person';
         $authnContextClassRef     = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
-        $ssoEndpointUsed = '/authentication/idp/single-sign-on';
+        $requestedIdPs            = ['aap', 'noot'];
+        $ssoEndpointUsed          = '/authentication/idp/single-sign-on';
 
         $mockAuthenticationLogger = m::mock(AuthenticationLogger::class);
         $mockAuthenticationLogger
@@ -76,6 +77,7 @@ class AuthenticationLoggerAdapterTest extends TestCase
                     $originalNameId,
                     $authnContextClassRef,
                     $ssoEndpointUsed,
+                    $requestedIdPs,
                     new ValueObjectEqualsMatcher(new KeyId($keyIdValue)),
                 ]
             )
@@ -93,7 +95,8 @@ class AuthenticationLoggerAdapterTest extends TestCase
             ],
             $originalNameId,
             $authnContextClassRef,
-            $ssoEndpointUsed
+            $ssoEndpointUsed,
+            $requestedIdPs
         );
     }
 }


### PR DESCRIPTION
Logline now has new `requestedidps` key. In prettyprinted form (but of course usually a single logline):

```json
{
   "channel" : "authentication",
   "context" : {
      "authncontextclassref" : "urn:thijs:voorbeeld",
      "engine_sso_endpoint_used" : "https://engine.test2.surfconext.nl/authentication/idp/single-sign-on",
      "idp_entity_id" : "http://mock-idp/",
      "key_id" : null,
      "login_stamp" : "2023-01-11T16:26:09.899430+01:00",
      "original_name_id" : "1a929a9cd49b901a497ac320152aa1cef6d542c9",
      "proxied_sp_entity_ids" : [],
      "requestedidps" : [
         "aap",
         "noot",
         "http://mock-idp/"
      ],
      "sp_entity_id" : "urn:thki:sid:ee1",
      "user_id" : "urn:collab:person:example.com:thijs",
      "workflow_state" : "prodaccepted"
   },
   "extra" : {
      "request_id" : "63bed511c8bd1",
      "session_id" : "c6crks94rcn88cub6kvm4cel39"
   },
   "level" : "INFO",
   "message" : "login granted"
}
```