### PR TITLE
Enable skipped MultipleSingleSignOn scenario

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MultipleSingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MultipleSingleSignOn.feature
@@ -38,7 +38,6 @@ Feature:
         And I give my consent
        Then the url should match "functional-testing/SSO-SP/acs"
 
-    @SKIP
     Scenario: One solicited and one unsolicited authentication requests
        When I switch to "Browser tab 1"
         And I log in at "SSO-SP"


### PR DESCRIPTION
A multiple in-flight authentication Behat scenario was disabled in the past as it was deemed unstable. This issue no longer seems present as the test passes with flying colors. Probably as dependencies that hindered this test where upgraded long ago.

https://www.pivotaltracker.com/n/projects/1425900/stories/174358940