### PR TITLE
Refuse to process incoming metadata push with 0 connections in it.

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -158,6 +158,11 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
                 $role->allowedIdpEntityIds = $allowedIdpEntityIds;
             }
         }
+
+        if (count($roles) === 0) {
+            throw new RuntimeException('Received 0 connections, refusing to process');
+        }
+
         return $roles;
     }
 

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -43,6 +43,17 @@ class PushMetadataAssemblerTest extends TestCase
         $this->assembler = new PushMetadataAssembler(new AllowedSchemeValidator(['http', 'https']), $logger);
     }
 
+    public function test_it_rejects_empty_push()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Received 0 connections, refusing to process');
+
+        $connection = '{}';
+        $input = json_decode($connection);
+
+        $this->assembler->assemble($input);
+    }
+
     /**
      * @dataProvider invalidAcsLocations
      */


### PR DESCRIPTION
This would effectively empty out the database. That is never a desirable outcome, so reject it, whatever the cause.