### PR TITLE
Support for authentication logging enrichment

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -293,3 +293,13 @@ parameters:
     # If set to 0 the cookie will expire at the end of the session (when the browser closes).
     sso_session_cookie_max_age: 0
 
+    ##########################################################################################
+    ## Authentication log enrichment
+    ##########################################################################################
+    # When a user successfully authenticates and additional logging to the authentication log is desired, the following
+    # parameter can be used to define a mapping of attributes that will be used to enrich the authentication log.
+    # A (list) mapping is for example <attributeLabel>: <attributeName> where the label represents the label that is
+    # used in the authentication log record. The attributeName will be searched in the response attributes and if present
+    # the log data will be enriched.
+    auth.log.attributes: []
+

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -300,6 +300,6 @@ parameters:
     # parameter can be used to define a mapping of attributes that will be used to enrich the authentication log.
     # A (list) mapping is for example <attributeLabel>: <attributeName> where the label represents the label that is
     # used in the authentication log record. The attributeName will be searched in the response attributes and if present
-    # the log data will be enriched.
+    # the log data will be enriched. The values of the response attributes are the final values after ARP and Attribute Manipulation.
     auth.log.attributes: []
 

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -555,4 +555,12 @@ class EngineBlock_Application_DiContainer extends Pimple
     {
         return $this->container->get('engineblock.service.sso_notification');
     }
+
+    /**
+     * @return array
+     */
+    public function getAuthLogAttributes()
+    {
+        return $this->container->getParameter('auth.log.attributes');
+    }
 }

--- a/library/EngineBlock/Corto/Filter/Command/LogLogin.php
+++ b/library/EngineBlock/Corto/Filter/Command/LogLogin.php
@@ -56,10 +56,10 @@ class EngineBlock_Corto_Filter_Command_LogLogin extends EngineBlock_Corto_Filter
 
         $logAttributes = [];
         if (!empty($this->configuredLogAttributes)) {
-            foreach ($this->configuredLogAttributes as $attributeKey => $attributeValue) {
-                if (!empty($this->_responseAttributes[$attributeValue])) {
-                    $attributeValues = implode(',', $this->_responseAttributes[$attributeValue]);
-                    $logAttributes[$attributeKey] = $attributeValues;
+            foreach ($this->configuredLogAttributes as $attributeLabel => $responseAttributeKey) {
+                if (array_key_exists($responseAttributeKey, $this->_responseAttributes)) {
+                    $attributeValues = implode(',', $this->_responseAttributes[$responseAttributeKey]);
+                    $logAttributes[$attributeLabel] = $attributeValues;
                 }
             }
         }

--- a/library/EngineBlock/Corto/Filter/Command/LogLogin.php
+++ b/library/EngineBlock/Corto/Filter/Command/LogLogin.php
@@ -25,9 +25,15 @@ class EngineBlock_Corto_Filter_Command_LogLogin extends EngineBlock_Corto_Filter
      */
     private $authenticationLogger;
 
-    public function __construct(AuthenticationLoggerAdapter $authenticationLogger)
+    /**
+     * @var array
+     */
+    private $configuredLogAttributes;
+
+    public function __construct(AuthenticationLoggerAdapter $authenticationLogger, array $configuredLogAttributes)
     {
         $this->authenticationLogger = $authenticationLogger;
+        $this->configuredLogAttributes = $configuredLogAttributes;
     }
 
     public function execute()
@@ -48,6 +54,16 @@ class EngineBlock_Corto_Filter_Command_LogLogin extends EngineBlock_Corto_Filter
         // Remove the SP that is our next hop
         array_pop($requesterChain);
 
+        $logAttributes = [];
+        if (!empty($this->configuredLogAttributes)) {
+            foreach ($this->configuredLogAttributes as $attributeKey => $attributeValue) {
+                if (!empty($this->_responseAttributes[$attributeValue])) {
+                    $attributeValues = implode(',', $this->_responseAttributes[$attributeValue]);
+                    $logAttributes[$attributeKey] = $attributeValues;
+                }
+            }
+        }
+
         $this->authenticationLogger->logLogin(
             $this->_serviceProvider,
             $this->_identityProvider,
@@ -57,7 +73,8 @@ class EngineBlock_Corto_Filter_Command_LogLogin extends EngineBlock_Corto_Filter
             $this->_response->getNameIdValue(),
             $this->_response->getAssertion()->getAuthnContextClassRef(),
             $this->_request->getDestination(),
-            $this->_request->getIDPList()
+            $this->_request->getIDPList(),
+            $logAttributes
         );
     }
 }

--- a/library/EngineBlock/Corto/Filter/Output.php
+++ b/library/EngineBlock/Corto/Filter/Output.php
@@ -87,7 +87,7 @@ class EngineBlock_Corto_Filter_Output extends EngineBlock_Corto_Filter_Abstract
             new EngineBlock_Corto_Filter_Command_DenormalizeAttributes(),
 
             // Log the login
-            new EngineBlock_Corto_Filter_Command_LogLogin($diContainer->getAuthenticationLogger()),
+            new EngineBlock_Corto_Filter_Command_LogLogin($diContainer->getAuthenticationLogger(), $diContainer->getAuthLogAttributes()),
         );
     }
 }

--- a/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
+++ b/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
@@ -79,10 +79,8 @@ class AuthenticationLogger
             'authncontextclassref' => $authnContextClassRef,
             'requestedidps' => $requestedIdPlist,
             'engine_sso_endpoint_used' => $engineSsoEndpointUsed,
+            'response_attributes' => $logAttributes
         ];
-        if (!empty($logAttributes)) {
-            $logData = array_merge($logData, $logAttributes);
-        }
 
         $this->logger->info(
             'login granted',

--- a/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
+++ b/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
@@ -78,9 +78,11 @@ class AuthenticationLogger
             'original_name_id' => $originalNameId,
             'authncontextclassref' => $authnContextClassRef,
             'requestedidps' => $requestedIdPlist,
-            'engine_sso_endpoint_used' => $engineSsoEndpointUsed,
-            'response_attributes' => $logAttributes
+            'engine_sso_endpoint_used' => $engineSsoEndpointUsed
         ];
+        if (!empty($logAttributes)) {
+            $logData['response_attributes'] = $logAttributes;
+        }
 
         $this->logger->info(
             'login granted',

--- a/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
+++ b/src/OpenConext/EngineBlock/Logger/AuthenticationLogger.php
@@ -55,7 +55,8 @@ class AuthenticationLogger
         ?string $authnContextClassRef,
         ?string $engineSsoEndpointUsed,
         ?array $requestedIdPlist,
-        KeyId $keyId = null
+        KeyId $keyId = null,
+        array $logAttributes = []
     ) {
         $proxiedServiceProviderEntityIds = array_map(
             function (Entity $entity) {
@@ -66,21 +67,26 @@ class AuthenticationLogger
 
         $timestamp = $this->generateTimestamp();
 
+        $logData = [
+            'login_stamp' => $timestamp,
+            'user_id' => $collabPersonId->getCollabPersonId(),
+            'sp_entity_id' => $serviceProvider->getEntityId()->getEntityId(),
+            'idp_entity_id' => $identityProvider->getEntityId()->getEntityId(),
+            'key_id' => $keyId ? $keyId->getKeyId() : null,
+            'proxied_sp_entity_ids' => $proxiedServiceProviderEntityIds,
+            'workflow_state' => $workflowState,
+            'original_name_id' => $originalNameId,
+            'authncontextclassref' => $authnContextClassRef,
+            'requestedidps' => $requestedIdPlist,
+            'engine_sso_endpoint_used' => $engineSsoEndpointUsed,
+        ];
+        if (!empty($logAttributes)) {
+            $logData = array_merge($logData, $logAttributes);
+        }
+
         $this->logger->info(
             'login granted',
-            [
-                'login_stamp' => $timestamp,
-                'user_id' => $collabPersonId->getCollabPersonId(),
-                'sp_entity_id' => $serviceProvider->getEntityId()->getEntityId(),
-                'idp_entity_id' => $identityProvider->getEntityId()->getEntityId(),
-                'key_id' => $keyId ? $keyId->getKeyId() : null,
-                'proxied_sp_entity_ids' => $proxiedServiceProviderEntityIds,
-                'workflow_state' => $workflowState,
-                'original_name_id' => $originalNameId,
-                'authncontextclassref' => $authnContextClassRef,
-                'requestedidps' => $requestedIdPlist,
-                'engine_sso_endpoint_used' => $engineSsoEndpointUsed,
-            ]
+            $logData
         );
     }
 

--- a/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
+++ b/src/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapter.php
@@ -39,6 +39,21 @@ class AuthenticationLoggerAdapter
         $this->authenticationLogger = $authenticationLogger;
     }
 
+    /**
+     * @param ServiceProvider $serviceProvider
+     * @param IdentityProvider $identityProvider
+     * @param string $collabPersonId
+     * @param string|null $keyId
+     * @param array $proxiedServiceProviders
+     * @param string $originalNameId
+     * @param string|null $authnContextClassRef
+     * @param string|null $engineSsoEndpointUsed
+     * @param array|null $requestedIdPlist
+     * @param array $logAttributes
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
     public function logLogin(
         ServiceProvider $serviceProvider,
         IdentityProvider $identityProvider,
@@ -48,7 +63,8 @@ class AuthenticationLoggerAdapter
         string $originalNameId,
         ?string $authnContextClassRef,
         ?string $engineSsoEndpointUsed,
-        ?array $requestedIdPlist
+        ?array $requestedIdPlist,
+        array $logAttributes = []
     ) {
         $keyId = $keyId ? new KeyId($keyId) : null;
 
@@ -69,7 +85,8 @@ class AuthenticationLoggerAdapter
             $authnContextClassRef,
             $engineSsoEndpointUsed,
             $requestedIdPlist,
-            $keyId
+            $keyId,
+            $logAttributes
         );
     }
 }

--- a/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
@@ -123,6 +123,93 @@ class AuthenticationLoggerTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     * @group EngineBlock
+     * @group Logger
+     */
+    public function the_logged_context_contains_all_enriched_information()
+    {
+        // raw data so we can compare later on
+        $serviceProviderEntityId  = 'SpEntityId';
+        $identityProviderEntityId = 'IdpEntityId';
+        $collabPersonIdValue      = 'urn:collab:person:openconext:some-person';
+        $keyIdValue               = '20160403';
+        $spProxy1EntityId         = 'SpProxy1EntityId';
+        $spProxy2EntityId         = 'SpProxy2EntityId';
+        $originalNameId           = 'urn:collab:person:original:some-person';
+        $authnContextClassRef     = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
+        $requestedIdPs            = ['aap', 'noot'];
+        $ssoEndpointUsed          = '/authentication/idp/single-sign-on';
+
+        $serviceProvider       = new Entity(new EntityId($serviceProviderEntityId), EntityType::SP());
+        $identityProvider      = new Entity(new EntityId($identityProviderEntityId), EntityType::IdP());
+        $collabPersonId        = new CollabPersonId($collabPersonIdValue);
+        $keyId                 = new KeyId($keyIdValue);
+        $serviceProviderProxy1 = new Entity(new EntityId($spProxy1EntityId), EntityType::SP());
+        $serviceProviderProxy2 = new Entity(new EntityId($spProxy2EntityId), EntityType::SP());
+        $logAttributes         = ['label' => 'attributeValue'];
+
+        // do note we omit login_stamp here as we check presence separately, but don't want to compare the value
+        $expected = [
+            'sp_entity_id' => $serviceProviderEntityId,
+            'idp_entity_id' => $identityProviderEntityId,
+            'user_id' => $collabPersonIdValue,
+            'key_id' => $keyIdValue,
+            'proxied_sp_entity_ids' => [$spProxy1EntityId, $spProxy2EntityId],
+            'workflow_state' => AbstractRole::WORKFLOW_STATE_PROD,
+            'original_name_id' => $originalNameId,
+            'authncontextclassref' => $authnContextClassRef,
+            'requestedidps' => $requestedIdPs,
+            'engine_sso_endpoint_used' => $ssoEndpointUsed,
+            'label' => 'attributeValue'
+        ];
+
+        $mockLogger = m::mock('\Psr\Log\LoggerInterface');
+        $mockLogger
+            ->shouldReceive('info')
+            ->withArgs([
+                m::any(),
+                m::on(function ($context) use ($expected) {
+                    if (!array_key_exists('login_stamp', $context)) {
+                        return false;
+                    }
+
+                    if (!$this->assertFormatting($context['login_stamp'], 'Y-m-d\TH:i:s.uP')) {
+                        return false;
+                    }
+
+                    foreach ($expected as $key => $value) {
+                        if (!isset($context[$key])) {
+                            return false;
+                        }
+
+                        if (!$context[$key] === $value) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                })
+            ])
+            ->once();
+
+        $authenticationLogger = new AuthenticationLogger($mockLogger);
+        $authenticationLogger->logGrantedLogin(
+            $serviceProvider,
+            $identityProvider,
+            $collabPersonId,
+            [$serviceProviderProxy1, $serviceProviderProxy2],
+            AbstractRole::WORKFLOW_STATE_PROD,
+            $originalNameId,
+            $authnContextClassRef,
+            $ssoEndpointUsed,
+            $requestedIdPs,
+            $keyId,
+            $logAttributes
+        );
+    }
+
     private function assertFormatting($loginStamp, $format)
     {
         $dateTime = DateTime::createFromFormat($format, $loginStamp);

--- a/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Logger/AuthenticationLoggerTest.php
@@ -162,7 +162,7 @@ class AuthenticationLoggerTest extends TestCase
             'authncontextclassref' => $authnContextClassRef,
             'requestedidps' => $requestedIdPs,
             'engine_sso_endpoint_used' => $ssoEndpointUsed,
-            'label' => 'attributeValue'
+            'response_attributes' => ['label' => 'attributeValue']
         ];
 
         $mockLogger = m::mock('\Psr\Log\LoggerInterface');

--- a/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/Logger/AuthenticationLoggerAdapterTest.php
@@ -79,6 +79,7 @@ class AuthenticationLoggerAdapterTest extends TestCase
                     $ssoEndpointUsed,
                     $requestedIdPs,
                     new ValueObjectEqualsMatcher(new KeyId($keyIdValue)),
+                    []
                 ]
             )
             ->once();
@@ -97,6 +98,70 @@ class AuthenticationLoggerAdapterTest extends TestCase
             $authnContextClassRef,
             $ssoEndpointUsed,
             $requestedIdPs
+        );
+    }
+
+    /**
+     * @test
+     * @group EngineBlockBridge
+     * @group Logger
+     */
+    public function arguments_with_log_attributes_are_converted_correctly()
+    {
+        $serviceProviderEntityId  = 'SpEntityId';
+        $identityProviderEntityId = 'IdpEntityId';
+        $collabPersonIdValue      = 'urn:collab:person:openconext:some-person';
+        $keyIdValue               = '20160403';
+        $spProxy1EntityId         = 'SpProxy1EntityId';
+        $spProxy2EntityId         = 'SpProxy2EntityId';
+        $originalNameId           = 'urn:collab:person:original:some-person';
+        $authnContextClassRef     = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
+        $requestedIdPs            = ['aap', 'noot'];
+        $ssoEndpointUsed          = '/authentication/idp/single-sign-on';
+        $logAttributes            = ['label' => 'attributeValue'];
+
+        $mockAuthenticationLogger = m::mock(AuthenticationLogger::class);
+        $mockAuthenticationLogger
+            ->shouldReceive('logGrantedLogin')
+            ->withArgs(
+                [
+                    new ValueObjectEqualsMatcher(new Entity(new EntityId($serviceProviderEntityId), EntityType::SP())),
+                    new ValueObjectEqualsMatcher(
+                        new Entity(new EntityId($identityProviderEntityId), EntityType::IdP())
+                    ),
+                    new ValueObjectEqualsMatcher(new CollabPersonId($collabPersonIdValue)),
+                    new ValueObjectListEqualsMatcher(
+                        [
+                            new Entity(new EntityId($spProxy1EntityId), EntityType::SP()),
+                            new Entity(new EntityId($spProxy2EntityId), EntityType::SP()),
+                        ]
+                    ),
+                    AbstractRole::WORKFLOW_STATE_PROD,
+                    $originalNameId,
+                    $authnContextClassRef,
+                    $ssoEndpointUsed,
+                    $requestedIdPs,
+                    new ValueObjectEqualsMatcher(new KeyId($keyIdValue)),
+                    $logAttributes
+                ]
+            )
+            ->once();
+
+        $authenticationLoggerAdapter = new AuthenticationLoggerAdapter($mockAuthenticationLogger);
+        $authenticationLoggerAdapter->logLogin(
+            new ServiceProvider($serviceProviderEntityId),
+            new IdentityProvider($identityProviderEntityId),
+            $collabPersonIdValue,
+            $keyIdValue,
+            [
+                new ServiceProvider($spProxy1EntityId),
+                new ServiceProvider($spProxy2EntityId),
+            ],
+            $originalNameId,
+            $authnContextClassRef,
+            $ssoEndpointUsed,
+            $requestedIdPs,
+            $logAttributes
         );
     }
 }


### PR DESCRIPTION
Hi all,

With these changes we would like to contribute support for enriching the authentication logging. For some context, this refers to the logging done with 'login granted' where information such as timestamp, SP, IdP etc. is logged. These changes allow the configuration of a mapping in parameters.yml to enrich the logging information with response attributes. 

The mapping consists of a label and the name of attribute that is desired e.g. in parameters.yml:
```
auth.log.attributes: 
    myLabel1: attributeKey1
    myLabel2: attributeKey2
    ...
```
Default value is empty array.

The logging would then look like

authentication.INFO: login granted {"login_stamp":"2024-04-26T12:02:42.904740+02:00","user_id":"<xxx>","sp_entity_id":"<sp>","idp_entity_id":"<idp>","key_id":null,"proxied_sp_entity_ids":[],"workflow_state":"prodaccepted","original_name_id":"3d264e07006590d060e96c618e8fafc13a6d21a1","authncontextclassref":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","requestedidps":[],"engine_sso_endpoint_used":"https://engine/authentication/idp/single-sign-on", "myLabel1":"value1","myLabel2":"value2"} {"session_id":"0gd53uec0mc4g1ohcneq6mo6s6","request_id":"662b7bb806f3e"}