### PR TITLE
Display the correct privacy statement url on consent screen

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/disclaimerList.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/disclaimerList.html.twig
@@ -1,10 +1,11 @@
+{% set currentLocale = app.request.locale %}
 <ul class="consent__disclaimer">
     <li class="disclaimer__privacy disclaimer__item">
         <div>
             {% include '@theme/Authentication/View/Proxy/Partials/Consent/SVG/file_info.svg' %}
             <p>
-                <strong>{{ spName }}</strong> {{ 'consent_disclaimer_privacy_statement'|trans({ '%org%': organizationName }) }}{% if sp.coins.termsOfServiceUrl is not null %}
-                    ({{ 'consent_disclaimer_privacy_read'|trans }} <a href="{{ sp.coins.termsOfServiceUrl }}" target="_blank" rel="noreferrer noopener">{{ 'consent_disclaimer_privacy_policy'|trans }}</a>){% endif %}.
+                <strong>{{ spName }}</strong> {{ 'consent_disclaimer_privacy_statement'|trans({ '%org%': organizationName }) }}{% if sp.mdui.hasPrivacyStatementURL(currentLocale) %}
+                    ({{ 'consent_disclaimer_privacy_read'|trans }} <a href="{{ sp.mdui.getPrivacyStatementURL(currentLocale) }}" target="_blank" rel="noreferrer noopener">{{ 'consent_disclaimer_privacy_policy'|trans }}</a>){% endif %}.
             </p>
         </div>
     </li>


### PR DESCRIPTION
Previously we would show the eula URL (that we mistakenly translated to be the privacy statement of the SP). In a recent change, we use the correct value sent to us from Manage (see #1234 for details). That PR did everything to load the correct data onto the SP/IdP, but would never show it on the consent screen.

This PR fixes that.

https://www.pivotaltracker.com/story/show/185134950