### PR TITLE
Check for needed parameters before constructing an auth failed response.

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
@@ -155,15 +155,16 @@ class Feedback extends Twig_Extension
         return '';
     }
 
-    public function hasBackToSpLink()
+    public function hasBackToSpLink(): bool
     {
         $info = $this->retrieveFeedbackInfo();
+        if (!$info->has('serviceProvider') ||
+            !$info->has('identityProvider') ||
+            !$info->has('requestId')) {
+            return false;
+        }
         $response = $this->getSamlFailedResponse();
-
-        return $info->has('serviceProvider') &&
-            $info->has('identityProvider') &&
-            $info->has('requestId') &&
-            $response !== '';
+        return $response !== '';
     }
 
     public function getSpName(): ?string


### PR DESCRIPTION
The function will return false if any of the needed info is not available, however EB would already fail with a type error inside the getSamlFailedResponse() method. By reordering these checks we prevent the type error for this case.

Closes: #1288