### PR TITLE
Bugfix: stricter regex; disallow trailing newline

### DIFF
--- a/library/EngineBlock/Validator/Urn.php
+++ b/library/EngineBlock/Validator/Urn.php
@@ -28,7 +28,7 @@ class EngineBlock_Validator_Urn
      * Taken from: https://stackoverflow.com/a/59048720/5494155
      */
     const REGEX = <<<'REGEX'
-/\A(?i:urn:(?!urn:)(?<nid>[a-z0-9][a-z0-9-]{1,31}):(?<nss>(?:[-a-z0-9()+,.:=@;$_!*\'&~\/]|%[0-9a-f]{2})+)(?:\?\+(?<rcomponent>.*?))?(?:\?=(?<qcomponent>.*?))?(?:#(?<fcomponent>.*?))?)\z/
+/\A(?i:urn:(?!urn:)(?<nid>[a-z0-9][a-z0-9-]{1,31}):(?<nss>(?:[-a-z0-9()+,.:=@;$_!*\'&~\/]|%[0-9a-f]{2})+)(?:\?\+(?<rcomponent>.*?))?(?:\?=(?<qcomponent>.*?))?(?:#(?<fcomponent>.*?))?)\z/D
 REGEX;
 
     public function validate(string $urn): bool

--- a/tests/library/EngineBlock/Test/Validator/UrnTest.php
+++ b/tests/library/EngineBlock/Test/Validator/UrnTest.php
@@ -68,6 +68,7 @@ class EngineBlock_Test_Validator_UrnTest extends TestCase
         yield ['urn:org.openconext.licenseInfo'];
         yield ['foo:bar:baz'];
         yield ['urn:f:bar'];
+        yield ["\nurn:mace:dir:attribute-def:eduPersonPrincipalName"];
         yield ["urn:mace:dir:attribute-def:eduPersonPrincipalName\n"];
         yield [' urn:collab:person:example.org:jdoe'];
         yield ['urn:collab:person:example.org:jdoe '];

--- a/tests/library/EngineBlock/Test/Validator/UrnTest.php
+++ b/tests/library/EngineBlock/Test/Validator/UrnTest.php
@@ -68,6 +68,7 @@ class EngineBlock_Test_Validator_UrnTest extends TestCase
         yield ['urn:org.openconext.licenseInfo'];
         yield ['foo:bar:baz'];
         yield ['urn:f:bar'];
+        yield ["urn:mace:dir:attribute-def:eduPersonPrincipalName\n"];
         yield [' urn:collab:person:example.org:jdoe'];
         yield ['urn:collab:person:example.org:jdoe '];
         yield ['urn:collab:person:example org:jdoe'];


### PR DESCRIPTION
To prevent false positives, we can make use of the [PCRE_DOLLAR_ENDONLY](https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php) flag (`D`) that will constraint the `$` anchor to match the end of the string only, not a newline character.