### PR TITLE
Prevent adding empty renamed attribute

### DIFF
--- a/src/OpenConext/EngineBlock/Service/ReleaseAsEnforcer.php
+++ b/src/OpenConext/EngineBlock/Service/ReleaseAsEnforcer.php
@@ -37,6 +37,29 @@ class ReleaseAsEnforcer implements ReleaseAsEnforcerInterface
     {
         foreach ($releaseAsOverrides as $oldAttributeName => $overrideValue) {
             $newAttributeName = $overrideValue[0]['release_as'];
+            if (!array_key_exists($oldAttributeName, $attributes)) {
+                $this->logger->notice(
+                    sprintf(
+                        'Releasing "%s" as "%s" is not possible, "%s" is not in assertion',
+                        $oldAttributeName,
+                        $newAttributeName,
+                        $oldAttributeName
+                    )
+                );
+                continue;
+            }
+            if (is_null($attributes[$oldAttributeName])) {
+                $this->logger->warning(
+                    sprintf(
+                        'Releasing "%s" as "%s" is not possible, value for "%s" is null',
+                        $oldAttributeName,
+                        $newAttributeName,
+                        $oldAttributeName
+                    )
+                );
+                unset($attributes[$oldAttributeName]);
+                continue;
+            }
             $attributeValue = $attributes[$oldAttributeName];
             unset($attributes[$oldAttributeName]);
             $this->logger->notice(


### PR DESCRIPTION
When Manage configures an override for an attribute name. But the targetted attribute is not in the assertion, then Engine would add an empty attribute with the overridden value to the assertion. The SAML2 lib would then warn us that an empty attribute value can not be processed.

To fix that. I added a test statement that verifies if the targetted attribute is present in the assertion. If not, the substitution is not made and a warning is logged.

See, Fixes: https://github.com/OpenConext/OpenConext-engineblock/issues/1321