### PR TITLE
Restore functionality of RelayState and return parameters to SPs

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/ConsentController.php
@@ -47,6 +47,7 @@ class ConsentController
         return new Response($this->twig->render('@theme/Authentication/View/Proxy/form.html.twig', [
             'action' => $action,
             'message' => $encodedMessage,
+            'xtra' => '<input type="hidden" name="RelayState" value="relaystate">',
             'name' => 'SAMLResponse',
             'preventAutoSubmit' => true
         ]), 200);

--- a/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/form.html.twig
@@ -28,6 +28,7 @@
         </p>
         <form id="ProcessForm" method="post" action="{{ action }}">
             <input type="hidden" name="{{ name }}" value="{{ message }}">
+            {{ xtra|raw }}
             <noscript>
                 <p>
                     <strong>{{ 'note'|trans }}:</strong>


### PR DESCRIPTION
This was inadvertently broken in #1272 