### PR TITLE
Show back to SP link on error page

### DIFF
--- a/docs/stepup_callout.md
+++ b/docs/stepup_callout.md
@@ -22,8 +22,8 @@ Note that this mode is very risky; the associated SP needs to do something with 
 #### metadata:coin:stepup:requireloa
 The LOA minimally required for any login to this SP.
 
-**Type:** boolean
-
+**Type:** string
+**Example value:** `http://vm.openconext.org/assurance/loa2`
 
 
 
@@ -45,3 +45,5 @@ The PDP will return a minimally required LoA for each matching ruleset. These ru
 ## Engineblock global configuration
 The EngineBlock installation also needs additional configuration in order to facilitate the SFO second factor authentications. For details on these configuration settings, please review the SFO section in the [app/config/parameters.yml.dist](app/config/parameters.yml.dist) file.
 
+## Development and testing
+To test this integration in EngineBlock, you can configure one of the SP's known to your installation (example `profile.vm.openconext.org`) to require step up authentication. After pushing the updated metadata back to EngineBlock, Engine should start asking for step up authentications when logging in to the SP. Note that a mock StepUp SFO endpoint is implemented in EB when in `dev` or `test` mode. That mimics the SFO callout to the StepUp Gateway. Allowing developers and testsers to modify the behaviour of the Gateway response without actually having to run a StepUp instance.

--- a/library/EngineBlock/Corto/Exception/ReceivedErrorStatusCode.php
+++ b/library/EngineBlock/Corto/Exception/ReceivedErrorStatusCode.php
@@ -40,6 +40,7 @@ class EngineBlock_Corto_Exception_ReceivedErrorStatusCode extends EngineBlock_Ex
 
     public function setResponse(EngineBlock_Saml2_ResponseAnnotationDecorator $response)
     {
+        $this->feedbackInfo['AuthnFailedResponse'] = $response;
         $this->response = $response;
     }
 

--- a/src/OpenConext/EngineBlockBundle/Authentication/Service/SamlResponseHelper.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Service/SamlResponseHelper.php
@@ -19,12 +19,12 @@
 namespace OpenConext\EngineBlockBundle\Authentication\Service;
 
 use DateTime;
+use EngineBlock_Saml2_ResponseAnnotationDecorator;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\EngineBlockBundle\Exception\RuntimeException;
 use SAML2\Constants;
 use SAML2\Response as SAMLResponse;
 use SAML2\XML\saml\Issuer;
-use function sprintf;
 
 class SamlResponseHelper
 {
@@ -38,20 +38,34 @@ class SamlResponseHelper
         $this->metaDataRepository = $metaDataRepository;
     }
 
-    public function createAuthnFailedResponse(string $spEntityId, string $idpEntityId, string $originalRequestId, string $message): string
-    {
-        $issuer = new Issuer();
-        $issuer->setValue($idpEntityId);
+    public function createAuthnFailedResponse(
+        string $spEntityId,
+        string $idpEntityId,
+        string $originalRequestId,
+        string $message,
+        EngineBlock_Saml2_ResponseAnnotationDecorator $originalResponse
+    ): string {
         $response = new SAMLResponse();
         $response->setDestination($this->getAcu($spEntityId));
-        $response->setIssuer($issuer);
-        $response->setIssueInstant((new DateTime('now'))->getTimestamp());
+        $response->setIssuer($originalResponse->getIssuer());
+        $response->setIssueInstant(time());
         $response->setInResponseTo($originalRequestId);
+        $status = $originalResponse->getStatus();
         $response->setStatus([
-            'Code' => Constants::STATUS_RESPONDER,
-            'SubCode' => Constants::STATUS_AUTHN_FAILED,
+            'Code' => array_key_exists('Code', $status) ? $status['Code'] : Constants::STATUS_RESPONDER,
+            'SubCode' => array_key_exists('SubCode', $status) ? $status['SubCode'] : Constants::STATUS_AUTHN_FAILED,
             'Message' => $message
         ]);
+
+        // Copy of behavior found in: https://github.com/OpenConext/OpenConext-engineblock/blob/8aea9cdaa8162d92b391c35c7c66ce6802273f72/library/EngineBlock/Corto/ProxyServer.php#L582-L598
+        $serviceProvider = $this->metaDataRepository->findServiceProviderByEntityId($spEntityId);
+        $isTransparant = $serviceProvider->getCoins()->isTransparentIssuer();
+        if ($isTransparant) {
+            $issuer = new Issuer();
+            $issuer->setValue($originalResponse->getOriginalIssuer());
+            $response->setIssuer($issuer);
+        }
+
         return base64_encode($response->toUnsignedXML()->ownerDocument->saveXML());
     }
 

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
@@ -158,9 +158,12 @@ class Feedback extends Twig_Extension
     public function hasBackToSpLink()
     {
         $info = $this->retrieveFeedbackInfo();
+        $response = $this->getSamlFailedResponse();
+
         return $info->has('serviceProvider') &&
             $info->has('identityProvider') &&
-            $info->has('requestId');
+            $info->has('requestId') &&
+            $response !== '';
     }
 
     public function getSpName(): ?string
@@ -178,15 +181,19 @@ class Feedback extends Twig_Extension
     {
         $session = $this->application->getSession();
         $feedbackInfo = $session->get('feedbackInfo');
+        // If AuthnFailedResponse is not set, we are unable to render a createAuthnFailedResponse
         $sspResponse = $feedbackInfo['AuthnFailedResponse'];
-        // Compose the Saml error response that can be used to travel back to the SP
-        $value = $this->samlResponseHelper->createAuthnFailedResponse(
-            $feedbackInfo['serviceProvider'],
-            $feedbackInfo['identityProvider'],
-            $feedbackInfo['requestId'],
-            $feedbackInfo['statusMessage'] ?? '',
-            $sspResponse
-        );
+        $value = '';
+        if (!is_null($sspResponse)) {
+            // Compose the Saml error response that can be used to travel back to the SP
+            $value = $this->samlResponseHelper->createAuthnFailedResponse(
+                $feedbackInfo['serviceProvider'],
+                $feedbackInfo['identityProvider'],
+                $feedbackInfo['requestId'],
+                $feedbackInfo['statusMessage'] ?? '',
+                $sspResponse
+            );
+        }
         return $value;
     }
 

--- a/src/OpenConext/EngineBlockBundle/Value/FeedbackInformation.php
+++ b/src/OpenConext/EngineBlockBundle/Value/FeedbackInformation.php
@@ -39,7 +39,10 @@ class FeedbackInformation
     public function __construct($key, $value)
     {
         Assertion::nonEmptyString($key, "The feedbackInfo key can't be empty and must be a string value");
-        Assertion::nonEmptyString($value, "The feedbackInfo value can't be empty and must be a string value");
+        Assertion::nonEmptyString(
+            $value,
+            sprintf("The feedbackInfo value for '%s' can't be empty and must be a string value", $key)
+        );
         $this->key = $key;
         $this->value = $value;
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -140,21 +140,20 @@ Feature:
         And the url should match "/feedback/stepup-callout-unmet-loa"
         And the response status code should be 400
 
-#    TODO: fix this test after re-enabling back to sp link
-#    Scenario: User can click back button on error page after failing StepUp
-#       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"
-#        When I log in at "SSO-SP"
-#         And I select "SSO-IdP" on the WAYF
-#         And I pass through EngineBlock
-#         And I pass through the IdP
-#         And Stepup will fail if the LoA can not be given
-#        Then I should see "Error - No suitable token found"
-#         And the url should match "/feedback/stepup-callout-unmet-loa"
-#         And the response status code should be 400
-#        Then I click the return to SP button
-#         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:Responder'
-#         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:AuthnFailed'
-#         And the response should contain '(No message provided)'
+    Scenario: User can click back button on error page after failing StepUp
+       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"
+        When I log in at "SSO-SP"
+         And I select "SSO-IdP" on the WAYF
+         And I pass through EngineBlock
+         And I pass through the IdP
+         And Stepup will fail if the LoA can not be given
+        Then I should see "Error - No suitable token found"
+         And the url should match "/feedback/stepup-callout-unmet-loa"
+         And the response status code should be 400
+        Then I click the return to SP button
+         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:Responder'
+         And the response should contain 'urn:oasis:names:tc:SAML:2.0:status:NoAuthnContext'
+         And the response should contain '(No message provided)'
 
     Scenario: Stepup authentication should show exception when user does cancel
       Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"

--- a/tests/unit/OpenConext/EngineBlockBundle/Authentication/Service/SamlResponseHelperTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Authentication/Service/SamlResponseHelperTest.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * Copyright 2010 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Tests;
+
+use EngineBlock_Saml2_ResponseAnnotationDecorator;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\IndexedService;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlockBundle\Authentication\AuthenticationLoopGuard;
+use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
+use OpenConext\EngineBlockBundle\Authentication\Service\SamlResponseHelper;
+use OpenConext\EngineBlockBundle\Exception\LogicException;
+use OpenConext\EngineBlockBundle\Exception\RuntimeException;
+use OpenConext\Value\Saml\Entity;
+use OpenConext\Value\Saml\EntityId;
+use OpenConext\Value\Saml\EntityType;
+use PHPUnit\Framework\TestCase;
+use SAML2\Constants;
+use SAML2\XML\saml\Issuer;
+use SimpleXMLElement;
+use Symfony\Component\Form\Tests\Extension\Validator\ViolationMapper\Fixtures\Issue;
+
+class SamlResponseHelperTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var SamlResponseHelper $helper */
+    private $helper;
+
+    /** @var MetadataRepositoryInterface&m\MockInterface  */
+    private $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = m::mock(MetadataRepositoryInterface::class);
+        $this->helper = new SamlResponseHelper($this->repo);
+    }
+
+    public function test_create_authn_failed_response()
+    {
+        $spEntityId = 'https://sp.example.org/metadata';
+        $idpEntityId = 'https://idp.example.org/metadata';
+        $requestId = 'arbitrary-request-id';
+
+        $mockSp = m::mock(ServiceProvider::class);
+        $mockSp->assertionConsumerServices = [
+            new IndexedService('https://sp.example.org/assertion/consumer', Constants::BINDING_HTTP_POST, 0)
+        ];
+        $mockSp->shouldReceive('getCoins->isTransparentIssuer')
+            ->andReturn(false);
+
+        $this->repo
+            ->shouldReceive('findServiceProviderByEntityId')
+            ->with($spEntityId)
+            ->andReturn($mockSp);
+
+        $issuer = new Issuer();
+        $issuer->setValue($spEntityId);
+        $originalResponse = m::mock(EngineBlock_Saml2_ResponseAnnotationDecorator::class);
+
+        $originalResponse
+            ->shouldReceive('getIssuer')
+            ->andReturn($issuer);
+
+        $originalResponse
+            ->shouldReceive('getStatus')
+            ->andReturn(
+                ['Code' => 'testCode', 'SubCode' => 'testSubCode']
+            );
+
+        $response = $this->helper->createAuthnFailedResponse(
+            $spEntityId,
+            $idpEntityId,
+            $requestId,
+            'message',
+            $originalResponse
+        );
+
+        // Parse the SAML response into a SimpleXMLElement
+        $response = base64_decode($response);
+        $responseXml = new SimpleXMLElement($response);
+
+        /**
+         * Test if the issuer was set correctly
+         * @var SimpleXMLElement $issuer
+         */
+        $responseResponse = array_pop($responseXml->xpath('/samlp:Response'));
+        self::assertEquals($responseResponse['InResponseTo'], $requestId);
+        self::assertEquals($responseResponse['Destination'], 'https://sp.example.org/assertion/consumer');
+
+        /**
+         * Test if the issuer was set correctly
+         * @var SimpleXMLElement $issuer
+         */
+        $responseIssuer = array_pop($responseXml->xpath('/samlp:Response/saml:Issuer'));
+        self::assertEquals($responseIssuer, $issuer->getValue());
+
+        /**
+         * Test if the codes are correctly copied from the original saml failed response
+         * @var SimpleXMLElement $code
+         */
+        $responseCode = array_pop($responseXml->xpath('/samlp:Response/samlp:Status/samlp:StatusCode'));
+        $responseSubCode = array_pop($responseXml->xpath('/samlp:Response/samlp:Status/samlp:StatusCode/samlp:StatusCode'));
+        self::assertEquals($responseCode['Value'], 'testCode');
+        self::assertEquals($responseSubCode['Value'], 'testSubCode');
+    }
+
+    public function test_create_authn_failed_response_transparent()
+    {
+        $spEntityId = 'https://sp.example.org/metadata';
+        $originalSpEntityId = 'https://original-sp.example.org/metadata';
+        $idpEntityId = 'https://idp.example.org/metadata';
+        $requestId = 'arbitrary-request-id';
+
+        $mockSp = m::mock(ServiceProvider::class);
+        $mockSp->assertionConsumerServices = [
+            new IndexedService('https://sp.example.org/assertion/consumer', Constants::BINDING_HTTP_POST, 0)
+        ];
+        $mockSp->shouldReceive('getCoins->isTransparentIssuer')
+            ->andReturn(true);
+
+        $this->repo
+            ->shouldReceive('findServiceProviderByEntityId')
+            ->with($spEntityId)
+            ->andReturn($mockSp);
+
+        $issuer = new Issuer();
+        $issuer->setValue($spEntityId);
+
+        $originalResponse = m::mock(EngineBlock_Saml2_ResponseAnnotationDecorator::class);
+
+        $originalResponse
+            ->shouldReceive('getIssuer')
+            ->andReturn($issuer);
+        $originalResponse
+            ->shouldReceive('getOriginalIssuer')
+            ->andReturn($originalSpEntityId);
+
+        $originalResponse
+            ->shouldReceive('getStatus')
+            ->andReturn(
+                ['Code' => 'testCode', 'SubCode' => 'testSubCode']
+            );
+
+        $response = $this->helper->createAuthnFailedResponse(
+            $spEntityId,
+            $idpEntityId,
+            $requestId,
+            'message',
+            $originalResponse
+        );
+
+        // Parse the SAML response into a SimpleXMLElement
+        $response = base64_decode($response);
+        $responseXml = new SimpleXMLElement($response);
+
+        /**
+         * Test if the issuer was set correctly
+         * @var SimpleXMLElement $issuer
+         */
+        $responseResponse = array_pop($responseXml->xpath('/samlp:Response'));
+        self::assertEquals($responseResponse['InResponseTo'], $requestId);
+        self::assertEquals($responseResponse['Destination'], 'https://sp.example.org/assertion/consumer');
+
+        /**
+         * Test if the issuer was set correctly
+         * @var SimpleXMLElement $issuer
+         */
+        $responseIssuer = array_pop($responseXml->xpath('/samlp:Response/saml:Issuer'));
+        self::assertEquals($responseIssuer, $originalSpEntityId);
+
+        /**
+         * Test if the codes are correctly copied from the original saml failed response
+         * @var SimpleXMLElement $code
+         */
+        $responseCode = array_pop($responseXml->xpath('/samlp:Response/samlp:Status/samlp:StatusCode'));
+        $responseSubCode = array_pop($responseXml->xpath('/samlp:Response/samlp:Status/samlp:StatusCode/samlp:StatusCode'));
+        self::assertEquals($responseCode['Value'], 'testCode');
+        self::assertEquals($responseSubCode['Value'], 'testSubCode');
+    }
+
+    /**
+     * @dataProvider provideAcuData
+     */
+    public function test_get_acu(array $inputAcus, string $expectedAcu): void
+    {
+        $spEntityId = 'https://existing.example.org';
+        $mockSp = m::mock(ServiceProvider::class);
+        $mockSp->assertionConsumerServices = $inputAcus;
+        $this->repo
+            ->shouldReceive('findServiceProviderByEntityId')
+            ->with($spEntityId)
+            ->andReturn($mockSp);
+        self::assertEquals($expectedAcu, $this->helper->getAcu($spEntityId));
+    }
+
+    public function provideAcuData(): array
+    {
+        $acuLocation0 = 'https://sp.example.org/assertion/consumer';
+        $acuLocation1 = 'https://sp.example.org/assertion/consumer-1';
+        $acuLocation2 = 'https://sp.example.org/assertion/consumer-2';
+        $acuLocation3 = 'https://sp.example.org/assertion/consumer-3';
+        return [
+            'one post acs location' => [
+                [
+                    new IndexedService($acuLocation0, Constants::BINDING_HTTP_POST, 0)
+                ],
+                'https://sp.example.org/assertion/consumer'
+            ],
+            'three post acs location yields first' => [
+                [
+                    new IndexedService($acuLocation0, Constants::BINDING_HTTP_POST, 0),
+                    new IndexedService($acuLocation1, Constants::BINDING_HTTP_POST, 1),
+                    new IndexedService($acuLocation2, Constants::BINDING_HTTP_POST, 2),
+                ],
+                'https://sp.example.org/assertion/consumer'
+            ],
+            'mixed bindings, only post is returned' => [
+                [
+                    new IndexedService($acuLocation0, Constants::BINDING_HOK_SSO, 0),
+                    new IndexedService($acuLocation1, Constants::BINDING_HTTP_POST, 1),
+                    new IndexedService($acuLocation2, Constants::BINDING_HTTP_ARTIFACT, 2),
+                ],
+                'https://sp.example.org/assertion/consumer-1'
+            ],
+            'mixed bindings, only first post is returned' => [
+                [
+                    new IndexedService($acuLocation0, Constants::BINDING_HOK_SSO, 0),
+                    new IndexedService($acuLocation1, Constants::BINDING_HTTP_ARTIFACT, 1),
+                    new IndexedService($acuLocation2, Constants::BINDING_HTTP_POST, 2),
+                    new IndexedService($acuLocation3, Constants::BINDING_HTTP_POST, 3),
+                ],
+                'https://sp.example.org/assertion/consumer-2'
+            ]
+        ];
+    }
+
+    public function test_get_acu_http_post_must_be_present(): void
+    {
+        $spEntityId = 'https://existing.example.org';
+        $mockSp = m::mock(ServiceProvider::class);
+        $mockSp->assertionConsumerServices = [
+            new IndexedService('https://sp.example.org/assertion/consumer', Constants::BINDING_HOK_SSO, 0),
+            new IndexedService('https://sp.example.org/assertion/consumer', Constants::BINDING_HTTP_ARTIFACT, 1),
+            new IndexedService('https://sp.example.org/assertion/consumer', Constants::BINDING_PAOS, 1),
+            new IndexedService('https://sp.example.org/assertion/consumer', Constants::BINDING_SOAP, 1),
+        ];
+        $this->repo
+            ->shouldReceive('findServiceProviderByEntityId')
+            ->with($spEntityId)
+            ->andReturn($mockSp);
+
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage('No suitable ACS location could be find, no HTTP-POST binding available');
+        $this->helper->getAcu($spEntityId);
+    }
+
+    public function test_get_acu_of_non_existing_sp(): void
+    {
+        $spEntityId = 'https://404.example.org';
+        $mockSp = m::mock(ServiceProvider::class);
+        $mockSp->assertionConsumerServices = [
+            new IndexedService('https://sp.example.org/assertion/consumer', Constants::BINDING_HTTP_POST, 0),
+        ];
+        $this->repo
+            ->shouldReceive('findServiceProviderByEntityId')
+            ->with($spEntityId)
+            ->andReturnNull();
+
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage('The SP with entity id "https://404.example.org" could not be found while building the error response');
+        $this->helper->getAcu($spEntityId);
+    }
+}

--- a/theme/base/templates/modules/Default/View/Error/partial/footer.html.twig
+++ b/theme/base/templates/modules/Default/View/Error/partial/footer.html.twig
@@ -2,15 +2,14 @@
 <footer class="error-page-footer-buttons">
     <div class="error-page-footer-buttons__container">
         <div class="error-page-footer-buttons__row">
-{#            TODO: fix back to sp link (see https://www.pivotaltracker.com/story/show/176960606)#}
-{#            {% if hasBackToSpLink() %}#}
-{#                <div class="footer-button">#}
-{#                    <button type="submit" class="footer-button__button" form="backToSPForm">#}
-{#                        <i class="footer-button__icon fa-arrow-left"></i><br/>#}
-{#                        <span class="footer-button__text">{{ 'error_return-sp-link-text'|trans({'%spName%': getSpName()}) }}</span>#}
-{#                    </button>#}
-{#                </div>#}
-{#            {%  endif %}#}
+            {% if hasBackToSpLink() %}
+                <div class="footer-button">
+                    <button type="submit" class="footer-button__button" form="backToSPForm">
+                        <i class="footer-button__icon fa-arrow-left"></i><br/>
+                        <span class="footer-button__text">{{ 'error_return-sp-link-text'|trans({'%spName%': getSpName()}) }}</span>
+                    </button>
+                </div>
+            {%  endif %}
             {% if hasWikiLink(template) %}
                 <div class="footer-button">
                     {# The template var is set in the individual error Twigs, that's te place where we can determine what template is loaded. #}
@@ -41,7 +40,7 @@
             {%  endif %}
         </div>
     </div>
-{#    {% if hasBackToSpLink() %}#}
-{#        {% include '@theme/Authentication/View/Feedback/partial/saml_response_form.html.twig' %}#}
-{#    {% endif %}#}
+    {% if hasBackToSpLink() %}
+        {% include '@theme/Authentication/View/Feedback/partial/saml_response_form.html.twig' %}
+    {% endif %}
 </footer>


### PR DESCRIPTION
When the preconditions are met, a Back to SP link is displayed on the error feedback page. The preconditions are described and discussed on the Pivotal story found in the link below.

The way this works is as follows: when EB sees that a response from the IdP is not successful, it throws an exception. This results in a user facing feedback page where the end user is instructed that authentication failed for a given reason (they can vary (cancelled, no auth context, ..). On that page the user is kind of stuck. But by pressing the back to sp button, the user can now travel back to the SP with the SamlFailedResponse. Allowing the SP to deal with the failed authentication instead of remain stranded at Engine.

Some what was most challenging was how to port all required data to the feedback page. You kind of need a lot of information to form a good Saml failed response. And it turned out, passing along the full response from the IdP was most convenient. This response is piggy backed to the feedback controller via the FeedbackInfo session.

Not the most elegant of solutions..

What I did to make up for that is:
1. I added a test for the SamlResponseHelper
2. Produced some additional readme content, describing how to test EngineBlock step-up authentications

See: https://www.pivotaltracker.com/story/show/176960606