### PR TITLE
Overwrite the NameID when specified in use_as_nameid ARP setting

### DIFF
--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -572,4 +572,12 @@ class EngineBlock_Application_DiContainer extends Pimple
     {
         return $this->container->getParameter('auth.log.attributes');
     }
+
+    /**
+     * @return EngineBlock_Arp_NameIdSubstituteResolver
+     */
+    public function getNameIdSubstituteResolver()
+    {
+        return new EngineBlock_Arp_NameIdSubstituteResolver($this->container->get('engineblock.compat.logger'));
+    }
 }

--- a/library/EngineBlock/Arp/NameIdSubstituteResolver.php
+++ b/library/EngineBlock/Arp/NameIdSubstituteResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class EngineBlock_Arp_NameIdSubstituteResolver
+{
+    /**
+     * @var LoggerInterface 
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function findNameIdSubstitute(AttributeReleasePolicy $arp, array $responseAttributes): ?string
+    {
+        $substituteAttribute = $arp->findNameIdSubstitute();
+        if ($substituteAttribute !== null && array_key_exists($substituteAttribute, $responseAttributes)) {
+            $this->logger->notice(
+                sprintf(
+                    'Found a NameId substitute ("use_as_nameid", %s will be used as NameID)',
+                    $substituteAttribute
+                )
+            );
+            return reset($responseAttributes[$substituteAttribute]);
+        }
+        return null;
+    }
+}

--- a/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
+++ b/library/EngineBlock/Corto/Filter/Command/ProvisionUser.php
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+use OpenConext\EngineBlockBridge\Authentication\Repository\UserDirectoryAdapter;
 use SAML2\Constants;
 use SAML2\XML\saml\NameID;
 
@@ -23,6 +24,16 @@ class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_F
     implements EngineBlock_Corto_Filter_Command_ResponseModificationInterface,
     EngineBlock_Corto_Filter_Command_CollabPersonIdModificationInterface
 {
+    /**
+     * @var UserDirectoryAdapter
+     */
+    private $userDirectory;
+
+    public function __construct(UserDirectoryAdapter $userDirectory)
+    {
+        $this->userDirectory = $userDirectory;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -41,8 +52,7 @@ class EngineBlock_Corto_Filter_Command_ProvisionUser extends EngineBlock_Corto_F
 
     public function execute()
     {
-        $userDirectory = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getUserDirectory();
-        $user = $userDirectory->identifyUser($this->_responseAttributes);
+        $user = $this->userDirectory->identifyUser($this->_responseAttributes);
 
         $collabPersonIdValue = $user->getCollabPersonId()->getCollabPersonId();
         $this->setCollabPersonId($collabPersonIdValue);

--- a/library/EngineBlock/Corto/Filter/Input.php
+++ b/library/EngineBlock/Corto/Filter/Input.php
@@ -80,7 +80,9 @@ class EngineBlock_Corto_Filter_Input extends EngineBlock_Corto_Filter_Abstract
             new EngineBlock_Corto_Filter_Command_AddGuestStatus(),
 
             // Figure out the collabPersonId
-            new EngineBlock_Corto_Filter_Command_ProvisionUser(),
+            new EngineBlock_Corto_Filter_Command_ProvisionUser(
+                $diContainer->getUserDirectory()
+            ),
 
             // Aggregate additional attributes for this Service Provider
             new EngineBlock_Corto_Filter_Command_AttributeAggregator(

--- a/library/EngineBlock/Corto/Filter/Output.php
+++ b/library/EngineBlock/Corto/Filter/Output.php
@@ -62,7 +62,6 @@ class EngineBlock_Corto_Filter_Output extends EngineBlock_Corto_Filter_Abstract
     {
         $diContainer = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer();
         $logger = EngineBlock_ApplicationSingleton::getLog();
-
         return array(
             // If EngineBlock is in Processing mode (redirecting to it's self)
             // Then don't continue with the rest of the modifications
@@ -84,7 +83,7 @@ class EngineBlock_Corto_Filter_Output extends EngineBlock_Corto_Filter_Abstract
             new EngineBlock_Corto_Filter_Command_ApplyTrustedProxyBehavior($logger),
 
             // Add the appropriate NameID to the 'eduPeronTargetedID' and the Assertions NameId.
-            new EngineBlock_Corto_Filter_Command_AddIdentityAttributes($logger),
+            new EngineBlock_Corto_Filter_Command_AddIdentityAttributes($diContainer->getNameIdSubstituteResolver(), $logger),
 
             // Convert all attributes to their OID format (if known) and add these.
             new EngineBlock_Corto_Filter_Command_DenormalizeAttributes(),

--- a/src/OpenConext/EngineBlock/Metadata/AttributeReleasePolicy.php
+++ b/src/OpenConext/EngineBlock/Metadata/AttributeReleasePolicy.php
@@ -19,6 +19,7 @@
 namespace OpenConext\EngineBlock\Metadata;
 
 use InvalidArgumentException;
+use function array_key_exists;
 
 class AttributeReleasePolicy
 {
@@ -139,6 +140,9 @@ class AttributeReleasePolicy
         foreach ($this->attributeRules as $name => $rules) {
             foreach ($rules as $rule) {
                 if (isset($rule['use_as_nameid']) && $rule['use_as_nameid'] === true) {
+                    if (array_key_exists('release_as', $rule)) {
+                        return $rule['release_as'];
+                    }
                     return $name;
                 }
             }

--- a/tests/library/EngineBlock/Test/Arp/NameIdSubstituteResolverTest.php
+++ b/tests/library/EngineBlock/Test/Arp/NameIdSubstituteResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Mockery as m;
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class EngineBlock_Arp_NameIdSubstituteResolverTest extends TestCase
+{
+    private $resolver;
+    private $loggerMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loggerMock = m::mock(LoggerInterface::class);
+        $this->resolver = new EngineBlock_Arp_NameIdSubstituteResolver($this->loggerMock);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    public function testFindNameIdSubstituteWithValidSubstitute()
+    {
+        $arp = m::mock(AttributeReleasePolicy::class);
+        $arp->shouldReceive('findNameIdSubstitute')->andReturn('email');
+
+        $responseAttributes = ['email' => ['test@example.com']];
+
+        $this->loggerMock->shouldReceive('notice')
+            ->with('Found a NameId substitute ("use_as_nameid", email will be used as NameID)')
+            ->once();
+
+        $result = $this->resolver->findNameIdSubstitute($arp, $responseAttributes);
+
+        $this->assertEquals('test@example.com', $result);
+    }
+
+    public function testFindNameIdSubstituteWithInvalidSubstitute()
+    {
+        $arp = m::mock(AttributeReleasePolicy::class);
+
+        $arp->shouldReceive('findNameIdSubstitute')->andReturn('non_existent_attribute');
+
+        $responseAttributes = ['email' => ['test@example.com']];
+
+        $result = $this->resolver->findNameIdSubstitute($arp, $responseAttributes);
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Metadata/AttributeReleasePolicyTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/AttributeReleasePolicyTest.php
@@ -221,4 +221,21 @@ class AttributeReleasePolicyTest extends TestCase
 
         $this->assertNull($policyWithoutNameId->findNameIdSubstitute());
     }
+    public function testFindNameIdSubstituteWithReleaseAs()
+    {
+        $policy = new AttributeReleasePolicy([
+            'attr1' => [
+                ['value' => 'value1', 'use_as_nameid' => false],
+            ],
+            'attr2' => [
+                // When release_as is set, the name id value must be retrieved on that
+                // attribute in the assertion (release as is evaluated first)
+                ['value' => 'value2', 'use_as_nameid' => true, 'release_as' => 'new_attr_name'],
+            ],
+            'attr3' => [
+                ['value' => 'value3', 'use_as_nameid' => false],
+            ],
+        ]);
+        $this->assertEquals('new_attr_name', $policy->findNameIdSubstitute());
+    }
 }


### PR DESCRIPTION
This PR aims to close the feature described in issue: #1301 For functional details, please study the well described feature there.

For this PR some noteworthy things passed:

1. A small boyscout task was performed in commit b82468c
2. I tried to make things solid as possible. But the library code is challenging in that regard. But I tried to make up for that by adding as many tests as possible.