### PR TITLE
Docker: Log to json, fixes multiline logging in Docker

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -13,7 +13,7 @@ RUN tar -xvjf /tmp/*.tar.bz2 -C /var/www/html/ && \
 # Add the config files for Apache2
 RUN rm -rf /etc/apache2/sites-enabled/*
 COPY ./docker/conf/engine.conf /etc/apache2/sites-enabled/engine.conf
-COPY ./docker/conf/logging.yml /var/www/html/config/packages/
+COPY ./docker/conf/logging.yml /var/www/html/app/config/logging.yml
 # Instantiate devconf config
 RUN cp app/config/parameters.yml.docker app/config/parameters.yml
 

--- a/docker/conf/logging.yml
+++ b/docker/conf/logging.yml
@@ -5,18 +5,15 @@ monolog:
             type: fingers_crossed
             activation_strategy: engineblock.logger.manual_or_error_activation_strategy
             passthru_level: "%logger.fingers_crossed.passthru_level%"
+            channels:  [!authentication]
             handler: stderr
-            channels: ["!authentication"]
-        stderr:
-            type:      stream
-            path:      php://stderr
-            ident:     "%logger.syslog.ident%"
-            formatter: engineblock.logger.additional_info_formatter
         authentication:
             type:      stream
             path:      php://stderr
-            ident:     EBAUTH
-            facility:  user
             level:     INFO
             channels:  [authentication]
+            formatter: engineblock.logger.formatter.syslog_json
+        stderr:
+            type:      stream
+            path:      php://stderr
             formatter: engineblock.logger.formatter.syslog_json


### PR DESCRIPTION
Since Docker logs to stdout, the ident to distinguish between the authentication and application logs is no longer applicable.  
Furthermore, logging using the regular formatters lead to all logs landing in a single line, making it hard to read and distinguish. It also hits the 16KB logline length of Docker
Using the syslog formatter fixes those issues. 