### PR TITLE
Add ARP numeric key exception

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/AttributeReleasePolicy.php
+++ b/src/OpenConext/EngineBlock/Metadata/AttributeReleasePolicy.php
@@ -84,6 +84,16 @@ class AttributeReleasePolicy
                 );
             }
 
+            if (isset($rule['release_as']) && is_numeric($rule['release_as'])) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Invalid release as for attribute "%s", attribute cannot be numeric, got: "%s"',
+                        $key,
+                        (string)$rule['release_as']
+                    )
+                );
+            }
+
             $value = $rule['value'];
         } else {
             $value = $rule;

--- a/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsController.php
@@ -36,6 +36,8 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Static calls, factories, and having to check HTTP methods which is
  *                                                 usually done by Symfony
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity) Extensive role validation
+ * @SuppressWarnings(PHPMD.NPathComplexity) Extensive role validation
  */
 class ConnectionsController
 {
@@ -111,7 +113,11 @@ class ConnectionsController
             throw new BadApiRequestHttpException('Unrecognized structure for JSON');
         }
 
-        $roles     = $this->pushMetadataAssembler->assemble($body->connections);
+        try {
+            $roles = $this->pushMetadataAssembler->assemble($body->connections);
+        } catch (Exception $exception) {
+            throw new BadApiRequestHttpException(sprintf('Unable to assemble the pushed metadata: %s', $exception->getMessage()), $exception);
+        }
 
         unset($body);
 

--- a/tests/library/EngineBlock/Test/Arp/AttributeReleasePolicyTest.php
+++ b/tests/library/EngineBlock/Test/Arp/AttributeReleasePolicyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
+use PHPUnit\Framework\TestCase;
+
+class EngineBlock_Test_Arp_AttributeReleasePolicyTest extends TestCase
+{
+    public function testEnforceNumericArpKeyException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid release as for attribute "urn:mace:dir:attribute-def:cn", attribute cannot be numeric, got: "9999"');
+
+        $arp = array(
+            'urn:mace:dir:attribute-def:cn' => array(
+                array(
+                    "value" => "*",
+                    "release_as" => "9999",
+                ),
+            ),
+        );
+
+        $policy = new AttributeReleasePolicy($arp);
+    }
+}


### PR DESCRIPTION
Validate numeric key in ARP settings on metadata push.

https://github.com/OpenConext/OpenConext-engineblock/issues/1336