### PR TITLE
No longer run security checker as part of integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -122,18 +122,6 @@ jobs:
                   '
               env:
                   SYMFONY_ENV: ci
-            - name: Run security audit
-              if: always()
-              run: |
-                  cd docker && docker-compose exec -T php-fpm.vm.openconext.org bash -c '
-                      echo -e "\nSensioLabs Security Check\n" && \
-                      ./bin/securityChecker.sh && \
-                      cd theme && \
-                      echo -e "\nNPM Audit\n" && \
-                      npm run audit --production
-                  '
-              env:
-                  SYMFONY_ENV: ci
 #            - name: Run Cypress visual regression tests
 #              if: ${{ github.event_name == 'schedule' && matrix.php == env.PROD_PHP }}
 #              run: |


### PR DESCRIPTION
There's no relation between changes in a PR and the presence of a security issue or between the frequency of PRs and the frequency we want to check for security issues. So remove it here. We keep the script in bin/ for now, might come in handy at some point.