### PR TITLE
Request Access bugfixes

### DIFF
--- a/src/OpenConext/EngineBlock/Service/RequestAccessMailer.php
+++ b/src/OpenConext/EngineBlock/Service/RequestAccessMailer.php
@@ -94,7 +94,7 @@ TPL;
         $message = new Swift_Message();
         $message
             ->setSubject($subject)
-            ->setFrom($email, $name)
+            ->setFrom($this->requestAccessEmailAddress)
             ->setTo($this->requestAccessEmailAddress)
             ->setBody($body, 'text/plain');
 
@@ -127,7 +127,7 @@ TPL;
         $message = new Swift_Message();
         $message
             ->setSubject($subject)
-            ->setFrom($email, $name)
+            ->setFrom($this->requestAccessEmailAddress)
             ->setTo($this->requestAccessEmailAddress)
             ->setBody($body, 'text/plain');
 

--- a/src/OpenConext/EngineBlock/Service/RequestAccessMailer.php
+++ b/src/OpenConext/EngineBlock/Service/RequestAccessMailer.php
@@ -91,6 +91,8 @@ TPL;
             $comment
         );
 
+        // We use the destination email address also as a From since we do
+        // not have a better generic sender address available currently.
         $message = new Swift_Message();
         $message
             ->setSubject($subject)

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/requestForm.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/requestForm.html.twig
@@ -51,9 +51,9 @@
     <fieldset class="hidden">
         <legend class="hidden">Motivation</legend>
         <label for="motivation">
-            {{ 'wayf_noaccess_motivation'|trans }}
+            <strong aria-hidden="true">*</strong> {{ 'wayf_noaccess_motivation'|trans }}
         </label>
-        <textarea name="comment" id="motivation" rows="5"></textarea>
+        <textarea name="comment" required id="motivation" rows="5"></textarea>
     </fieldset>
 
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/noAccess/ctas.html.twig' %}


### PR DESCRIPTION
* The 'motivation' field seems to be actually required, since submitting the form without it filled fails (with no message). Simplest solution is to also make it required in the front end so it's clear to the user they need to fill this in. It also makes sense to require a motivation with the report.
* Mails fail to send because the From is set to the user's emailadress, which we may not be allowed to send mail as at all. Change this to the To address which we own and can send mail as.