### PR TITLE
Improve social previews of EB URLs

### DIFF
--- a/theme/base/templates/layouts/scripts/default.html.twig
+++ b/theme/base/templates/layouts/scripts/default.html.twig
@@ -7,6 +7,9 @@
     <meta content="initial-scale=1.0,width=device-width" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="translucent-black" name="apple-mobile-web-app-status-bar-style">
+    <meta property="og:title" content="{{ defaultTitle }}">
+    <meta property="og:site_name" content="{{ defaultTitle }}">
+    <meta property="og:image" content="{{ defaultLogo }}">
     <title>{% block title %}{{ defaultTitle }}{% endblock %}</title>
     <link href="/favicon.ico?v={{ assetsVersion }}" rel="shortcut icon" type="image/x-icon">
     {% block stylesheets %}{% spaceless %}


### PR DESCRIPTION
This happens mostly when someone pastes a link to a social medium which redirects immediately to OpenConext and e.g. shows a WAYF. The social preview of that link is then the logo of the first IdP in the wayf. This improves on that by ensuring that the logo used is the OpenConext instance's own logo. This is a less "random" experience.

There are more fields available in the OpenGraph specification but we do not have readily available content for those fields. The fields we add now we can fill with information we already have in the template so are a quick way to improve the social previews over the previous situation.