### PR TITLE
Improve error message on duplicate SP entityID in PUSH

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/MfaEntityCollection.php
+++ b/src/OpenConext/EngineBlock/Metadata/MfaEntityCollection.php
@@ -42,7 +42,7 @@ class MfaEntityCollection implements JsonSerializable, Countable
         foreach ($data as $mfaEntityData) {
             $entityId = (string) $mfaEntityData['name'];
             $level = (string) $mfaEntityData['level'];
-            Assertion::keyNotExists($entities, $entityId, 'Duplicate SP entity ids are not allowed');
+            Assertion::keyNotExists($entities, $entityId, sprintf('Duplicate SP entity ids are not allowed in MFA list: %s', $entityId));
             $entities[$entityId] = MfaEntityFactory::from($entityId, $level);
         }
         return new self($entities);
@@ -59,7 +59,7 @@ class MfaEntityCollection implements JsonSerializable, Countable
         $entities = [];
         foreach ($data as $mfaEntityData) {
             $entity = MfaEntityFactory::fromJson($mfaEntityData);
-            Assertion::keyNotExists($entities, $entity->entityId(), 'Duplicate SP entity ids are not allowed');
+            Assertion::keyNotExists($entities, $entity->entityId(), sprintf('Duplicate SP entity ids are not allowed in coin MFA list: %s', $entity->entityId()));
             $entities[$entity->entityId()] = $entity;
         }
         return new self($entities);

--- a/src/OpenConext/EngineBlock/Metadata/MfaEntityCollection.php
+++ b/src/OpenConext/EngineBlock/Metadata/MfaEntityCollection.php
@@ -42,7 +42,11 @@ class MfaEntityCollection implements JsonSerializable, Countable
         foreach ($data as $mfaEntityData) {
             $entityId = (string) $mfaEntityData['name'];
             $level = (string) $mfaEntityData['level'];
-            Assertion::keyNotExists($entities, $entityId, sprintf('Duplicate SP entity ids are not allowed in MFA list: %s', $entityId));
+            Assertion::keyNotExists(
+                $entities,
+                $entityId,
+                sprintf('Duplicate SP entity ids are not allowed in MFA list: %s', $entityId)
+            );
             $entities[$entityId] = MfaEntityFactory::from($entityId, $level);
         }
         return new self($entities);
@@ -59,7 +63,11 @@ class MfaEntityCollection implements JsonSerializable, Countable
         $entities = [];
         foreach ($data as $mfaEntityData) {
             $entity = MfaEntityFactory::fromJson($mfaEntityData);
-            Assertion::keyNotExists($entities, $entity->entityId(), sprintf('Duplicate SP entity ids are not allowed in coin MFA list: %s', $entity->entityId()));
+            Assertion::keyNotExists(
+                $entities,
+                $entity->entityId(),
+                sprintf('Duplicate SP entity ids are not allowed in coin MFA list: %s', $entity->entityId())
+            );
             $entities[$entity->entityId()] = $entity;
         }
         return new self($entities);


### PR DESCRIPTION
Make it clear where this occurs (MFA list) and mention the ID that's duplicated