### PR TITLE
Ensure the NameID is correctly set

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/AddIdentityAttributes.php
+++ b/library/EngineBlock/Corto/Filter/Command/AddIdentityAttributes.php
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use Psr\Log\LoggerInterface;
 use SAML2\Constants;
@@ -84,11 +85,6 @@ class EngineBlock_Corto_Filter_Command_AddIdentityAttributes extends EngineBlock
                 $isResolved = true;
                 $this->_response->getAssertion()->setNameId($nameId);
             }
-
-            // If there's an ARP, but it does not contain the EPTI, we're done now.
-            if (!$arp->hasAttribute(Constants::EPTI_URN_MACE)) {
-                return;
-            }
         }
 
         if (!$isResolved || !isset($nameId)){
@@ -103,6 +99,11 @@ class EngineBlock_Corto_Filter_Command_AddIdentityAttributes extends EngineBlock
 
             $this->logger->info('Setting the NameId on the Assertion');
             $this->_response->getAssertion()->setNameId($nameId);
+        }
+
+        // If there's an ARP, but it does not contain the EPTI, we're done now.
+        if ($arp instanceof AttributeReleasePolicy && !$arp->hasAttribute(Constants::EPTI_URN_MACE)) {
+            return;
         }
 
         // We arrive here if either:

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/NameIdFormat.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/NameIdFormat.feature
@@ -1,0 +1,69 @@
+Feature:
+  To ensure no confusion about the NameID Format
+  As EngineBlock
+  I want to be sure after ARP my name id format is presented correctly to the SP
+
+  Background:
+    Given an EngineBlock instance on "vm.openconext.org"
+    And no registered SPs
+    And no registered Idps
+    And an Identity Provider named "SSO-IdP"
+    And a Service Provider named "SSO-SP"
+
+  Scenario: EngineBlock should not update the Unspecified NameIdFormat when no ARP filters are applied
+    Given SP "SSO-SP" uses the Unspecified NameID format
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    When I give my consent
+    And I pass through EngineBlock
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"]'
+
+  Scenario: EngineBlock should not update the Unspecified NameIdFormat when the ARP is applied
+    Given SP "SSO-SP" uses the Unspecified NameID format
+    And SP "SSO-SP" allows an attribute named "urn:mace:dir:attribute-def:uid"
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    When I give my consent
+    And I pass through EngineBlock
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"]'
+
+  Scenario: EngineBlock should not update the Persistent NameIdFormat when no ARP filters are applied
+    Given SP "SSO-SP" uses the Persistent NameID format
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    When I give my consent
+    And I pass through EngineBlock
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]'
+
+  Scenario: EngineBlock should not update the Persistent NameIdFormat when the ARP is applied
+    Given SP "SSO-SP" uses the Persistent NameID format
+    And SP "SSO-SP" allows an attribute named "urn:mace:dir:attribute-def:uid"
+    And SP "SSO-SP" allows an attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    When I give my consent
+    And I pass through EngineBlock
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]'
+
+  Scenario: EngineBlock should not update the Transient NameIdFormat when no ARP filters are applied
+    Given SP "SSO-SP" uses the Transient NameID format
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    When I give my consent
+    And I pass through EngineBlock
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]'
+
+  Scenario: EngineBlock should not update the Transient NameIdFormat when the ARP is applied
+    Given SP "SSO-SP" uses the Transient NameID format
+    And SP "SSO-SP" allows an attribute named "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    When I give my consent
+    And I pass through EngineBlock
+    And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]'


### PR DESCRIPTION
Due to the NameId juggling taking place during the Input filtering. There MUST be a point in time when we set the correct outgoing NameId value and format. And that is done in the AddIdentityAttributes filter.

During the optimization I moved the 'were done here' return statement to a block that seemed to make more sense to me. But that caused the NameId from not being set even though it was resolved.

So I moved that block back to the position where it is supposed to be.

It is meant as a guard from injustly overwriting the eduPersonTargettedId. Not for preventing the setting of the correct NameId in the subject.

Fixes: #1318 