### PR TITLE
Limit value length of metadata fields to max 255 chars.

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -162,7 +162,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
      */
     private function limitValueLength(string $value): string
     {
-        if(strlen($value) < self::FIELDS_MAX_LENGTH) {
+        if (strlen($value) < self::FIELDS_MAX_LENGTH) {
             return $value;
         }
         $this->logger->info(sprintf("Push Metadata Assembler: truncating too long value: '%s'", $value));

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -434,7 +434,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         ));
     }
 
-    private function setPathFromObjectString($from, $to, $limitlength = false)
+    private function setPathFromObjectString(array $from, string $to, bool $limitlength = false): array
     {
         $reference = $this->getValueFromPath($from);
         if (is_null($reference)) {
@@ -446,7 +446,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         return array($to => (string)$reference);
     }
 
-    private function setPathFromObjectArray($from, $to)
+    private function setPathFromObjectArray(array $from, string $to): array
     {
         $reference = $this->getValueFromPath($from);
         if (!array($reference)) {
@@ -455,7 +455,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         return array($to => $reference);
     }
 
-    private function setPathFromObjectBool($from, $to)
+    private function setPathFromObjectBool(array $from, string $to): array
     {
         $reference = $this->getValueFromPath($from);
         if (is_null($reference)) {
@@ -464,7 +464,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         return array($to => (bool)$reference);
     }
 
-    private function getValueFromPath($from)
+    private function getValueFromPath(array $from)
     {
         $pathParts = explode(':', $from[1]);
 

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -35,6 +35,7 @@ use OpenConext\EngineBlock\Metadata\Utils;
 use OpenConext\EngineBlock\Metadata\X509\X509CertificateFactory;
 use OpenConext\EngineBlock\Metadata\X509\X509CertificateLazyProxy;
 use OpenConext\EngineBlock\Validator\ValidatorInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use stdClass;
 
@@ -49,13 +50,19 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
     private $allowedAcsLocationsValidator;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Maximum length that will fit in certain string type fields.
      */
     private const FIELDS_MAX_LENGTH = 255;
 
-    public function __construct(ValidatorInterface $allowedAcsLocations)
+    public function __construct(ValidatorInterface $allowedAcsLocations, LoggerInterface $logger)
     {
         $this->allowedAcsLocationsValidator = $allowedAcsLocations;
+        $this->logger = $logger;
     }
 
     public function assemble($connections)
@@ -155,6 +162,10 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
      */
     private function limitValueLength(string $value): string
     {
+        if(strlen($value) < self::FIELDS_MAX_LENGTH) {
+            return $value;
+        }
+        $this->logger->info(sprintf("Push Metadata Assembler: truncating too long value: '%s'", $value));
         return mb_strcut($value, 0, self::FIELDS_MAX_LENGTH);
     }
 

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -162,7 +162,6 @@ services:
             - '@OpenConext\EngineBlock\Xml\MetadataRenderer'
             - '@engineblock.factory.service_provider_factory'
             - '@engineblock.factory.identity_provider_factory'
-            - '@OpenConext\EngineBlock\Metadata\X509\KeyPairFactory'
             - '@engineblock.metadata.repository.idps_metadata'
             - '@engineblock.configuration.stepup.endpoint'
 

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -162,6 +162,7 @@ services:
             - '@OpenConext\EngineBlock\Xml\MetadataRenderer'
             - '@engineblock.factory.service_provider_factory'
             - '@engineblock.factory.identity_provider_factory'
+            - '@OpenConext\EngineBlock\Metadata\X509\KeyPairFactory'
             - '@engineblock.metadata.repository.idps_metadata'
             - '@engineblock.configuration.stepup.endpoint'
 
@@ -281,6 +282,7 @@ services:
         class: OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler
         arguments:
             - "@engineblock.validator.allowed_scheme_validator"
+            - "@engineblock.compat.logger"
 
     OpenConext\EngineBlock\Metadata\X509\KeyPairFactory:
         arguments:

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -18,6 +18,8 @@
 
 namespace OpenConext\EngineBlock\Tests;
 
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
@@ -27,14 +29,18 @@ use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
 use OpenConext\EngineBlock\Validator\AllowedSchemeValidator;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Psr\Log\LoggerInterface;
 
 class PushMetadataAssemblerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     private $assembler;
 
     public function setUp()
     {
-        $this->assembler = new PushMetadataAssembler(new AllowedSchemeValidator(['http', 'https']));
+        $logger = m::mock(LoggerInterface::class);
+        $this->assembler = new PushMetadataAssembler(new AllowedSchemeValidator(['http', 'https']), $logger);
     }
 
     /**


### PR DESCRIPTION
The current database scheme has varchar(255) for several metadata types. Traditionally, MySQL would just truncate silently any too long values. Modern installations have strict mode enabled which instead generates a justified error. To make EB usable in this configuration, limit the length of some fields that (a) have a trend to sometimes be long, (b) which can be truncated without real loss.

One could consider to enlarge columns but as far as I'm aware description is not used and 255 chars of keywords should be enough for everyone. So for now lets keep it to this simple fix.