### PR TITLE
Move to modern BaseContainer base image

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Pull OpenConext build container
         run: cd docker && ${DOCKER_COMPOSE} up -d
       - name: Make the release files
-        run: cd docker && ${DOCKER_COMPOSE} exec -T openconext bash -c 'HOME=/home/runner/work/OpenConext-engineblock ./bin/makeRelease.sh ${{ steps.vars.outputs.tag }}'
+        run: cd docker && ${DOCKER_COMPOSE} exec -T openconext bash -lc 'HOME=/home/runner/work/OpenConext-engineblock ./bin/makeRelease.sh ${{ steps.vars.outputs.tag }}'
       - name: Create Draft Release
         id: create_release
         uses: actions/create-release@v1

--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -64,7 +64,7 @@ fi
 
 # Install composer dependencies
 echo "Running Composer Install" &&
-php $(which composer) install -n --no-dev --prefer-dist -o
+php $(which composer) install -n --no-dev --prefer-dist --ignore-platform-req=ext-exif -o
 
 if [ $? -eq 0 ]; then
     echo "Composer install ran"

--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -64,7 +64,7 @@ fi
 
 # Install composer dependencies
 echo "Running Composer Install" &&
-php $(which composer) install -n --no-dev --prefer-dist --ignore-platform-req=ext-exif -o
+php $(which composer) install -n --no-dev --prefer-dist -o
 
 if [ $? -eq 0 ]; then
     echo "Composer install ran"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "sensio/generator-bundle": "^3.0",
         "simplesamlphp/saml2": "^4.1",
         "swiftmailer/swiftmailer": "^5.4",
-        "sybio/image-workshop": "~2.0.7",
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/swiftmailer-bundle": "^2.6",
         "symfony/symfony": "3.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "700e134839ac34b44b6286830c5caddc",
+    "content-hash": "4ea3bffda5cedfbc93ac5352054e5316",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2942,64 +2942,6 @@
             ],
             "abandoned": "symfony/mailer",
             "time": "2018-07-31T09:26:32+00:00"
-        },
-        {
-            "name": "sybio/image-workshop",
-            "version": "2.0.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Sybio/ImageWorkshop.git",
-                "reference": "b7f678b51b21c96049bd0a535382520a596d6526"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Sybio/ImageWorkshop/zipball/b7f678b51b21c96049bd0a535382520a596d6526",
-                "reference": "b7f678b51b21c96049bd0a535382520a596d6526",
-                "shasum": ""
-            },
-            "require": {
-                "ext-exif": "*",
-                "ext-gd": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "PHPImageWorkshop": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Clément Guillemain",
-                    "homepage": "http://clementguillemain.fr",
-                    "role": "Developer / Freelancer"
-                },
-                {
-                    "name": "ImageWorkshop Community",
-                    "homepage": "https://github.com/Sybio/ImageWorkshop/graphs/contributors"
-                }
-            ],
-            "description": "Powerful PHP class using GD library to work easily with images including layer notion (like Photoshop or GIMP)",
-            "homepage": "http://phpimageworkshop.com",
-            "keywords": [
-                "class",
-                "crop",
-                "gd",
-                "image",
-                "library",
-                "resize",
-                "rotate",
-                "thumbnail",
-                "watermark"
-            ],
-            "time": "2015-07-05T09:09:12+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -7214,5 +7156,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/docker/docker-compose-tag-release.yml
+++ b/docker/docker-compose-tag-release.yml
@@ -4,9 +4,7 @@ version: "3.8"
 
 services:
     openconext:
-        image: ghcr.io/openconext/openconext-containers/openconext-php-build-eb:latest
+        image: ghcr.io/openconext/openconext-basecontainers/php72-apache2-node14-composer2:latest
         volumes:
             - ../:/home/runner/work/OpenConext-engineblock
         working_dir: /home/runner/work/OpenConext-engineblock
-        environment:
-            - PHPFPM_PORT=9000


### PR DESCRIPTION
The 'openconext' container is now based on the BaseContainers Apache 2 PHP 7.2 Composer 2 Node 14 base image.

As the build tag script only utilizes npm & composer to build the tarbal, this image should suffice nicely.

To get a working tarbal a couple of minor tweaks were in order.

1. We for now ignore the dependency on ext_exif, could be added to the base container @quartje ?
2. To get npm in the path, the login script must be run when executing code in the container (`tag-release.yml` L22)