### PR TITLE
Make the /health and /info endpoints also available via engine-api

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -22,16 +22,16 @@ security:
             security: false
             stateless: true
 
+        monitor:
+            pattern: ^/(info|health)$
+            security: false
+
         api:
             host: ^engine-api\..+
             http_basic: ~
             entry_point: engineblock.security.http_basic_entry_point
             stateless: true
             pattern: ^/.+
-
-        monitor:
-            pattern: ^/(info|health)$
-            security: false
 
         main:
             anonymous: ~


### PR DESCRIPTION
Before, the api protection came first so the endpoints provided by the monitor bundle cannot be accessed on engine-api vhost (without credentials). Change the order such that the monitor bundle endpoints are always available, both on engine and engine-api.