### PR TITLE
Support ForceAuthn to Stepup Gateway callout

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -207,7 +207,13 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         $nameId = clone $receivedResponse->getNameId();
         $authnClassRef = $this->_stepupGatewayCallOutHelper->getStepupLoa($idp, $sp, $authnRequestLoas, $pdpLoas);
 
-        $this->_server->sendStepupAuthenticationRequest($receivedRequest, $currentProcessStep->getRole(), $authnClassRef, $nameId);
+        $this->_server->sendStepupAuthenticationRequest(
+            $receivedRequest,
+            $currentProcessStep->getRole(),
+            $authnClassRef,
+            $nameId,
+            $sp->getCoins()->isStepupForceAuthn()
+        );
     }
 
     /**

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -456,7 +456,8 @@ class EngineBlock_Corto_ProxyServer
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $spRequest,
         IdentityProvider $identityProvider,
         Loa $authnContextClassRef,
-        NameID $nameId
+        NameID $nameId,
+        bool $isForceAuthn
     ) {
         $ebRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest(
             $spRequest,
@@ -465,6 +466,8 @@ class EngineBlock_Corto_ProxyServer
             'stepupMetadataService',
             'stepupAssertionConsumerService'
         );
+
+        $ebRequest->setForceAuthn($isForceAuthn);
 
         $sspMessage = $ebRequest->getSspMessage();
         if (!$sspMessage instanceof AuthnRequest) {

--- a/library/EngineBlock/Saml2/AuthnRequestAnnotationDecorator.php
+++ b/library/EngineBlock/Saml2/AuthnRequestAnnotationDecorator.php
@@ -179,4 +179,9 @@ class EngineBlock_Saml2_AuthnRequestAnnotationDecorator extends EngineBlock_Saml
     {
         return $this->transparent;
     }
+
+    public function setForceAuthn(bool $isForceAuthn)
+    {
+        $this->sspMessage->setForceAuthn($isForceAuthn);
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -43,7 +43,8 @@ class Coins
         $stepupRequireLoa,
         $disableScoping,
         $additionalLogging,
-        $signatureMethod
+        $signatureMethod,
+        $stepupForceAuthn
     ) {
         return new self([
             'isConsentRequired' => $isConsentRequired,
@@ -60,6 +61,7 @@ class Coins
             'signatureMethod' => $signatureMethod,
             'stepupAllowNoToken' => $stepupAllowNoToken,
             'stepupRequireLoa' => $stepupRequireLoa,
+            'stepupForceAuthn' => $stepupForceAuthn,
         ]);
     }
 
@@ -176,6 +178,15 @@ class Coins
     public function stepupRequireLoa()
     {
         return $this->getValue('stepupRequireLoa', '');
+    }
+
+    /**
+     * Should the Stepup authentication request (to the Stepup Gateway)
+     * have the ForceAuthn attribute in the AuthnRequest?
+     */
+    public function isStepupForceAuthn()
+    {
+        return $this->getValue('stepupForceAuthn', false);
     }
 
     // IDP

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -273,7 +273,13 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
             ),
             'stepupAllowNoToken'
         );
-
+        $properties += $this->setPathFromObjectBool(
+            array(
+                $connection,
+                'metadata:coin:stepup:forceauthn'
+            ),
+            'stepupForceAuthn'
+        );
         return Utils::instantiate(
             ServiceProvider::class,
             $properties

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -105,54 +105,6 @@ class ServiceProvider extends AbstractRole
     /**
      * WARNING: Please don't use this entity directly but use the dedicated factory instead.
      * @see \OpenConext\EngineBlock\Factory\Factory\ServiceProviderFactory
-     *
-     * @param string $entityId
-     * @param Organization $organizationEn
-     * @param Organization $organizationNl
-     * @param Organization $organizationPt
-     * @param Service $singleLogoutService
-     * @param bool $additionalLogging
-     * @param X509Certificate[] $certificates
-     * @param ContactPerson[] $contactPersons
-     * @param string $descriptionEn
-     * @param string $descriptionNl
-     * @param string $descriptionPt
-     * @param bool $disableScoping
-     * @param string $displayNameEn
-     * @param string $displayNameNl
-     * @param string $displayNamePt
-     * @param string $keywordsEn
-     * @param string $keywordsNl
-     * @param string $keywordsPt
-     * @param Logo $logo
-     * @param string $nameEn
-     * @param string $nameNl
-     * @param string $namePt
-     * @param null $nameIdFormat
-     * @param array $supportedNameIdFormats
-     * @param bool $requestsMustBeSigned
-     * @param string $signatureMethod
-     * @param string $workflowState
-     * @param array $allowedIdpEntityIds
-     * @param bool $allowAll
-     * @param array $assertionConsumerServices
-     * @param bool $displayUnconnectedIdpsWayf
-     * @param null $termsOfServiceUrl
-     * @param bool $isConsentRequired
-     * @param bool $isTransparentIssuer
-     * @param bool $isTrustedProxy
-     * @param null $requestedAttributes
-     * @param bool $skipDenormalization
-     * @param bool $policyEnforcementDecisionRequired
-     * @param bool $requesteridRequired
-     * @param bool $signResponse
-     * @param string $manipulation
-     * @param AttributeReleasePolicy $attributeReleasePolicy
-     * @param string|null $supportUrlEn
-     * @param string|null $supportUrlNl
-     * @param string|null $supportUrlPt
-     * @param bool|null $stepupAllowNoToken
-     * @param bool|null $stepupRequireLoa
      */
     public function __construct(
         $entityId,
@@ -160,51 +112,52 @@ class ServiceProvider extends AbstractRole
         Organization $organizationNl = null,
         Organization $organizationPt = null,
         Service $singleLogoutService = null,
-        $additionalLogging = false,
+        bool $additionalLogging = false,
         array $certificates = array(),
         array $contactPersons = array(),
-        $descriptionEn = '',
-        $descriptionNl = '',
-        $descriptionPt = '',
-        $disableScoping = false,
-        $displayNameEn = '',
-        $displayNameNl = '',
-        $displayNamePt = '',
-        $keywordsEn = '',
-        $keywordsNl = '',
-        $keywordsPt = '',
-        Logo $logo = null,
-        $nameEn = '',
-        $nameNl = '',
-        $namePt = '',
-        $nameIdFormat = null,
-        $supportedNameIdFormats = array(
+        string $descriptionEn = '',
+        string $descriptionNl = '',
+        string $descriptionPt = '',
+        bool $disableScoping = false,
+        ?string $displayNameEn = '',
+        ?string $displayNameNl = '',
+        ?string $displayNamePt = '',
+        ?string $keywordsEn = '',
+        ?string $keywordsNl = '',
+        ?string $keywordsPt = '',
+        ?Logo $logo = null,
+        ?string $nameEn = '',
+        ?string $nameNl = '',
+        ?string $namePt = '',
+        ?string $nameIdFormat = null,
+        array $supportedNameIdFormats = array(
             Constants::NAMEID_TRANSIENT,
             Constants::NAMEID_PERSISTENT,
         ),
-        $requestsMustBeSigned = false,
-        $signatureMethod = XMLSecurityKey::RSA_SHA256,
-        $workflowState = self::WORKFLOW_STATE_DEFAULT,
+        bool $requestsMustBeSigned = false,
+        string $signatureMethod = XMLSecurityKey::RSA_SHA256,
+        string $workflowState = self::WORKFLOW_STATE_DEFAULT,
         array $allowedIdpEntityIds = array(),
-        $allowAll = false,
+        bool $allowAll = false,
         array $assertionConsumerServices = array(),
-        $displayUnconnectedIdpsWayf = false,
-        $termsOfServiceUrl = null,
-        $isConsentRequired = true,
-        $isTransparentIssuer = false,
-        $isTrustedProxy = false,
+        bool $displayUnconnectedIdpsWayf = false,
+        string $termsOfServiceUrl = null,
+        bool $isConsentRequired = true,
+        bool $isTransparentIssuer = false,
+        bool $isTrustedProxy = false,
         $requestedAttributes = null,
-        $skipDenormalization = false,
-        $policyEnforcementDecisionRequired = false,
-        $requesteridRequired = false,
-        $signResponse = false,
-        $manipulation = '',
+        bool $skipDenormalization = false,
+        bool $policyEnforcementDecisionRequired = false,
+        bool $requesteridRequired = false,
+        bool $signResponse = false,
+        string $manipulation = '',
         AttributeReleasePolicy $attributeReleasePolicy = null,
-        $supportUrlEn = null,
-        $supportUrlNl = null,
-        $supportUrlPt = null,
-        $stepupAllowNoToken = null,
-        $stepupRequireLoa = null
+        string $supportUrlEn = null,
+        string $supportUrlNl = null,
+        string $supportUrlPt = null,
+        bool $stepupAllowNoToken = null,
+        string $stepupRequireLoa = null,
+        bool $stepupForceAuthn = false
     ) {
         parent::__construct(
             $entityId,
@@ -257,7 +210,8 @@ class ServiceProvider extends AbstractRole
             $stepupRequireLoa,
             $disableScoping,
             $additionalLogging,
-            $signatureMethod
+            $signatureMethod,
+            $stepupForceAuthn
         );
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/StepupMockController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/StepupMockController.php
@@ -20,6 +20,7 @@ namespace OpenConext\EngineBlockFunctionalTestingBundle\Controllers;
 use Exception;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockStepupGateway;
 use SAML2\Constants;
+use SAML2\HTTPRedirect;
 use SAML2\Response as SamlResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,10 +63,14 @@ class StepupMockController extends Controller
             // Parse available responses
             $responses = $this->getAvailableResponses($request);
 
+            $redirectBinding = new HTTPRedirect();
+            $message = $redirectBinding->receive();
+
             // Present response
             $body = $this->twig->render(
                 '@OpenConextEngineBlockFunctionalTesting/Sso/consumeAssertion.html.twig',
                 [
+                    'receivedAuthnRequest' => $message->toUnsignedXML()->ownerDocument->saveXml(),
                     'responses' => $responses,
                 ]
             );

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/StepupContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/StepupContext.php
@@ -136,6 +136,19 @@ class StepupContext extends AbstractSubContext
     }
 
     /**
+     * @Given /^the SP "([^"]*)" forces stepup authentication$/
+     */
+    public function spForcesAuthn($spName)
+    {
+        /** @var MockServiceProvider $mockSp */
+        $mockSp = $this->mockSpRegistry->get($spName);
+
+        $this->serviceRegistryFixture
+            ->setStepupForceAuthn($mockSp->entityId(), true)
+            ->save();
+    }
+
+    /**
      * @Given /^the SP "([^"]*)" requires Stepup LoA "([^"]*)"$/
      */
     public function setSpStepupRequireLoa($spName, $requiredLoa)

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -401,6 +401,13 @@ QUERY;
         return $this;
     }
 
+    public function setStepupForceAuthn($entityId, $isForceAuthn)
+    {
+        $this->setCoin($this->getServiceProvider($entityId), 'stepupForceAuthn', $isForceAuthn);
+
+        return $this;
+    }
+
     public function setSpStepupAllowNoToken($entityId)
     {
         $this->setCoin($this->getServiceProvider($entityId), 'stepupAllowNoToken', true);

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/views/Sso/consumeAssertion.html.twig
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/views/Sso/consumeAssertion.html.twig
@@ -17,4 +17,8 @@
         </noscript>
         </form>
     {% endfor %}
+
+    <form action="#">
+        <input type="text" name="authnRequestXml" value="{{ receivedAuthnRequest }}">
+    </form>
 </html>

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
@@ -210,7 +210,8 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
             null,
             false,
             false,
-            XMLSecurityKey::RSA_SHA256
+            XMLSecurityKey::RSA_SHA256,
+            false
         );
         $overrides['attributeReleasePolicy'] = null;
         $overrides['allowedIdpEntityIds'] = [];
@@ -344,7 +345,8 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
             null,
             false,
             false,
-            XMLSecurityKey::RSA_SHA256
+            XMLSecurityKey::RSA_SHA256,
+            false
         );
         $overrides['attributeReleasePolicy'] = null;
         $overrides['allowedIdpEntityIds'] = [];


### PR DESCRIPTION
Manage can push SP Metadata containing the coin:stepup:forceauthn coin.

That value is picked up in the Assembler, and saved on the SP eb5 roles, coin column.

During the StepUp round trip via StepUp Gateway, EB checks if the FoceAuthn flag should be added to that AuthNRequest. If this is specified for that SP, it is added. Otherwise no additional logic is performed.

When dealing with a trusted proxy setup, the stepup settings for the requesting sp are used, not that of the TP.

In order to get insghts in the outgoing AR to the StepUp Gateway, the mock gateway page that is used in the funcitonal tests now displays the received AR as an unsigned xml string. That string is used to perform xpath queries on, determiniing the presense or absence of the forceauthn flag.

See: https://www.pivotaltracker.com/story/show/184369636