### PR TITLE
Clear error unknown keyid

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -176,6 +176,8 @@ HTML
     'error_invalid_acs_binding_desc'     => 'The provided or configured "Assertion Consumer Service" Binding Type is unknown or invalid.',
     'error_unsupported_signature_method' => 'Error - Signature method is not supported',
     'error_unsupported_signature_method_desc' => 'The signature method %arg1% is not supported, please upgrade to RSA-SHA256 (http://www.w3.org/2001/04/xmldsig-more#rsa-sha256).',
+    'error_unknown_keyid' => 'Error - unknown key id',
+    'error_unknown_keyid_desc' => 'The requested key-ID is not known to %suiteName%. Perhaps the service provider is using outdated metadata or has a configuration error.',
     'error_unknown_preselected_idp' => 'Error - %spName% not accessible through your %organisationNoun%',
     'error_unknown_preselected_idp_no_sp_name' => 'Error - Service not accessible through your %organisationNoun%',
     'error_unknown_preselected_idp_desc' => 'The %organisationNoun% that you want to use to login to %spName% did not activate access to it. This means you are unable to use %spName% through %suiteName%. Please contact the service desk of your %organisationNoun% to request access. State it is about %spName% and why you need access.',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -175,6 +175,8 @@ HTML
     'error_invalid_acs_binding_desc'        => 'Het opgegeven of geconfigureerde "Assertion Consumer Service" Binding Type is onjuist of bestaat niet.',
     'error_unsupported_signature_method' => 'Fout - Ondertekeningsmethode wordt niet ondersteund',
     'error_unsupported_signature_method_desc' => 'De ondertekeningsmethode %arg1% wordt niet ondersteund, upgrade naar RSA-SHA256 (http://www.w3.org/2001/04/xmldsig-more#rsa-sha256).',
+    'error_unknown_keyid' => 'Fout - onbekend key-ID',
+    'error_unknown_keyid_desc' => 'De gevraagde key-ID is niet bekend bij %suiteName%. Wellicht gebruikt de service provider achterhaalde metadata of is er sprake van een andere configuratiefout.',
     'error_unknown_preselected_idp' => 'Fout - %spName% niet toegankelijk via %organisationNoun%',
     'error_unknown_preselected_idp_no_sp_name' => 'Fout - Dienst niet toegankelijk via %organisationNoun%',
     'error_unknown_preselected_idp_desc' => 'De %organisationNoun% waarmee je wilt inloggen heeft toegang tot %spName% niet geactiveerd. Dat betekent dat jij geen gebruik kunt maken van deze dienst via %suiteName%. Neem contact op met de helpdesk van jouw %organisationNoun% als je toegang wilt krijgen tot %spName%. Geef daarbij aan dat het om %spName% gaat en waarom je toegang wilt.',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -176,6 +176,8 @@ HTML
     'error_invalid_acs_binding_desc'     => 'O "Binding Type" do "Serviço de Consumidor de Asserção" fornecido ou configurado é desconhecido ou inválido.',
     'error_unsupported_signature_method' => 'O método de assinatura não é suportado',
     'error_unsupported_signature_method_desc' => 'O método de assinatura %arg1% não é suportado, faça upgrade para RSA-SHA256 (http://www.w3.org/2001/04/xmldsig-more#rsa-sha256).',
+    'error_unknown_keyid' => 'Error - unknown key id',
+    'error_unknown_keyid_desc' => 'The requested key-ID is not known to %suiteName%. Perhaps the service provider is using outdated metadata or has a configuration error.',
     'error_unknown_preselected_idp' => 'Erro - Não há ligação entre %organisationNoun% e o serviço',
     'error_unknown_preselected_idp_no_sp_name' => 'Erro - Não há ligação entre %organisationNoun% e o serviço',
     'error_unknown_preselected_idp_desc' => 'A %organisationNoun% que pretende utilizar para se autenticar e aceder ao serviço, não tem activado o acesso a este serviço. Isto significa que não pode aceder a este serviço através da %suiteName%. Entre em contacto com com o suporte da sua %organisationNoun% para solicitar o acesso a este serviço. Declare que serviço se trata (o &lsquo;Fornecedor de Serviço&rsquo;) e porque necessita do acesso.',

--- a/library/EngineBlock/Corto/Exception/UnknownKeyId.php
+++ b/library/EngineBlock/Corto/Exception/UnknownKeyId.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class EngineBlock_Corto_Exception_UnknownKeyId extends EngineBlock_Exception
+{
+    private $_requestedKeyId;
+
+    public function __construct($requestedKeyId)
+    {
+        $message = sprintf("Unknown key id '%s'", $requestedKeyId);
+        parent::__construct($message, self::CODE_NOTICE);
+        $this->_requestedKeyId = $requestedKeyId;
+    }
+
+    public function getRequestedKeyId(): string
+    {
+        return $this->_requestedKeyId;
+    }
+}

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -310,9 +310,7 @@ class EngineBlock_Corto_ProxyServer
         }
 
         if (!isset($this->_keyPairs[$keyId])) {
-            throw new EngineBlock_Corto_ProxyServer_Exception(
-                sprintf('Unknown key id "%s"', $keyId)
-            );
+            throw new EngineBlock_Corto_Exception_UnknownKeyId($keyId);
         }
         return $this->_keyPairs[$keyId];
     }

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -26,6 +26,7 @@ use OpenConext\EngineBlock\Metadata\MfaEntity;
 use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
 use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
+use OpenConext\EngineBlockBundle\Exception\UnknownKeyIdException;
 use OpenConext\Value\Saml\Entity;
 use OpenConext\Value\Saml\EntityId;
 use OpenConext\Value\Saml\EntityType;
@@ -301,6 +302,7 @@ class EngineBlock_Corto_ProxyServer
     /**
      * @return EngineBlock_X509_KeyPair
      * @throws EngineBlock_Corto_ProxyServer_Exception
+     * @throws UnknownKeyIdException
      */
     public function getSigningCertificates()
     {
@@ -310,7 +312,7 @@ class EngineBlock_Corto_ProxyServer
         }
 
         if (!isset($this->_keyPairs[$keyId])) {
-            throw new EngineBlock_Corto_Exception_UnknownKeyId($keyId);
+            throw new UnknownKeyIdException($keyId);
         }
         return $this->_keyPairs[$keyId];
     }

--- a/src/OpenConext/EngineBlock/Metadata/X509/KeyPairFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/X509/KeyPairFactory.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlock\Metadata\X509;
 
+use EngineBlock_Corto_Exception_UnknownKeyId;
 use OpenConext\EngineBlock\Assert\Assertion;
 use OpenConext\EngineBlock\Exception\RuntimeException;
 
@@ -54,8 +55,6 @@ class KeyPairFactory
             $publicKey = new X509Certificate(openssl_x509_read(file_get_contents($keys['publicFile'])));
             return new X509KeyPair($publicKey, $privateKey);
         }
-        throw new RuntimeException(
-            sprintf('Unable to find the encryption key pair identified by "%s"', $identifier)
-        );
+        throw new EngineBlock_Corto_Exception_UnknownKeyId($identifier);
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/X509/KeyPairFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/X509/KeyPairFactory.php
@@ -18,9 +18,9 @@
 
 namespace OpenConext\EngineBlock\Metadata\X509;
 
-use EngineBlock_Corto_Exception_UnknownKeyId;
 use OpenConext\EngineBlock\Assert\Assertion;
 use OpenConext\EngineBlock\Exception\RuntimeException;
+use OpenConext\EngineBlockBundle\Exception\UnknownKeyIdException;
 
 class KeyPairFactory
 {
@@ -55,6 +55,6 @@ class KeyPairFactory
             $publicKey = new X509Certificate(openssl_x509_read(file_get_contents($keys['publicFile'])));
             return new X509KeyPair($publicKey, $privateKey);
         }
-        throw new EngineBlock_Corto_Exception_UnknownKeyId($identifier);
+        throw new UnknownKeyIdException($identifier);
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -425,6 +425,18 @@ class FeedbackController
         );
     }
 
+    public function unknownKeyIdAction(Request $request): Response
+    {
+        // Add feedback info from url
+        $customFeedbackInfo['Key ID'] = $request->get('keyid');
+        $this->setFeedbackInformationOnSession($request->getSession(), $customFeedbackInfo);
+
+        return new Response(
+            $this->twig->render('@theme/Authentication/View/Feedback/unknown-keyid.html.twig'),
+            400
+        );
+    }
+
     /**
      * @return Response
      */

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -28,7 +28,6 @@ use EngineBlock_Corto_Exception_InvalidStepupLoaLevel;
 use EngineBlock_Corto_Exception_MissingRequiredFields;
 use EngineBlock_Corto_Exception_PEPNoAccess;
 use EngineBlock_Corto_Exception_ReceivedErrorStatusCode;
-use EngineBlock_Corto_Exception_UnknownKeyId;
 use EngineBlock_Corto_Exception_UnknownPreselectedIdp;
 use EngineBlock_Corto_Exception_InvalidAttributeValue;
 use EngineBlock_Corto_Exception_UserCancelledStepupCallout;
@@ -50,6 +49,7 @@ use OpenConext\EngineBlock\Exception\MissingParameterException;
 use OpenConext\EngineBlockBridge\ErrorReporter;
 use OpenConext\EngineBlockBundle\Exception\EntityCanNotBeFoundException;
 use OpenConext\EngineBlockBundle\Exception\StuckInAuthenticationLoopException;
+use OpenConext\EngineBlockBundle\Exception\UnknownKeyIdException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -176,7 +176,7 @@ class RedirectToFeedbackPageExceptionListener
         } elseif ($exception instanceof EngineBlock_Corto_Exception_PEPNoAccess) {
             $message         = 'PEP authorization rule violation';
             $redirectToRoute = 'authentication_feedback_pep_violation';
-        } elseif ($exception instanceof EngineBlock_Corto_Exception_UnknownKeyId) {
+        } elseif ($exception instanceof UnknownKeyIdException) {
             $message         = $exception->getMessage();
             $redirectToRoute = 'authentication_feedback_unknown_keyid';
 

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -28,6 +28,7 @@ use EngineBlock_Corto_Exception_InvalidStepupLoaLevel;
 use EngineBlock_Corto_Exception_MissingRequiredFields;
 use EngineBlock_Corto_Exception_PEPNoAccess;
 use EngineBlock_Corto_Exception_ReceivedErrorStatusCode;
+use EngineBlock_Corto_Exception_UnknownKeyId;
 use EngineBlock_Corto_Exception_UnknownPreselectedIdp;
 use EngineBlock_Corto_Exception_InvalidAttributeValue;
 use EngineBlock_Corto_Exception_UserCancelledStepupCallout;
@@ -175,6 +176,11 @@ class RedirectToFeedbackPageExceptionListener
         } elseif ($exception instanceof EngineBlock_Corto_Exception_PEPNoAccess) {
             $message         = 'PEP authorization rule violation';
             $redirectToRoute = 'authentication_feedback_pep_violation';
+        } elseif ($exception instanceof EngineBlock_Corto_Exception_UnknownKeyId) {
+            $message         = $exception->getMessage();
+            $redirectToRoute = 'authentication_feedback_unknown_keyid';
+
+            $redirectParams = ['keyid' => $exception->getRequestedKeyId()];
         } elseif ($exception instanceof EngineBlock_Corto_Exception_UnknownPreselectedIdp) {
             $message         = $exception->getMessage();
             $redirectToRoute = 'authentication_feedback_unknown_preselected_idp';

--- a/src/OpenConext/EngineBlockBundle/Exception/UnknownKeyIdException.php
+++ b/src/OpenConext/EngineBlockBundle/Exception/UnknownKeyIdException.php
@@ -20,17 +20,20 @@ namespace OpenConext\EngineBlockBundle\Exception;
 
 class UnknownKeyIdException extends RuntimeException
 {
-    private $_requestedKeyId;
+    /**
+     * @var string
+     */
+    private $requestedKeyId;
 
     public function __construct($requestedKeyId)
     {
         $message = sprintf("Unknown key id '%s'", $requestedKeyId);
         parent::__construct($message);
-        $this->_requestedKeyId = $requestedKeyId;
+        $this->requestedKeyId = $requestedKeyId;
     }
 
     public function getRequestedKeyId(): string
     {
-        return $this->_requestedKeyId;
+        return $this->requestedKeyId;
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Exception/UnknownKeyIdException.php
+++ b/src/OpenConext/EngineBlockBundle/Exception/UnknownKeyIdException.php
@@ -16,14 +16,16 @@
  * limitations under the License.
  */
 
-class EngineBlock_Corto_Exception_UnknownKeyId extends EngineBlock_Exception
+namespace OpenConext\EngineBlockBundle\Exception;
+
+class UnknownKeyIdException extends RuntimeException
 {
     private $_requestedKeyId;
 
     public function __construct($requestedKeyId)
     {
         $message = sprintf("Unknown key id '%s'", $requestedKeyId);
-        parent::__construct($message, self::CODE_NOTICE);
+        parent::__construct($message);
         $this->_requestedKeyId = $requestedKeyId;
     }
 

--- a/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/routing/feedback.yml
@@ -103,6 +103,11 @@ authentication_feedback_pep_violation:
     methods:    [GET]
     defaults:   { _controller: engineblock.controller.authentication.feedback:authorizationPolicyViolationAction }
 
+authentication_feedback_unknown_keyid:
+    path:       '/authentication/feedback/unknown-keyid'
+    methods:    [GET]
+    defaults:   { _controller: engineblock.controller.authentication.feedback:unknownKeyIdAction }
+
 authentication_feedback_unknown_preselected_idp:
     path:       '/authentication/feedback/unknown-preselected-idp'
     methods:    [GET]

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -414,6 +414,11 @@ Feature:
     Then I should see "Metadata can not be generated"
      And I should see "The following error occurred: Unable to find the SP with entity ID \"does:not:exist\"."
 
+  Scenario: I request IdPs metadata for an unknown metadata key
+    When I go to Engineblock URL "/authentication/proxy/idps-metadata/key:does-not-exist"
+    Then I should see "Unknown key id"
+     And I should see "Key ID: does-not-exist"
+
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a location
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a binding
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying an invalid index

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Metadata.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Metadata.feature
@@ -117,3 +117,85 @@ Feature:
       And the response should match xpath '//md:KeyDescriptor[@use="signing"]//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
       # Verify the used signing key is EB key
       And the response should match xpath '//ds:Signature//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+
+  # Perform the same tests, but now for URLs with a specific preselected Key ID
+
+  Scenario: A user can request the EngineBlock SP Proxy metadata with a keyID
+    When I go to Engineblock URL "/authentication/sp/metadata/key:default"
+    # Verify the entity id is correctly set in the metadata
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/authentication/sp/metadata"]'
+    # Verify the display name (EN) correctly set in the metadata
+      And the response should match xpath '//mdui:DisplayName[@xml:lang="en" and text()="OpenConext EngineBlock"]'
+      # Verify the signature method is set to sha256
+      And the response should match xpath '//ds:SignatureMethod[@Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"]'
+      # Verify the ACS location and binding
+      And the response should match xpath '//md:AssertionConsumerService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" and @Location="https://engine.vm.openconext.org/authentication/sp/consume-assertion"]'
+      # Verify the propagated signing key is EB key
+      And the response should match xpath '//md:KeyDescriptor[@use="signing"]//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+      # Verify the used signing key is EB key
+      And the response should match xpath '//ds:Signature//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+
+  Scenario: A user can request the EngineBlock IdP Proxy metadata with a keyID
+    When I go to Engineblock URL "/authentication/idp/metadata/key:default"
+    # Verify the entity id is correctly set in the metadata
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/authentication/idp/metadata"]'
+      # Verify the display name (EN) correctly set in the metadata
+      And the response should match xpath '//mdui:DisplayName[@xml:lang="en" and text()="OpenConext EngineBlock"]'
+      # Verify the signature method is set to sha256
+      And the response should match xpath '//ds:SignatureMethod[@Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"]'
+      # Verify SSO location and binding is set correctly including Key ID
+      And the response should match xpath '//md:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" and @Location="https://engine.vm.openconext.org/authentication/idp/single-sign-on/key:default"]'
+      # Verify the propagated signing key is EB key
+      And the response should match xpath '//md:KeyDescriptor[@use="signing"]//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+      # Verify the used signing key is EB key
+      And the response should match xpath '//ds:Signature//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+
+  Scenario: A user can request the EngineBlock stepup metadata with a keyID
+    When I go to Engineblock URL "/authentication/stepup/metadata/key:default"
+    # Verify the entity id is correctly set in the metadata
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/authentication/stepup/metadata"]'
+      # Verify the signature method is set to sha256
+      And the response should match xpath '//ds:SignatureMethod[@Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"]'
+      # Verify the ACS location and binding
+      And the response should match xpath '//md:AssertionConsumerService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" and @Location="https://engine.vm.openconext.org/authentication/stepup/consume-assertion"]'
+      # Verify the propagated signing key is EB key
+      And the response should match xpath '//md:KeyDescriptor[@use="signing"]//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+      # Verify the used signing key is EB key
+      And the response should match xpath '//ds:Signature//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+
+  Scenario: A user can request the metadata of all known and visible IdPs with a keyID
+    Given an Identity Provider named "Known-IdP"
+      And an Identity Provider named "Second-IdP"
+      And an Identity Provider named "Regular-IdP"
+    When I go to Engineblock URL "/authentication/proxy/idps-metadata/key:default"
+    # Verify the three IdPs are present in the list
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Known-IdP/metadata"]'
+      And the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Second-IdP/metadata"]'
+      And the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Regular-IdP/metadata"]'
+      # And Engine IdP is not listed
+      And the response should not match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/authentication/idp/metadata"]'
+      # Verify the propagated signing key is EB key
+      And the response should match xpath '//md:KeyDescriptor[@use="signing"]//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+      # Verify the used signing key is EB key
+      And the response should match xpath '//ds:Signature//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+      # Verify the schema and hostname are not appende twice as was done prior to resolving: https://www.pivotaltracker.com/story/show/169724838
+      And the response should not match xpath '//mdui:Logo[text()="https://engine.vm.openconext.orghttps://engine.vm.openconext.org/images/logo.png"]'
+
+  Scenario: A user can request the metadata of the IdPs connected to a specific SP with a keyID
+    Given an Identity Provider named "Connected-IdP"
+      And an Identity Provider named "Second-Connected-IdP"
+      And an Identity Provider named "Not-Connected-IdP"
+      And a Service Provider named "Test-SP"
+      And SP "Test-SP" is not connected to IdP "Not-Connected-IdP"
+    When I go to Engineblock URL "/authentication/proxy/idps-metadata/key:default?sp-entity-id=https://engine.vm.openconext.org/functional-testing/Test-SP/metadata"
+    # Verify the two connected IdPs are present in the list
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Connected-IdP/metadata"]'
+      And the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Second-Connected-IdP/metadata"]'
+      # Verify the disconnected IdP is not listed
+      And the response should not match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Not-Connected-IdP/metadata"]'
+      # Verify the SP enitty is not listed (used to be the case in older EB versions)
+      And the response should not match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/functional-testing/Test-SP/metadata"]'
+      # Verify the propagated signing key is EB key
+      And the response should match xpath '//md:KeyDescriptor[@use="signing"]//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+      # Verify the used signing key is EB key
+      And the response should match xpath '//ds:Signature//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/UnsolicitedSingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/UnsolicitedSingleSignOn.feature
@@ -38,4 +38,5 @@ Feature:
   # Trying to use a non existent key results in a generic 500 error, this is known, correct behavior
   Scenario: An IdP initiates a login with an invalid signing key
     When An IdP initiated Single Sign on for SP "Dummy SP" is triggered by IdP "Dummy IdP" and specifies an invalid signing key
-    Then I should see "OpenConext - Error - An error occurred"
+    Then I should see "Error - unknown key id"
+     And I should see "Key ID: does-not-exist"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Service/EngineBlock.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Service/EngineBlock.php
@@ -51,11 +51,6 @@ class EngineBlock
         return $this->singleSignOnLocation() . '/' . md5($idpEntityId);
     }
 
-    public function voSsoLocation($voId)
-    {
-        return $this->singleSignOnLocation() . '/vo:' . $voId;
-    }
-
     public function singleSignOnLocation()
     {
         return $this->baseUrl . self::SINGLE_SIGN_ON_PATH;

--- a/tests/unit/OpenConext/EngineBlock/Metadata/X509/KeyPairFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/X509/KeyPairFactoryTest.php
@@ -18,9 +18,9 @@
 
 namespace OpenConext\EngineBlock\Metadata\X509;
 
-use EngineBlock_Corto_Exception_UnknownKeyId;
 use OpenConext\EngineBlock\Exception\InvalidArgumentException;
 use OpenConext\EngineBlock\Exception\RuntimeException;
+use OpenConext\EngineBlock\Exception\UnknownKeyIdException;
 use PHPUnit\Framework\TestCase;
 
 class KeyPairFactoryTest extends TestCase
@@ -64,7 +64,7 @@ class KeyPairFactoryTest extends TestCase
 
     public function test_it_raises_exception_when_requesting_invalid_key_pair()
     {
-        $this->expectException(EngineBlock_Corto_Exception_UnknownKeyId::class);
+        $this->expectException(UnknownKeyIdException::class);
         $this->expectExceptionMessage("Unknown key id 'ahnk-morpork'");
         $this->factory->buildFromIdentifier('ahnk-morpork');
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/X509/KeyPairFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/X509/KeyPairFactoryTest.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlock\Metadata\X509;
 
+use EngineBlock_Corto_Exception_UnknownKeyId;
 use OpenConext\EngineBlock\Exception\InvalidArgumentException;
 use OpenConext\EngineBlock\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase;
@@ -63,8 +64,8 @@ class KeyPairFactoryTest extends TestCase
 
     public function test_it_raises_exception_when_requesting_invalid_key_pair()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to find the encryption key pair identified by "ahnk-morpork"');
+        $this->expectException(EngineBlock_Corto_Exception_UnknownKeyId::class);
+        $this->expectExceptionMessage("Unknown key id 'ahnk-morpork'");
         $this->factory->buildFromIdentifier('ahnk-morpork');
     }
 }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/X509/KeyPairFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/X509/KeyPairFactoryTest.php
@@ -20,7 +20,7 @@ namespace OpenConext\EngineBlock\Metadata\X509;
 
 use OpenConext\EngineBlock\Exception\InvalidArgumentException;
 use OpenConext\EngineBlock\Exception\RuntimeException;
-use OpenConext\EngineBlock\Exception\UnknownKeyIdException;
+use OpenConext\EngineBlockBundle\Exception\UnknownKeyIdException;
 use PHPUnit\Framework\TestCase;
 
 class KeyPairFactoryTest extends TestCase

--- a/theme/base/templates/modules/Authentication/View/Feedback/unknown-keyid.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/unknown-keyid.html.twig
@@ -1,0 +1,12 @@
+{% extends '@theme/Default/View/Error/error.html.twig' %}
+
+{% set pageTitle = 'error_unknown_keyid'|trans %}
+{% block pageTitle %}
+    {{ 'error_unknown_keyid'|trans }}
+{% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
+{% block pageHeading %}{{ pageTitle }}{% endblock %}
+
+{% block errorMessage %}
+    {{ 'error_unknown_keyid_desc'|trans }}
+{% endblock %}

--- a/theme/openconext/templates/modules/Authentication/View/Feedback/unknown-keyid.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Feedback/unknown-keyid.html.twig
@@ -1,0 +1,12 @@
+{% extends '@theme/Default/View/Error/error.html.twig' %}
+
+{% set pageTitle = 'error_unknown_keyid'|trans %}
+{% block pageTitle %}
+    {{ 'error_unknown_keyid'|trans }}
+{% endblock %}
+{% block title %}{{ parent() }}{% endblock %}
+{% block pageHeading %}{{ pageTitle }}{% endblock %}
+
+{% block errorMessage %}
+    {{ 'error_unknown_keyid_desc'|trans }}
+{% endblock %}


### PR DESCRIPTION
* Add a concrete error message when someone access a URL (SSO or metadata) with an unknown key id. Unknown is then likely: used to work, but key has been phased out since. But could also be some typo of course.
* While we're at it, add integration tests for metadata endpoints with a keyid specified.
* Clean up an obsolete function.