### PR TITLE
Make content container slightly wider

### DIFF
--- a/theme/base/stylesheets/classes.scss
+++ b/theme/base/stylesheets/classes.scss
@@ -11,7 +11,7 @@
 }
 
 .container {
-    width: 38rem;
+    width: 40rem;
 
     @include screen('mobile') {
         width: 100%;


### PR DESCRIPTION
Prior to this change, long uninterruptible strings would cause a linebreak that was not visually pleasing, mainly identifiers. This change widens the container so linebreaks for identifiers occur less.

Resolves https://github.com/OpenConext/OpenConext-engineblock/issues/1324