### PR TITLE
Ensure HTTP exception is thrown when API fails

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
@@ -18,11 +18,13 @@
 
 namespace OpenConext\EngineBlockBundle\Controller\Api;
 
+use Exception;
 use OpenConext\EngineBlock\Metadata\Entity\Assembler\MetadataAssemblerInterface;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\DoctrineMetadataPushRepository;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiAccessDeniedHttpException;
+use OpenConext\EngineBlockBundle\Http\Exception\ApiInternalServerErrorHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiMethodNotAllowedHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\ApiNotFoundHttpException;
 use OpenConext\EngineBlockBundle\Http\Exception\BadApiRequestHttpException;
@@ -113,7 +115,11 @@ class ConnectionsController
 
         unset($body);
 
-        $result    = $this->repository->synchronize($roles);
+        try {
+            $result = $this->repository->synchronize($roles);
+        } catch (Exception $exception) {
+            throw new ApiInternalServerErrorHttpException('Unable to synchronize the assembled roles to the repository', $exception);
+        }
 
         return new JsonResponse($result);
     }


### PR DESCRIPTION
When the pushConnectionsAction fails because the DoctrineMetadataPushRepository failed to save the assembled roles data. We should throw a HTTP exception. Otherwise the action would not output JSON. Resulting in a user facing error page. Which is not user friendly for a consumer

Fixes: https://github.com/OpenConext/OpenConext-engineblock/issues/1309