### PR TITLE
Default feature block_user_on_violation to on

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -221,7 +221,7 @@ parameters:
     feature_api_metadata_api: true
     feature_api_deprovision: true
     feature_run_all_manipulations_prior_to_consent: false
-    feature_block_user_on_violation: false
+    feature_block_user_on_violation: true
     feature_enable_consent: true
     feature_stepup_sfo_override_engine_entityid: false
 


### PR DESCRIPTION
For new installs this makes sense - the scope check is only done when you add scopes in Manage anyway, but if you add them, it's a safer default that they are actually enforced.

The feature flag mostly exists to phase in scopes where you previously not had enabled them, so you want to start logging first.