### PR TITLE
When starting an engine IdP debug authentication, force authentication at the IdP

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -375,6 +375,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
         $issuer = new Issuer();
         $issuer->setValue($this->_server->getUrl('spMetadataService'));
         $sspRequest->setIssuer($issuer);
+        $sspRequest->setForceAuthn(true);
 
         $request = new EngineBlock_Saml2_AuthnRequestAnnotationDecorator($sspRequest);
         $request->setDebug();

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Debug.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Debug.feature
@@ -29,3 +29,9 @@ Feature:
     And I should see "test"
     And I should see "urn:mace:terena.org:attribute-def:schacHomeOrganization"
     And I should see "engine-test-stand.openconext.org"
+
+  Scenario: A debug AuthnRequest should force the user to relogin
+    When I go to Engineblock URL "/authentication/sp/debug"
+    And I select "Second-IdP" on the WAYF
+    And I pass through EngineBlock
+    Then the received AuthnRequest should match xpath '/samlp:AuthnRequest[@ForceAuthn="true"]'


### PR DESCRIPTION
This ensures we have a fresh session of the user to test against, so any changes to the IdP config will be reflected in this debug result.