### PR TITLE
Stepup ACS: add check that returned NameID matches the one we requested.

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
@@ -129,14 +129,20 @@ class EngineBlock_Corto_Module_Service_StepupAssertionConsumer implements Engine
 
         // Get active request
         $processStep = $this->_processingStateHelper->getStepByRequestId($receivedRequest->getId(), ProcessingStateHelperInterface::STEP_STEPUP);
-        $receivedResponse = $processStep->getResponse();
+        $originalReceivedResponse = $processStep->getResponse();
+
+        // Only non-error responses will have a NameID in them
+        if ($checkResponseSignature) {
+            $this->verifyReceivedNameID($originalReceivedResponse, $receivedResponse);
+        }
 
         $nextProcessStep = $this->_processingStateHelper->getStepByRequestId(
             $receivedRequest->getId(),
             ProcessingStateHelperInterface::STEP_CONSENT
         );
 
-        $this->_server->sendConsentAuthenticationRequest($receivedResponse, $receivedRequest, $nextProcessStep->getRole(), $this->getAuthenticationState());
+
+        $this->_server->sendConsentAuthenticationRequest($originalReceivedResponse, $receivedRequest, $nextProcessStep->getRole(), $this->getAuthenticationState());
 
         return;
     }
@@ -308,5 +314,21 @@ class EngineBlock_Corto_Module_Service_StepupAssertionConsumer implements Engine
             );
         }
         $log->info('Received a suitable LoA response from the stepup gateway.');
+    }
+
+    /**
+     * The NameID that the assertion from Stepup reports back, must always match the one we
+     * requested Stepup for when sending the request to Stepup. As a defense in depth against
+     * any gaps elsewhere, we doublecheck that this indeed matches.
+     */
+    private function verifyReceivedNameID(
+        EngineBlock_Saml2_ResponseAnnotationDecorator $originalReceivedResponse,
+        EngineBlock_Saml2_ResponseAnnotationDecorator $stepupReceivedResponse
+    ): void {
+        if ($originalReceivedResponse->getNameID()->getValue() !== $stepupReceivedResponse->getNameID()->getValue()) {
+            throw new EngineBlock_Exception(
+                'Stepup authentication failed, the received NameID from Stepup does not match the one we sent out.'
+            );
+        }
     }
 }


### PR DESCRIPTION
This should always be the case, we request a LoA from Stepup for NameID A, then we should receive a response that contains that same NameID A. This is defense in depth, should at some point in the entire chain another check fail and an adversary be able to switch or replay assertions, this will guard against them being accepted by Engineblock as valid.