### PR TITLE
Support overriding StepUp EntityId

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -35,6 +35,7 @@ jobs:
                     ./app/console cache:clear --env=ci && \
                     cd theme && CYPRESS_INSTALL_BINARY=0 yarn install --frozen-lockfile && EB_THEME=skeune yarn build
                 '
+
             - name: Run code quality tests
               if: always()
               run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -35,7 +35,6 @@ jobs:
                     ./app/console cache:clear --env=ci && \
                     cd theme && CYPRESS_INSTALL_BINARY=0 yarn install --frozen-lockfile && EB_THEME=skeune yarn build
                 '
-
             - name: Run code quality tests
               if: always()
               run: |

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ bin/ignore_me.php
 .idea
 local-php-security-checker
 /tests/e2e/node_modules
+/tests/.phpunit.result.cache
 /languages/overrides.*.php
 /theme/node_modules
 /theme/.sass-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ We will continue to post relevant release notes on the GitHub release page. More
 
 More information about our release strategy can be found in the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes) on the EngineBlock wiki.
 
+## 6.14.0
+* A new feature was added to allow overwriting the internal StepUp auth EntityId 
+
 ## 6.13.0
 
 * Move most HTML from translatable strings into Twig templates, where it

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,24 @@
 # UPGRADE NOTES
 
+## 6.13 -> 6.14
+Previously the SAML EntityID of the EngineBlock SP that was used to do Stepup (SFO) authentications to the Stepup-Gateway 
+always was https://<engineblock.sever.domain.name>/authentication/stepup/metadata. For these authentication the default
+EngineBlock key is always used for signing.
+
+If you'd like to key-rollover the StepUp entity (baked into EngineBlock).
+The key used to sign the SAML AuthnRequests from this SP is the engineblock default key.
+
+To facilitate a rolling configuration update I want the SP entityID that is used for Stepup to be configurable so that at the same time that the engineblock default key is updated, this entityID can be changed. This then allows two entities, with two different keys, to be configured in the Stepup-Gateway.
+
+There are two new parameters that configure this behavior.
+
+1. `feature_stepup_sfo_override_engine_entityid` [bool] enables/disables the feature. Default: disabled
+2. `stepup.sfo.override_engine_entityid` [string] should be set with the Entity ID you'd like to use for the stepup EntityId. Default: ''
+
+The feature flag was added mainly to aid our test suite to easily test this feature.
+
+By default this feature is disabled and the default Entity Id is used for the StepUp entity.
+
 ## 6.12 -> 6.13
 
 Some translatable strings have been changed and "raw" use of HTML in

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -27,6 +27,8 @@ open_conext_engine_block:
         eb.enable_sso_notification: "%feature_enable_sso_notification%"
         eb.feature_enable_consent: "%feature_enable_consent%"
         eb.enable_sso_session_cookie: "%feature_enable_sso_session_cookie%"
+        eb.stepup.sfo.override_engine_entityid: "%feature_stepup_sfo_override_engine_entityid%"
+
 
 swiftmailer:
     transport: "%mailer_transport%"

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -48,6 +48,7 @@ monolog:
             activation_strategy: engineblock.logger.manual_or_error_activation_strategy
             passthru_level: "%logger.fingers_crossed.passthru_level%"
             handler: file
+            channels: ['!event']
         file:
             type:   stream
             path:   "%kernel.logs_dir%/%kernel.environment%.log"

--- a/app/config/functional_testing.yml.dist
+++ b/app/config/functional_testing.yml.dist
@@ -3,5 +3,6 @@ parameters:
     router.request_context.scheme: "https"
 
     # Where must we store the writable state of the Mock IdP and Mock SP?
-    idp_fixture_file:   "%kernel.root_dir%/../tmp/fixtures/db/idp.states.php.serialized"
-    sp_fixture_file:    "%kernel.root_dir%/../tmp/fixtures/db/sp.states.php.serialized"
+    idp_fixture_file: '/tmp/eb-fixtures/db/idp.states.php.serialized'
+    sp_fixture_file: '/tmp/eb-fixtures/db/sp.states.php.serialized'
+    stepup.sfo.override_engine_entityid: 'https://engine.vm.openconext.com/new/stepup/metadata'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -223,6 +223,7 @@ parameters:
     feature_run_all_manipulations_prior_to_consent: false
     feature_block_user_on_violation: false
     feature_enable_consent: true
+    feature_stepup_sfo_override_engine_entityid: false
 
     ##########################################################################################
     ## PROFILE SETTINGS
@@ -261,6 +262,7 @@ parameters:
     stepup.gateway.sfo.sso_location: 'https://gateway.stepup.vm.openconext.org/second-factor-only/single-sign-on'
     ## The public key from the Stepup Gateway IdP
     stepup.gateway.sfo.key_file: /etc/openconext/engineblock.crt
+    stepup.sfo.override_engine_entityid: 'https://engine.vm.openconext.com/new/stepup/metadata'
 
     ##########################################################################################
     ## THEME SETTINGS

--- a/docker/php-fpm/Dockerfile-php72
+++ b/docker/php-fpm/Dockerfile-php72
@@ -3,6 +3,7 @@ FROM ghcr.io/openconext/openconext-basecontainers/php72-apache2-node16-composer2
 RUN a2enmod ssl
 # Copy phpfpm config
 COPY docker/php-fpm/app.ini /usr/local/etc/php/conf.d/
+RUN rm -rf /etc/apache2/sites-enabled/*
 COPY docker/php-fpm/apache2.conf /etc/apache2/sites-enabled/
 RUN chown -R www-data: /var/www/
 WORKDIR /opt/openconext/OpenConext-engineblock

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -17,7 +17,7 @@
  */
 
 use Doctrine\ORM\EntityManager;
-use OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactor;
+use OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactory;
 use OpenConext\EngineBlock\Metadata\LoaRepository;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\EngineBlock\Service\MfaHelperInterface;
@@ -519,6 +519,12 @@ class EngineBlock_Application_DiContainer extends Pimple
     protected function getStepupEndpoint()
     {
         return $this->container->get('engineblock.configuration.stepup.endpoint');
+    }
+
+    /** @return string */
+    public function getStepupEntityIdOverrideValue()
+    {
+        return $this->container->getParameter('stepup.sfo.override_engine_entityid');
     }
 
     public function getCookieDomain()

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactory.php
@@ -35,6 +35,7 @@ use OpenConext\EngineBlockBundle\Url\UrlProvider;
 /**
  * This factory is used for instantiating an entity with the required adapters and/or decorators set.
  * It also makes sure that static, internally used, entities can be generated without the use of the database.
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ServiceProviderFactory
 {
@@ -108,7 +109,10 @@ class ServiceProviderFactory
 
         if ($isEnabled && $isConfigured) {
             if (empty($this->entityIdOverrideValue)) {
-                throw new MissingParameterException('When feature "feature_stepup_sfo_override_engine_entityid" is enabled, you must provide the "stepup.sfo.override_engine_entityid" parameter.');
+                throw new MissingParameterException(
+                    'When feature "feature_stepup_sfo_override_engine_entityid" is enabled, you must provide the '.
+                    '"stepup.sfo.override_engine_entityid" parameter.'
+                );
             }
             $entityId = $this->entityIdOverrideValue;
         }

--- a/src/OpenConext/EngineBlock/Stepup/StepupEntityFactory.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupEntityFactory.php
@@ -18,7 +18,6 @@
 namespace OpenConext\EngineBlock\Stepup;
 
 use EngineBlock_X509_CertificateFactory;
-use OpenConext\EngineBlock\Metadata\EmptyMduiElement;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\IndexedService;
@@ -29,7 +28,6 @@ use SAML2\Constants;
 
 class StepupEntityFactory
 {
-
     /**
      * @throws \EngineBlock_Exception
      */

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -45,6 +45,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.enable_sso_notification', false));
         $this->setFeature(new Feature('eb.feature_enable_consent', true));
         $this->setFeature(new Feature('eb.enable_sso_session_cookie', true));
+        $this->setFeature(new Feature('eb.stepup.sfo.override_engine_entityid', false));
     }
 
     public function setFeature(Feature $feature): void

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -129,6 +129,8 @@ services:
             - '@OpenConext\EngineBlock\Metadata\X509\KeyPairFactory'
             - '@OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration'
             - '@engineblock.url_provider'
+            - '@engineblock.features'
+            - '%stepup.sfo.override_engine_entityid%'
 
     OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration:
         public: false

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/StepupMockController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/StepupMockController.php
@@ -96,6 +96,10 @@ class StepupMockController extends Controller
         $samlResponse = $this->mockStepupGateway->handleSsoSuccess($request, $this->getFullRequestUri($request));
         $results['success'] = $this->getResponseData($request, $samlResponse);
 
+        // Parse successfull loa3 with changed audience
+        $samlResponse = $this->mockStepupGateway->handleSsoSuccess($request, $this->getFullRequestUri($request), true);
+        $results['success-audience'] = $this->getResponseData($request, $samlResponse);
+
         // Parse successfull loa2
         $samlResponse = $this->mockStepupGateway->handleSsoSuccessLoa2($request, $this->getFullRequestUri($request));
         $results['loa2'] = $this->getResponseData($request, $samlResponse);

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -18,14 +18,11 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
-use Ingenerator\BehatTableAssert\AssertTable;
-use Ingenerator\BehatTableAssert\TableParser\HTMLTable;
 use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingAttributeAggregationClient;
 use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingAuthenticationLoopGuard;
 use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\FunctionalTestingFeatureConfiguration;
@@ -39,10 +36,6 @@ use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RuntimeException;
 use SAML2\Constants;
 use SAML2\DOMDocumentFactory;
-use function assertStringNotMatchesFormat;
-use function assertStringStartsWith;
-use function preg_match;
-use function sprintf;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyPublicMethods) Both set up and tasks can be a lot...

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/StepupContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/StepupContext.php
@@ -72,6 +72,16 @@ class StepupContext extends AbstractSubContext
     }
 
     /**
+     * @Given /^Stepup will successfully verify a user with override entityID$/
+     */
+    public function stepupWillsSuccessfullyVerifyAUserAndUpdateAudience()
+    {
+        $mink = $this->getMinkContext();
+
+        $mink->pressButton('Submit-success-audience');
+    }
+
+    /**
      * @Given /^Stepup will successfully verify a user with a LoA 2 token$/
      */
     public function stepupWillsSuccessfullyVerifyAUserLoa2()

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/StepupKeyRollover.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/StepupKeyRollover.feature
@@ -37,7 +37,7 @@ Feature:
     And I pass through EngineBlock
     # This is where the Issuer is overridden. See: \EngineBlock_Corto_ProxyServer::sendStepupAuthenticationRequest
     And I pass through the IdP
-    And Stepup will successfully verify a user
+    And Stepup will successfully verify a user with override entityID
     And I give my consent
     And I pass through EngineBlock
     Then the url should match "/functional-testing/SSO-SP/acs"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/StepupKeyRollover.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/StepupKeyRollover.feature
@@ -1,0 +1,35 @@
+Feature:
+  In order to facilitate a rolling configuration update
+  As EngineBlock
+  I want the SP entityID that is used for Stepup auth to be configurable so that at the same time
+  that the EngineBlock default key is updated, this entityID can be changed.
+  This then allows two entities, with two different keys, to be configured in the Stepup-Gateway
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+    And no registered SPs
+    And no registered Idps
+    And an Identity Provider named "SSO-IdP"
+    And a Service Provider named "SSO-SP"
+    And an Identity Provider named "Dummy-IdP"
+    And a Service Provider named "Dummy-SP"
+    And a Service Provider named "Proxy-SP"
+
+  Scenario: When stepup.sfo.override_engine_entityid is not configured, stepup/metadata should show default EntityId
+    Given feature "eb.stepup.sfo.override_engine_entityid" is disabled
+    When I go to Engineblock URL "/authentication/stepup/metadata"
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.org/authentication/stepup/metadata"]'
+
+  Scenario: When stepup.sfo.override_engine_entityid is configured with a valid EntityId, stepup/metadata should show that EntityId
+    Given feature "eb.stepup.sfo.override_engine_entityid" is enabled
+    When I go to Engineblock URL "/authentication/stepup/metadata"
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.com/new/stepup/metadata"]'
+
+  Scenario: When stepup.sfo.override_engine_entityid is configured, the the Issuer is updated
+    Given the SP "SSO-SP" requires Stepup LoA "http://vm.openconext.org/assurance/loa2"
+    And feature "eb.stepup.sfo.override_engine_entityid" is enabled
+    When I log in at "SSO-SP"
+    And I select "SSO-IdP" on the WAYF
+    Then the response should match xpath '//md:EntityDescriptor[@entityID="https://engine.vm.openconext.com/new/stepup/metadata"]'
+
+

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/FunctionalTestingFeatureConfiguration.php
@@ -42,7 +42,7 @@ final class FunctionalTestingFeatureConfiguration implements FeatureConfiguratio
      */
     private $dataStore;
 
-    public function __construct(TestFeatureConfiguration $featureConfiguration, AbstractDataStore $dataStore)
+    public function __construct(FeatureConfigurationInterface $featureConfiguration, AbstractDataStore $dataStore)
     {
         $this->featureConfiguration = $featureConfiguration;
         $this->dataStore            = $dataStore;

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/mocks.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/mocks.yml
@@ -30,3 +30,4 @@ services:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockStepupGateway
         arguments:
             - "@engineblock.functional_testing.fixture.stepup_gateway_mock"
+            - '%stepup.sfo.override_engine_entityid%'

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/config/services.yml
@@ -1,12 +1,12 @@
 parameters:
-    engineblock.functional_testing.service_registry_data_store.dir:           "%kernel.root_dir%/../tmp/eb-fixtures/metadata-push/"
-    engineblock.functional_testing.service_registry_data_store.file:          "%kernel.root_dir%/../tmp/eb-fixtures/metadata-push/entities"
-    engineblock.functional_testing.features_data_store.file:                  "%kernel.root_dir%/../tmp/eb-fixtures/features.json"
-    engineblock.functional_testing.authentication_loop_guard_data_store.file: "%kernel.root_dir%/../tmp/eb-fixtures/authentication-loop-guard.json"
-    engineblock.functional_testing.pdp_data_store.file:                       "%kernel.root_dir%/../tmp/eb-fixtures/policy_decision.json"
-    engineblock.functional_testing.attribute_aggregation_data_store.file:     "%kernel.root_dir%/../tmp/eb-fixtures/attribute_aggregation.json"
-    engineblock.functional_testing.stepup_gateway_mock_data_store.file:       "%kernel.root_dir%/../tmp/eb-fixtures/stepup_gateway_mock.json"
-    engineblock.functional_testing.translator_mock_data_store.file:           "%kernel.root_dir%/../tmp/eb-fixtures/translator_mock.json"
+    engineblock.functional_testing.service_registry_data_store.dir:           "/tmp/eb-fixtures/metadata-push/"
+    engineblock.functional_testing.service_registry_data_store.file:          "/tmp/eb-fixtures/metadata-push/entities"
+    engineblock.functional_testing.features_data_store.file:                  "/tmp/eb-fixtures/features.json"
+    engineblock.functional_testing.authentication_loop_guard_data_store.file: "/tmp/eb-fixtures/authentication-loop-guard.json"
+    engineblock.functional_testing.pdp_data_store.file:                       "/tmp/eb-fixtures/policy_decision.json"
+    engineblock.functional_testing.attribute_aggregation_data_store.file:     "/tmp/eb-fixtures/attribute_aggregation.json"
+    engineblock.functional_testing.stepup_gateway_mock_data_store.file:       "/tmp/eb-fixtures/stepup_gateway_mock.json"
+    engineblock.functional_testing.translator_mock_data_store.file:           "/tmp/eb-fixtures/translator_mock.json"
 
 services:
     engineblock.functional_testing.service.engine_block:
@@ -109,3 +109,13 @@ services:
         class: OpenConext\EngineBlockBundle\Configuration\ErrorFeedbackConfiguration
         arguments:
             - "@engineblock.functional_testing.mock.translator"
+
+    engineblock.factory.service_provider_factory:
+        class: OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactory
+        arguments:
+            - '@engineblock.compat.metadata.definitions'
+            - '@OpenConext\EngineBlock\Metadata\X509\KeyPairFactory'
+            - '@OpenConext\EngineBlock\Metadata\Factory\ValueObject\EngineBlockConfiguration'
+            - '@engineblock.url_provider'
+            - '@engineblock.functional_testing.fixture.features'
+            - '%stepup.sfo.override_engine_entityid%'

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -87,4 +87,3 @@ default:
                                     - "--no-sandbox"
                                     - "--disable-dev-shm-usage"
         Behat\Symfony2Extension: ~
-


### PR DESCRIPTION
Currently the SAML EntityID of the engineblock SP that us used to do Stepup (SFO) authenticatons to the Stepup-Gateway is always https://<engineblock.sever.domain.name>/authentication/stepup/metadata

The key used to sign the SAML AuthnRequests from this SP is the engineblock default key.

To facilitate a rolling configuration update I want the SP entityID that is used for Stepup to be configurable so that at the same time that the engineblock default key is updated, this entityID can be changed. This then allows two entities, with two different keys, to be configured in the Stepup-Gateway.

https://www.pivotaltracker.com/story/show/186200738