### PR TITLE
GHA: change "docker-compose" to "docker compose" for the release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-        DOCKER_COMPOSE: docker-compose -f docker-compose-tag-release.yml
+        DOCKER_COMPOSE: docker compose -f docker-compose-tag-release.yml
     if: always()
     steps:
       - name: Checkout


### PR DESCRIPTION
Some time ago docker compose has become a default plugin shipped with docker, in stead of a separate package. So the command "docker-compose" has changed to "docker compose" 

This will fix the workflow that creates the release.

