### PR TITLE
Exclude the node modules directory when packaging a build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,7 @@
             "!/library",
             "!/src",
             "!/theme",
+            "/theme/node_modules",
             "!/vendor",
             "!/web"
         ]


### PR DESCRIPTION
Node modules take 100MB of extra space in the tarball and container, and are not needed. 