### PR TITLE
Show an Unknown SP error page also when invoking the unsolicited endpoint

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
@@ -53,7 +53,6 @@ class IdpsMetadataRepository
     }
 
     /**
-     * @param string $entityId
      * @return ServiceProvider
      * @throws EntityCanNotBeFoundException
      */
@@ -62,6 +61,8 @@ class IdpsMetadataRepository
         try {
             return $this->repository->fetchServiceProviderByEntityId($entityId);
         } catch (EntityNotFoundException $e) {
+            // The EntityCanNotBeFoundException is ensuring the exception is presented to the user on a nicely
+            // styled, meaningful error page.
             throw new EntityCanNotBeFoundException(sprintf('Unable to find the SP with entity ID "%s".', $entityId));
         }
     }

--- a/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
+++ b/src/OpenConext/EngineBlock/Metadata/MetadataRepository/IdpsMetadataRepository.php
@@ -55,7 +55,7 @@ class IdpsMetadataRepository
     /**
      * @param string $entityId
      * @return ServiceProvider
-     * @throws EntityNotFoundException
+     * @throws EntityCanNotBeFoundException
      */
     public function fetchServiceProviderByEntityId(string $entityId)
     {


### PR DESCRIPTION
In regular auhtentication the UnknownServiceProvider exception is thrown when an authnrequest is received from an unknown SP. Do the same for when the unknown SP originates from the unsolicited SSO url parameter (before it would throw the generic uncaught exception page).