### PR TITLE
Avoid generating PHP notices when calling metadata API for IdP without SLO

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Http/Response/JsonHelper.php
+++ b/src/OpenConext/EngineBlockBundle/Http/Response/JsonHelper.php
@@ -51,10 +51,6 @@ final class JsonHelper
                         'url'          => $identityProvider->organizationPt->url,
                     ]
                 ],
-                'single_logout_service'   => [
-                    'binding'  => $identityProvider->singleLogoutService->binding,
-                    'location' => $identityProvider->singleLogoutService->location,
-                ],
                 'contact_persons'         => array_map(
                     function (ContactPerson $contactPerson) {
                         return [


### PR DESCRIPTION
This API is used by Profile to get information about the user's IdP for display purposes. It does not use this information at all. We can add more code to avoid the notices or just remove working on something that is not used at all.