### PR TITLE
Display no metadata endpoints with key default

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Controller/IndexController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IndexController.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlockBundle\Controller;
 
+use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
@@ -46,6 +47,8 @@ class IndexController
     {
         $keyPairIds = [];
         if ($this->keyPairs) {
+            // Do not include the default key, as this duplicates the metadata URLs without a keyslug
+            unset($this->keyPairs[KeyPairFactory::DEFAULT_KEY_PAIR_IDENTIFIER]);
             $keyPairIds = array_keys($this->keyPairs);
         }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/FrontPage.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/FrontPage.feature
@@ -10,32 +10,32 @@ Feature:
 
   Scenario: The user can see all available metadata links
     When I go to Engineblock URL "/"
-    Then I should see 15 links on the front page
+    Then I should see 8 links on the front page
      And I should see text matching "The Public SAML Signing certificate of the OpenConext IdP"
      And I should see URL "/authentication/idp/certificate"
-     And I should see URL "/authentication/idp/certificate/key:default"
+     And I should not see URL "/authentication/idp/certificate/key:default"
      And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext IdP Proxy"
      And I should see URL "/authentication/idp/metadata"
-     And I should see URL "/authentication/idp/metadata/key:default"
+     And I should not see URL "/authentication/idp/metadata/key:default"
      And I should see text matching "The Public SAML metadata \(the entities descriptor\) for all the OpenConext IdPs"
      And I should see URL "/authentication/proxy/idps-metadata"
-     And I should see URL "/authentication/proxy/idps-metadata/key:default"
+     And I should not see URL "/authentication/proxy/idps-metadata/key:default"
      And I should see text matching "The Public SAML metadata \(the entities descriptor\) of the OpenConext IdPs which"
      And I should see URL "/authentication/proxy/idps-metadata?sp-entity-id=urn:example.org"
-     And I should see URL "/authentication/proxy/idps-metadata/key:default?sp-entity-id=urn:example.org"
+     And I should not see URL "/authentication/proxy/idps-metadata/key:default?sp-entity-id=urn:example.org"
      # The test debug link is present on the page
      And I should see text matching "Test authentication with an identity provider."
      And I should see URL "/authentication/sp/debug"
      And I should see text matching "The Public SAML Signing certificate of the OpenConext SP"
      And I should see URL "/authentication/sp/certificate"
-     And I should see URL "/authentication/sp/certificate/key:default"
+     And I should not see URL "/authentication/sp/certificate/key:default"
      And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext SP Proxy"
      And I should see URL "/authentication/sp/metadata"
-     And I should see URL "/authentication/sp/metadata/key:default"
+     And I should not see URL "/authentication/sp/metadata/key:default"
      And I should see text matching "Step-up authentication Certificate and Metadata"
      And I should see text matching "The Public SAML metadata \(the entity descriptor\) of the OpenConext step-up authentication Proxy"
      And I should see URL "/authentication/stepup/metadata"
-     And I should see URL "/authentication/stepup/metadata/key:default"
+     And I should not see URL "/authentication/stepup/metadata/key:default"
      # eduGAIN metadata is no longer created by EngineBlock
      And I should not see text matching "eduGAIN"
      # IdP / SP metadata combination (for Shiboleth entities) is no longer supported

--- a/theme/base/templates/modules/Authentication/View/Index/index.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Index/index.html.twig
@@ -7,7 +7,7 @@
     <main id="engine-main-page" class="box">
         <div class="mod-content">
             <header>
-                <img class="logo" src="{{ defaultLogo }}?v={{ assetsVersion }}" alt=""/>
+                <img class="logo" src="{{ defaultLogo }}?v={{ assetsVersion }}" alt="">
                 <h1>{{ 'suite_name'|trans }} EngineBlock</h1>
             </header>
 
@@ -50,7 +50,7 @@
                         </ul>
                     </dd>
                     <dt>
-                        <p class="strong">Metadata below is only relevant for key rollover or in
+                        <p class="strong">Metadata below is only relevant in
                             case you want a custom WAYF for your SP</p>
                     </dt>
                     <dt>

--- a/theme/openconext/templates/modules/Authentication/View/Index/index.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Index/index.html.twig
@@ -11,7 +11,7 @@
     <main id="engine-main-page" class="box">
         <div class="mod-content">
             <header>
-                <img class="logo" src="{{ defaultLogo }}?v={{ assetsVersion }}" alt=""/>
+                <img class="logo" src="{{ defaultLogo }}?v={{ assetsVersion }}" alt="">
                 <h1>{{ 'suite_name'|trans }} EngineBlock</h1>
             </header>
 
@@ -53,7 +53,7 @@
                         </ul>
                     </dd>
                     <dt>
-                        <p class="strong">Metadata below is only relevant for key rollover or in
+                        <p class="strong">Metadata below is only relevant in
                             case you want a custom WAYF for your SP</p>
                     </dt>
                     <dt>


### PR DESCRIPTION
Previously, the index page of Engineblock would look like this (an installation with two keys in the config: the same key is set as 'default' and '20181213'):

![Screenshot EB index showing three links for each type of metadata](https://user-images.githubusercontent.com/3808792/220154563-c0c593c4-e61f-4ccd-ac5e-ee804cda1815.png)

There's three links of metadata for each type. However, the first two are duplicated. The URLs without a keyslug are already implying that the default key is used. So there's no actual difference between those two. If the default key changes, both will change. This is confusing and also clutters the page, even more for installs that have a single key defined.

Skip the redundant key:default when generating the list of metadata variants. The URLs with key:default in them will still work but just are not displayed. They will still work because key:default is not otherwise 'special' and just another key in the config. Changing that (e.g.: having one key and an option to mark it as default or not) requires a significant amount of refactoring which does not seem currently to bring a lot of value.