### PR TITLE
When AM error occurs, accept any type of exception for logging

### DIFF
--- a/library/EngineBlock/Attributes/Manipulator/ServiceRegistry.php
+++ b/library/EngineBlock/Attributes/Manipulator/ServiceRegistry.php
@@ -102,7 +102,7 @@ class EngineBlock_Attributes_Manipulator_ServiceRegistry
                 eval($manipulationCode);
             },
             // Should an error occur, log the input, if nothing happens, then don't
-            function(EngineBlock_Exception $exception)
+            function($exception)
                 use (
                     $entityType,
                     $manipulationCode,


### PR DESCRIPTION
The exception can be an EngineBlock_Exception, but e.g. a ParseError is not unlikely to occur in practice. A ParseError would previously give a confusing Uncaugt TypeError, removing the type declaration makes it being processed and logged as a problem with the AM which is what it is.