### PR TITLE
Fix WAYF placeholder.png having uninterpolated assetsVersion variable

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
@@ -19,7 +19,7 @@
         {% if idp.logo is not null %}
             {% set logoUrl = idp.logo %}
         {% else %}
-            {% set logoUrl = "/images/placeholder.png?v={{ assetsVersion }}" %}
+            {% set logoUrl = "/images/placeholder.png?v=" ~ assetsVersion %}
         {% endif %}
         <img src="{{ logoUrl }}" alt="" loading="lazy">
     </div>


### PR DESCRIPTION
The WAYF would perform requests for literally `/images/placeholder.png?v={{ assetsVersion }}`, because of this misuse of Twig variable interpolation.