### PR TITLE
Feat: Implement Discovery support

### DIFF
--- a/ci/qa/phpcbf.sh
+++ b/ci/qa/phpcbf.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+cd $(dirname $0)/../../
+
+echo -e "\nPHP CodeSniffer\n"
+./vendor/bin/phpcbf --standard=ci/qa-config/phpcs.xml src

--- a/database/DoctrineMigrations/Version20250206095609.php
+++ b/database/DoctrineMigrations/Version20250206095609.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250206095609 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 ADD idp_discoveries LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sso_provider_roles_eb5 DROP idp_discoveries');
+    }
+}

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -463,6 +463,14 @@ class EngineBlock_Application_DiContainer extends Pimple
         return $this->container->get('engineblock.service.processing_state_helper');
     }
 
+    /**
+     * @return \OpenConext\EngineBlockBundle\Service\DiscoverySelectionService
+     */
+    public function getDiscoverySelectionService()
+    {
+        return $this->container->get('engineblock.service.discovery_selection_service');
+    }
+
     public function getMfaHelper(): MfaHelperInterface
     {
         return $this->container->get('engineblock.service.mfa_helper');

--- a/library/EngineBlock/Corto/Module/Services.php
+++ b/library/EngineBlock/Corto/Module/Services.php
@@ -102,7 +102,8 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
                     $diContainer->getConsentService(),
                     $diContainer->getAuthenticationStateHelper(),
                     $diContainer->getTwigEnvironment(),
-                    $diContainer->getProcessingStateHelper()
+                    $diContainer->getProcessingStateHelper(),
+                    $diContainer->getDiscoverySelectionService()
                 );
             case EngineBlock_Corto_Module_Service_ProcessConsent::class :
                 return new EngineBlock_Corto_Module_Service_ProcessConsent(
@@ -139,7 +140,8 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
                     $server,
                     $diContainer->getXmlConverter(),
                     $diContainer->getTwigEnvironment(),
-                    $diContainer->getServiceProviderFactory()
+                    $diContainer->getServiceProviderFactory(),
+                    $diContainer->getDiscoverySelectionService()
                 );
             case EngineBlock_Corto_Module_Service_ContinueToIdp::class :
                 return new EngineBlock_Corto_Module_Service_ContinueToIdp(

--- a/src/OpenConext/EngineBlock/Exception/InvalidDiscoveryException.php
+++ b/src/OpenConext/EngineBlock/Exception/InvalidDiscoveryException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Exception;
+
+final class InvalidDiscoveryException extends RuntimeException
+{
+}

--- a/src/OpenConext/EngineBlock/Metadata/Discovery.php
+++ b/src/OpenConext/EngineBlock/Metadata/Discovery.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use JsonSerializable;
+use OpenConext\EngineBlock\Exception\InvalidDiscoveryException;
+
+/**
+ * Value object representing the cosmetic override data when a 'sub-idp' is present
+ */
+class Discovery implements JsonSerializable
+{
+    /**
+     * @var string[]
+     */
+    private $names;
+
+    /**
+     * @var string[]
+     */
+    private $keywords;
+
+    /**
+     * @var ?Logo
+     */
+    private $logo;
+
+    /**
+     * @param array<string,string> $names
+     * @param array<string,string> $keywords
+     */
+    public static function create(array $names, array $keywords, ?Logo $logo): Discovery
+    {
+        $discovery = new self;
+        $discovery->logo = $logo;
+
+        self::assertLocaleValueArray($names);
+        self::assertLocaleValueArray($keywords);
+
+        $discovery->names = array_filter($names);
+        $discovery->keywords = array_filter($keywords);
+
+        if (!$discovery->isValid()) {
+            throw new InvalidDiscoveryException('The Discovery does not have a required english name.');
+        }
+
+        return $discovery;
+    }
+
+    private static function assertLocaleValueArray(array $array): void
+    {
+        foreach ($array as $localeKey => $value) {
+            if (!is_string($localeKey)) {
+                throw new InvalidDiscoveryException(sprintf("Discovery language key must be a string, '%s' given", $localeKey));
+            }
+
+            if (strlen($localeKey) !== 2) {
+                throw new InvalidDiscoveryException(sprintf("Invalid discovery language key, '%s' given", $localeKey));
+            }
+
+
+            if (!is_string($value)) {
+                throw new InvalidDiscoveryException(sprintf("Discovery value must be a string, '%s' given", $value));
+            }
+        }
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'names' => $this->names,
+            'keywords' => $this->keywords,
+            'logo' => $this->logo,
+        ];
+    }
+
+    public function hasLogo(): bool
+    {
+        return $this->logo !== null && $this->logo->url !== null;
+    }
+
+    public function getLogo(): ?Logo
+    {
+        return $this->logo;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    public function getName(string $locale): string
+    {
+        if ($locale !== '' && isset($this->names[$locale])) {
+            return $this->names[$locale];
+        }
+
+        return $this->names['en'] ?? '';
+    }
+
+    public function getKeywords(string $locale): string
+    {
+        if ($locale !== '' && isset($this->keywords[$locale])) {
+            return $this->keywords[$locale];
+        }
+
+        return $this->keywords['en'] ?? '';
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getKeywordsArray(string $locale): array
+    {
+        return explode(' ', $this->getKeywords($locale));
+    }
+
+    public function isValid(): bool
+    {
+        return $this->getName('en') !== '';
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssembler.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata\Entity\Assembler;
+
+use OpenConext\EngineBlock\Metadata\Discovery;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlockBundle\Localization\LanguageSupportProvider;
+use stdClass;
+
+class DiscoveryAssembler
+{
+    /**
+     * @var LanguageSupportProvider
+     */
+    private $languageSupportProvider;
+
+    public function __construct(LanguageSupportProvider $languageSupportProvider)
+    {
+        $this->languageSupportProvider = $languageSupportProvider;
+    }
+
+    public function assembleDiscoveries(stdClass $connection): array
+    {
+        if (!isset($connection->metadata->discoveries)) {
+            return [];
+        }
+
+        $discoveries = [];
+        foreach ($connection->metadata->discoveries as $discovery) {
+            $names = $this->extractLocalizedFields($discovery, 'name');
+            $keywords = $this->extractLocalizedFields($discovery, 'keywords');
+            $logo = $this->assembleLogo($discovery);
+
+            if (isset($names['en'])) {
+                $discoveries[] = Discovery::create($names, $keywords, $logo);
+            }
+        }
+
+        return empty($discoveries) ? [] : ['discoveries' => $discoveries];
+    }
+
+    private function extractLocalizedFields(stdClass $discovery, string $fieldPrefix): array
+    {
+        $fields = [];
+        foreach ($this->languageSupportProvider->getSupportedLanguages() as $language) {
+            $accessor = sprintf('%s_%s', $fieldPrefix, $language);
+            if (isset($discovery->$accessor)) {
+                $fields[$language] = $discovery->$accessor;
+            }
+        }
+
+        return array_filter(array_map('trim', $fields));
+    }
+
+    private function assembleLogo(stdClass $discovery): ?Logo
+    {
+        $logoFields = [];
+        $logoProperties = ['logo_url', 'logo_height', 'logo_width'];
+
+        foreach ($logoProperties as $property) {
+            if (isset($discovery->$property)) {
+                $logoFields[$property] = $discovery->$property;
+            }
+        }
+
+        if (!isset($logoFields['logo_url']) || trim($logoFields['logo_url']) === '') {
+            return null;
+        }
+
+        $logo = new Logo($logoFields['logo_url']);
+
+        if (isset($logoFields['logo_height'])) {
+            $logo->height = $logoFields['logo_height'];
+        }
+        if (isset($logoFields['logo_width'])) {
+            $logo->width = $logoFields['logo_width'];
+        }
+
+        return $logo;
+    }
+}

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Adapter/IdentityProviderEntity.php
@@ -260,4 +260,9 @@ class IdentityProviderEntity implements IdentityProviderEntityInterface
     {
         return $this->entity->getMdui();
     }
+
+    public function getDiscoveries(): array
+    {
+        return $this->entity->getDiscoveries();
+    }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/Decorator/AbstractIdentityProvider.php
@@ -17,6 +17,7 @@
 
 namespace OpenConext\EngineBlock\Metadata\Factory\Decorator;
 
+use OpenConext\EngineBlock\Metadata\Discovery;
 use OpenConext\EngineBlock\Metadata\Factory\IdentityProviderEntityInterface;
 use OpenConext\EngineBlock\Metadata\Coins;
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
@@ -238,5 +239,13 @@ abstract class AbstractIdentityProvider implements IdentityProviderEntityInterfa
     public function getMdui(): Mdui
     {
         return $this->entity->getMdui();
+    }
+
+    /**
+     * @return array<Discovery>
+     */
+    public function getDiscoveries(): array
+    {
+        return $this->entity->getDiscoveries();
     }
 }

--- a/src/OpenConext/EngineBlock/Metadata/Factory/IdentityProviderEntityInterface.php
+++ b/src/OpenConext/EngineBlock/Metadata/Factory/IdentityProviderEntityInterface.php
@@ -148,4 +148,6 @@ interface IdentityProviderEntityInterface
     public function getShibMdScopes(): array;
 
     public function getMdui(): Mdui;
+
+    public function getDiscoveries(): array;
 }

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -205,13 +205,13 @@ class RedirectToFeedbackPageExceptionListener
         } elseif ($exception instanceof EngineBlock_Corto_Exception_UserCancelledStepupCallout) {
             $message = $exception->getMessage();
             $redirectToRoute = 'authentication_feedback_stepup_callout_user_cancelled';
-        } else if ($exception instanceof EngineBlock_Corto_Exception_InvalidStepupLoaLevel) {
+        } elseif ($exception instanceof EngineBlock_Corto_Exception_InvalidStepupLoaLevel) {
             $message = $exception->getMessage();
             $redirectToRoute = 'authentication_feedback_stepup_callout_unmet_loa';
-        } else if ($exception instanceof EngineBlock_Corto_Exception_InvalidStepupCalloutResponse) {
+        } elseif ($exception instanceof EngineBlock_Corto_Exception_InvalidStepupCalloutResponse) {
             $message = $exception->getMessage();
             $redirectToRoute = 'authentication_feedback_stepup_callout_unknown';
-        } else if ($exception instanceof EntityCanNotBeFoundException) {
+        } elseif ($exception instanceof EntityCanNotBeFoundException) {
             $event->getRequest()->getSession()->set('feedback_custom', $exception->getMessage());
             $redirectToRoute = 'authentication_feedback_metadata_entity_not_found';
         } else {

--- a/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/controllers/authentication.yml
@@ -60,6 +60,8 @@ services:
             - "@engineblock.compat.application"
             - "@twig"
             - "@engineblock.service.sso_session"
+            - "@engineblock.service.discovery_selection_service"
+            - "@engineblock.compat.logger"
 
     engineblock.controller.authentication.proxy:
         class: OpenConext\EngineBlockBundle\Controller\ProxyController

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -291,6 +291,7 @@ services:
         class: OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler
         arguments:
             - "@engineblock.validator.allowed_scheme_validator"
+            - "@engineblock.language_support_provider"
             - "@engineblock.compat.logger"
 
     OpenConext\EngineBlock\Metadata\X509\KeyPairFactory:
@@ -377,3 +378,6 @@ services:
             - "@translator"
         tags:
              - { name: 'twig.extension' }
+
+    engineblock.service.discovery_selection_service:
+        class: OpenConext\EngineBlockBundle\Service\DiscoverySelectionService

--- a/src/OpenConext/EngineBlockBundle/Service/DiscoverySelectionService.php
+++ b/src/OpenConext/EngineBlockBundle/Service/DiscoverySelectionService.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Service;
+
+use OpenConext\EngineBlock\Metadata\Discovery;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class DiscoverySelectionService
+{
+    private const PREVIOUSLY_SELECTED_DISCOVERY_SESSION_NAME = 'discovery';
+    public const USED_DISCOVERY_HASH_PARAM = 'discovery';
+
+    public function discoveryMatchesHash(Discovery $discovery, string $hash): bool
+    {
+        return $this->hash($discovery) === $hash;
+    }
+
+    public function getDiscoveryFromRequest(SessionInterface $session, IdentityProvider $identityProvider): ?Discovery
+    {
+        $storedDiscoveryHash = $this->loadSelectedDiscoveryHashFromSession($session);
+        foreach ($identityProvider->getDiscoveries() as $discovery) {
+            if ($this->discoveryMatchesHash($discovery, $storedDiscoveryHash)) {
+                return $discovery;
+            }
+        }
+        return null;
+    }
+
+    public function hash(Discovery $discovery): string
+    {
+        $string = json_encode($discovery);
+        return hash('sha256', $string);
+    }
+
+    public function registerDiscoveryHash(SessionInterface $session, string $hash): void
+    {
+        $session->set(self::PREVIOUSLY_SELECTED_DISCOVERY_SESSION_NAME, $hash);
+    }
+
+    public function clearDiscoveryHash(SessionInterface $session): void
+    {
+        $session->remove(self::PREVIOUSLY_SELECTED_DISCOVERY_SESSION_NAME);
+    }
+
+    private function loadSelectedDiscoveryHashFromSession(SessionInterface $session): string
+    {
+        $previousSelection = $session->get(self::PREVIOUSLY_SELECTED_DISCOVERY_SESSION_NAME, false);
+
+        if ($previousSelection) {
+            return $previousSelection;
+        }
+
+        return '';
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Service/IdpHistoryService.php
+++ b/src/OpenConext/EngineBlockBundle/Service/IdpHistoryService.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Service;
+
+class IdpHistoryService
+{
+    public function makeIdpDiscoveryHash(string $entityId, ?string $discoveryHash = null): string
+    {
+        return rtrim($entityId . '|' . $discoveryHash, '|');
+    }
+}

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/WayfController.php
@@ -44,6 +44,7 @@ class WayfController extends Controller
         $request->cookies->set('lang', $currentLocale);
         $backLink = (bool) $request->get('backLink', false);
         $displayUnconnectedIdpsWayf = (bool) $request->get('displayUnconnectedIdpsWayf', false);
+        $addDiscoveries = (bool) $request->get('addDiscoveries', true);
         $rememberChoiceFeature = (bool) $request->get('rememberChoiceFeature', false);
         $cutoffPointForShowingUnfilteredIdps = $request->get('cutoffPointForShowingUnfilteredIdps', 100);
         $showIdPBanner = $request->get('showIdPBanner', true);
@@ -56,7 +57,7 @@ class WayfController extends Controller
         $randomIdps = (int) $request->get('randomIdps', 0);
 
         $idpList = $randomIdps === 0
-            ? TestEntitySeeder::buildIdps($connectedIdps, $unconnectedIdps, $currentLocale, $defaultIdpEntityId)
+            ? TestEntitySeeder::buildIdps($connectedIdps, $unconnectedIdps, $currentLocale, $defaultIdpEntityId, $addDiscoveries)
             : TestEntitySeeder::buildRandomIdps($randomIdps, $currentLocale, $defaultIdpEntityId);
 
         return new Response($this->twig->render(

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/Discoveries.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/Discoveries.feature
@@ -1,0 +1,56 @@
+Feature:
+  In order to find my IdP, I can find my IdP by a discovery entry
+  As a user
+  I want to see what information the SP requires from the discovery
+
+  Background:
+    Given an EngineBlock instance on "dev.openconext.local"
+      And an Identity Provider named "Dummy-IdP" with discovery "Dummy Discovery"
+      And an Identity Provider named "Second IdP to trigger wayf"
+      And a Service Provider named "Dummy-SP"
+      And SP "Dummy-SP" allows the following attributes:
+
+        | Name                                                    | Value | Source | Motivation                 |
+        | urn:mace:dir:attribute-def:uid                          | *     |        | Motivation for uid         |
+        | urn:mace:terena.org:attribute-def:schacHomeOrganization | *     |        | Motivation for sho         |
+        | urn:mace:dir:attribute-def:cn                           | *     |        | Motivation for cn          |
+        | urn:mace:dir:attribute-def:displayName                  | *     |        | Motivation for dn          |
+        | urn:mace:dir:attribute-def:eduPersonAffiliation         | *     |        | Motivation for affiliation |
+        | urn:mace:dir:attribute-def:eduPersonOrcid               | *     | voot   | Motivation for orcid       |
+
+      And the IdP "Dummy-IdP" sends attribute "urn:mace:dir:attribute-def:cn" with value "test"
+      And the IdP "Dummy-IdP" sends attribute "urn:mace:dir:attribute-def:displayName" with value "test"
+      And the IdP "Dummy-IdP" sends attribute "urn:mace:dir:attribute-def:eduPersonAffiliation" with value "test"
+
+      And SP "Dummy-SP" requires attribute aggregation
+      And feature "eb.run_all_manipulations_prior_to_consent" is disabled
+      And the attribute aggregator returns the attributes:
+
+        | Name                                      |  Value | Source |
+        | urn:mace:dir:attribute-def:eduPersonOrcid | 123456 | voot   |
+
+  Scenario: The user is asked for consent to share information with the SP showing the discovery name instead of the IdP name
+    Given I log in at "Dummy-SP"
+    And I select IdP by label "Dummy Discovery" on the WAYF
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "Do you agree with sharing this data?"
+    And the response should not contain "Yes, proceed to Dummy-SP"
+    And the response should contain "Dummy-SP will receive"
+    And the response should contain "provided by  <strong>Dummy Discovery</strong>"
+    And the response should contain "Proceed to Dummy-SP"
+    When I give my consent
+    Then I pass through EngineBlock
+
+  Scenario: Showing the IdP name when the main IdP is used instead of the discovery
+    Given I log in at "Dummy-SP"
+    And I select IdP by label "Dummy-IdP" on the WAYF
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then the response should not contain "Do you agree with sharing this data?"
+    And the response should not contain "Yes, proceed to Dummy-SP"
+    And the response should contain "Dummy-SP will receive"
+    And the response should contain "provided by  <strong>Dummy-IdP</strong>"
+    And the response should contain "Proceed to Dummy-SP"
+    When I give my consent
+    Then I pass through EngineBlock

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -355,6 +355,21 @@ class EngineBlockContext extends AbstractSubContext
     }
 
     /**
+     * @Given /^I select IdP by label "([^"]*)" on the WAYF$/
+     */
+    public function iSelectByLabelOnTheWAYF($idpLabel)
+    {
+        $selector = '[data-title="' . $idpLabel . '"] button.idp__submit';
+        $mink = $this->getMinkContext()->getSession()->getPage();
+        $button = $mink->find('css', $selector);
+        if (!$button) {
+            throw new RuntimeException(sprintf('Unable to find button with selector "%s"', $selector));
+        }
+
+        $button->click();
+    }
+
+    /**
      * @Then /^The process form should have the "([^"]*)" field$/
      */
     public function iSeeACertainFormFieldOnTheProcessForm($formFieldName)

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -19,6 +19,7 @@
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Features\Context;
 
 use OpenConext\EngineBlock\Metadata\ConsentSettings;
+use OpenConext\EngineBlock\Metadata\Discovery;
 use OpenConext\EngineBlockFunctionalTestingBundle\Fixtures\ServiceRegistryFixture;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\EntityRegistry;
 use OpenConext\EngineBlockFunctionalTestingBundle\Mock\MockIdentityProvider;
@@ -80,9 +81,15 @@ class MockIdpContext extends AbstractSubContext
 
     /**
      * @Given /^an Identity Provider named "([^"]*)"$/
+     * @Given /^an Identity Provider named "([^"]*)" with discovery "([^"]*)"$/
      */
-    public function anIdentityProviderNamed($name)
+    public function anIdentityProviderNamed($name, string $discoveryName = null)
     {
+        $discoveries = [];
+        if ($discoveryName !== null) {
+            $discoveries[] = Discovery::create(['en' => $discoveryName], [], null);
+        }
+
         $mockIdp = $this->mockIdpFactory->createNew($name);
         $this->mockIdpRegistry->set($name, $mockIdp);
         $this->mockIdpRegistry->save();
@@ -90,7 +97,8 @@ class MockIdpContext extends AbstractSubContext
             $name,
             $mockIdp->entityId(),
             $mockIdp->singleSignOnLocation(),
-            $mockIdp->publicKeyCertData()
+            $mockIdp->publicKeyCertData(),
+            $discoveries
         )->save();
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -182,7 +182,7 @@ QUERY;
         return $this;
     }
 
-    public function registerIdp($name, $entityId, $ssoLocation, $certData = '')
+    public function registerIdp($name, $entityId, $ssoLocation, $certData = '', $discoveries = [])
     {
         $idp = new IdentityProvider($entityId);
         $this->assembleEntityName($idp, $name);
@@ -213,6 +213,8 @@ QUERY;
             $sp->allowedIdpEntityIds[] = $idp->entityId;
             $this->entityManager->persist($sp);
         }
+
+        $idp->setDiscoveries($discoveries);
 
         $this->entityManager->persist($idp);
 

--- a/tests/e2e/cypress/integration/openconext/wayf/WayfShowsConnectedIdps.spec.js
+++ b/tests/e2e/cypress/integration/openconext/wayf/WayfShowsConnectedIdps.spec.js
@@ -4,7 +4,7 @@ context('WayfMouseBehaviour', () => {
       cy.visit('https://engine.dev.openconext.local/functional-testing/wayf');
 
       // Load the connected IdPs by selecting their h3 titles
-      cy.countIdps(5)
+      cy.countIdps(7)
           .eq(2)
           .should('have.text', 'Connected IdP 3 en');
 
@@ -23,7 +23,7 @@ context('WayfMouseBehaviour', () => {
   });
 
   it('Should show ten connected IdPs', () => {
-      cy.visit('https://engine.dev.openconext.local/functional-testing/wayf?connectedIdps=10');
+      cy.visit('https://engine.dev.openconext.local/functional-testing/wayf?connectedIdps=10&addDiscoveries=0');
       cy.countIdps(10);
   });
 

--- a/tests/e2e/cypress/integration/skeune/wayf/wayf.general.spec.js
+++ b/tests/e2e/cypress/integration/skeune/wayf/wayf.general.spec.js
@@ -87,6 +87,14 @@ context('WAYF behaviour not tied to mouse / keyboard navigation', () => {
         .should('contain.text', 'Connected IdP 4 en');
     });
 
+    it('Should be able to find IDP by entering keyword for discovery idp', () => {
+      cy.visit('https://engine.dev.openconext.local/functional-testing/wayf');
+      cy.get(searchFieldSelector).type('royal');
+      cy.get(matchSelector)
+        .should('have.length', 2)
+        .should('contain.text', 'National University of the Netherlands');
+    });
+
     it('Should get the correct weight for an idp with a full match on the title', () => {
       cy.visit('https://engine.dev.openconext.local/functional-testing/wayf?connectedIdps=50');
       cy.get(searchFieldSelector).type('Connected Idp 4 en');

--- a/tests/e2e/cypress/integration/skeune/wayf/wayf.keyboard.spec.js
+++ b/tests/e2e/cypress/integration/skeune/wayf/wayf.keyboard.spec.js
@@ -72,6 +72,8 @@ context('WAYF when using the keyboard', () => {
       cy.pressArrowOnIdpList('down', idpClass, '3');
       cy.pressArrowOnIdpList('down', idpClass, '4');
       cy.pressArrowOnIdpList('down', idpClass, '5');
+      cy.pressArrowOnIdpList('down', idpClass, '6');
+      cy.pressArrowOnIdpList('down', idpClass, '7');
       cy.pressArrowOnIdpList('down', searchFieldClass);
     });
 
@@ -79,6 +81,8 @@ context('WAYF when using the keyboard', () => {
       cy.visit('https://engine.dev.openconext.local/functional-testing/wayf?showIdpBanner=1');
       cy.get(searchFieldSelector).focus();
       cy.pressArrowOnIdpList('up', searchFieldClass);
+      cy.pressArrowOnIdpList('up', idpClass, '7');
+      cy.pressArrowOnIdpList('up', idpClass, '6');
       cy.pressArrowOnIdpList('up', idpClass, '5');
       cy.pressArrowOnIdpList('up', idpClass, '4');
       cy.pressArrowOnIdpList('up', idpClass, '3');

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssemblerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Tests;
+
+use OpenConext\EngineBlock\Metadata\Discovery;
+use OpenConext\EngineBlock\Metadata\Entity\Assembler\DiscoveryAssembler;
+use OpenConext\EngineBlock\Metadata\Logo;
+use OpenConext\EngineBlockBundle\Localization\LanguageSupportProvider;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class DiscoveryAssemblerTest extends TestCase
+{
+    private $discoveryAssembler;
+
+    protected function setUp(): void
+    {
+        $languageSupportProvider = $this->createMock(LanguageSupportProvider::class);
+        $languageSupportProvider
+            ->method('getSupportedLanguages')
+            ->willReturn(['en', 'fr', 'de']);
+
+        $this->discoveryAssembler = new DiscoveryAssembler($languageSupportProvider);
+    }
+
+    public function testAssembleDiscoveriesReturnsEmptyArrayWhenNoDiscoveries(): void
+    {
+        $connection = new stdClass();
+        $connection->metadata = new stdClass();
+
+        $result = $this->discoveryAssembler->assembleDiscoveries($connection);
+
+        $this->assertEquals([], $result);
+    }
+
+    public function testAssembleDiscoveriesProcessesValidDiscovery(): void
+    {
+        $connection = new stdClass();
+        $connection->metadata = new stdClass();
+        $connection->metadata->discoveries = [
+            $this->createDiscoveryObject([
+                'name_en' => 'Test Discovery',
+                'name_fr' => 'Découverte Test',
+                'keywords_en' => 'test, discovery',
+                'keywords_fr' => 'test, découverte',
+                'logo_url' => 'http://example.com/logo.png',
+                'logo_width' => 100,
+                'logo_height' => 100
+            ])
+        ];
+
+        $result = $this->discoveryAssembler->assembleDiscoveries($connection);
+
+        $this->assertArrayHasKey('discoveries', $result);
+        $this->assertCount(1, $result['discoveries']);
+        $this->assertInstanceOf(Discovery::class, $result['discoveries'][0]);
+
+        /** @var Discovery $discovery */
+        $discovery = $result['discoveries'][0];
+        $this->assertEquals('Test Discovery', $discovery->getName('en'));
+        $this->assertEquals('Découverte Test', $discovery->getName('fr'));
+        $this->assertEquals('test, discovery', $discovery->getKeywords('en'));
+        $this->assertEquals('test, découverte', $discovery->getKeywords('fr'));
+
+        $this->assertInstanceOf(Logo::class, $discovery->getLogo());
+        $this->assertEquals('http://example.com/logo.png', $discovery->getLogo()->url);
+        $this->assertEquals(100, $discovery->getLogo()->width);
+        $this->assertEquals(100, $discovery->getLogo()->height);
+    }
+
+    public function testAssembleDiscoveriesSkipsDiscoveryWithoutEnglishName(): void
+    {
+        $connection = new stdClass();
+        $connection->metadata = new stdClass();
+        $connection->metadata->discoveries = [
+            $this->createDiscoveryObject([
+                'name_fr' => 'Découverte Test',
+                'keywords_fr' => 'test, découverte'
+            ])
+        ];
+
+        $result = $this->discoveryAssembler->assembleDiscoveries($connection);
+
+        $this->assertEquals([], $result);
+    }
+
+    public function testAssembleDiscoveriesWithTrimmedValues(): void
+    {
+        $connection = new stdClass();
+        $connection->metadata = new stdClass();
+        $connection->metadata->discoveries = [
+            $this->createDiscoveryObject([
+                'name_en' => '  Test Discovery  ',
+                'name_fr' => '  Découverte Test  ',
+                'keywords_en' => '  test, discovery  ',
+                'keywords_fr' => '  test, découverte  '
+            ])
+        ];
+
+        $result = $this->discoveryAssembler->assembleDiscoveries($connection);
+
+        $this->assertArrayHasKey('discoveries', $result);
+        /** @var Discovery $discovery */
+        $discovery = $result['discoveries'][0];
+        $this->assertEquals('Test Discovery', $discovery->getName('en'));
+        $this->assertEquals('Découverte Test', $discovery->getName('fr'));
+        $this->assertEquals('test, discovery', $discovery->getKeywords('en'));
+        $this->assertEquals('test, découverte', $discovery->getKeywords('fr'));
+    }
+
+    public function testAssembleDiscoveriesWithEmptyLogoUrl(): void
+    {
+        $connection = new stdClass();
+        $connection->metadata = new stdClass();
+        $connection->metadata->discoveries = [
+            $this->createDiscoveryObject([
+                'name_en' => 'Test Discovery',
+                'logo_url' => '',
+                'logo_width' => 100,
+                'logo_height' => 100
+            ])
+        ];
+
+        $result = $this->discoveryAssembler->assembleDiscoveries($connection);
+
+        $this->assertArrayHasKey('discoveries', $result);
+        $this->assertFalse($result['discoveries'][0]->hasLogo());
+    }
+
+    public function testAssembleDiscoveriesWithLogoWithoutDimensions(): void
+    {
+        $connection = new stdClass();
+        $connection->metadata = new stdClass();
+        $connection->metadata->discoveries = [
+            $this->createDiscoveryObject([
+                'name_en' => 'Test Discovery',
+                'logo_url' => 'http://example.com/logo.png'
+            ])
+        ];
+
+        $result = $this->discoveryAssembler->assembleDiscoveries($connection);
+
+        $this->assertArrayHasKey('discoveries', $result);
+        /** @var Discovery $discovery */
+        $discovery = $result['discoveries'][0];
+        $this->assertInstanceOf(Logo::class, $discovery->getLogo());
+        $this->assertEquals('http://example.com/logo.png', $discovery->getLogo()->url);
+        $this->assertNull($discovery->getLogo()->width);
+        $this->assertNull($discovery->getLogo()->height);
+    }
+
+    private function createDiscoveryObject(array $properties): stdClass
+    {
+        $discovery = new stdClass();
+        foreach ($properties as $key => $value) {
+            $discovery->$key = $value;
+        }
+        return $discovery;
+    }
+}

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/fixtures/metadata_idp_display_data.json
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/fixtures/metadata_idp_display_data.json
@@ -1,0 +1,62 @@
+{
+    "2d96e27a-76cf-4ca2-ac70-ece5d4c49524": {
+        "stepup_connections": [
+            {
+                "name": "https://serviceregistry.test2.openconext.nl/simplesaml/module.php/saml/sp/metadata.php/default-sp",
+                "level": "http://test.openconext.nl/assurance/loa2"
+            },
+            {
+                "name": "http://mock-sp",
+                "level": "http://test.openconext.nl/assurance/loa3"
+            }
+        ],
+        "name": "https:\/\/serviceregistry.dev.openconext.local\/simplesaml\/module.php\/saml\/sp\/metadata.php\/default-idp",
+        "state": "prodaccepted",
+        "type": "saml20-idp",
+        "metadata": {
+            "discoveries": [
+                {
+                    "logo_url": "https://engine.dev.openconext.local/images/discovery_logo.png?v=dev",
+                    "name_en": "Discovery #1",
+                    "name_nl": "Discovery #1 nl",
+                    "keywords_en": "disco keywords, (test)",
+                    "keywords_nl": "disco keywords, nl",
+                    "logo_height": "96",
+                    "logo_width": "128"
+                },
+                {
+                    "name_en": "Minimal discovery"
+                }
+            ],
+            "OrganizationName": {
+                "en": "OpenConext DEV"
+            },
+            "SingleSignOnService": [
+                {
+                    "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "Location": "https://mujina-idp.dev.openConext.local/SingleSignOnService"
+                }
+            ],
+            "certData": "MIIDEzCCAfugAwIBAgIJAKoK/heBjcOYMA0GCSqGSIb3DQEBBQUAMCAxHjAcBgNVBAoMFU9yZ2FuaXphdGlvbiwgQ049T0lEQzAeFw0xNTExMTExMDEyMTVaFw0yNTExMTAxMDEyMTVaMCAxHjAcBgNVBAoMFU9yZ2FuaXphdGlvbiwgQ049T0lEQzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANBGwJ/qpTQNiSgUglSE2UzEkUow+wS8r67etxoEhlzJZfgK/k5TfG1wICDqapHAxEVgUM10aBHRctNocA5wmlHtxdidhzRZroqHwpKy2BmsKX5Z2oK25RLpsyusB1KroemgA/CjUnI6rIL1xxFn3KyOFh1ZBLUQtKNQeMS7HFGgSDAp+sXuTFujz12LFDugX0T0KB5a1+0l8y0PEa0yGa1oi6seONx849ZHxM0PRvUunWkuTM+foZ0jZpFapXe02yWMqhc/2iYMieE/3GvOguJchJt6R+cut8VBb6ubKUIGK7pmoq/TB6DVXpvsHqsDJXechxcicu4pdKVDHSec850CAwEAAaNQME4wHQYDVR0OBBYEFK7RqjoodSYVXGTVEdLf3kJflP/sMB8GA1UdIwQYMBaAFK7RqjoodSYVXGTVEdLf3kJflP/sMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBADNZkxlFXh4F45muCbnQd+WmaXlGvb9tkUyAIxVL8AIu8J18F420vpnGpoUAE+Hy3evBmp2nkrFAgmr055fAjpHeZFgDZBAPCwYd3TNMDeSyMta3Ka+oS7GRFDePkMEm+kH4/rITNKUF1sOvWBTSowk9TudEDyFqgGntcdu/l/zRxvx33y3LMG5USD0x4X4IKjRrRN1BbcKgi8dq10C3jdqNancTuPoqT3WWzRvVtB/q34B7F74/6JzgEoOCEHufBMp4ZFu54P0yEGtWfTwTzuoZobrChVVBt4w/XZagrRtUCDNwRpHNbpjxYudbqLqpi1MQpV9oht/BpTHVJG2i0ro=",
+            "coin": {
+                "guest_qualifier": "None"
+            },
+            "description": {
+                "en": "Dummy IDP"
+            },
+            "logo": [
+                {
+                    "url": "https://engine.dev.openconext.local/images/logo.png?v=dev"
+                }
+            ],
+            "name": {
+                "en": "Dummy IdP",
+                "nl": "Dummy IdP nl"
+            },
+            "keywords": {
+                "en": "idp keywords",
+                "nl": "idp keywords nl"
+            }
+        }
+    }
+}

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/fixtures/metadata_without_discoveries.json
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/fixtures/metadata_without_discoveries.json
@@ -1,0 +1,46 @@
+{
+    "2d96e27a-76cf-4ca2-ac70-ece5d4c49524": {
+        "stepup_connections": [
+            {
+                "name": "https://serviceregistry.test2.openconext.nl/simplesaml/module.php/saml/sp/metadata.php/default-sp",
+                "level": "http://test.openconext.nl/assurance/loa2"
+            },
+            {
+                "name": "http://mock-sp",
+                "level": "http://test.openconext.nl/assurance/loa3"
+            }
+        ],
+        "name": "https:\/\/serviceregistry.dev.openconext.local\/simplesaml\/module.php\/saml\/sp\/metadata.php\/default-idp",
+        "state": "prodaccepted",
+        "type": "saml20-idp",
+        "metadata": {
+            "OrganizationName": {
+                "en": "OpenConext DEV"
+            },
+            "SingleSignOnService": [
+                {
+                    "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "Location": "https://mujina-idp.dev.openConext.local/SingleSignOnService"
+                }
+            ],
+            "certData": "MIIDEzCCAfugAwIBAgIJAKoK/heBjcOYMA0GCSqGSIb3DQEBBQUAMCAxHjAcBgNVBAoMFU9yZ2FuaXphdGlvbiwgQ049T0lEQzAeFw0xNTExMTExMDEyMTVaFw0yNTExMTAxMDEyMTVaMCAxHjAcBgNVBAoMFU9yZ2FuaXphdGlvbiwgQ049T0lEQzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANBGwJ/qpTQNiSgUglSE2UzEkUow+wS8r67etxoEhlzJZfgK/k5TfG1wICDqapHAxEVgUM10aBHRctNocA5wmlHtxdidhzRZroqHwpKy2BmsKX5Z2oK25RLpsyusB1KroemgA/CjUnI6rIL1xxFn3KyOFh1ZBLUQtKNQeMS7HFGgSDAp+sXuTFujz12LFDugX0T0KB5a1+0l8y0PEa0yGa1oi6seONx849ZHxM0PRvUunWkuTM+foZ0jZpFapXe02yWMqhc/2iYMieE/3GvOguJchJt6R+cut8VBb6ubKUIGK7pmoq/TB6DVXpvsHqsDJXechxcicu4pdKVDHSec850CAwEAAaNQME4wHQYDVR0OBBYEFK7RqjoodSYVXGTVEdLf3kJflP/sMB8GA1UdIwQYMBaAFK7RqjoodSYVXGTVEdLf3kJflP/sMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBADNZkxlFXh4F45muCbnQd+WmaXlGvb9tkUyAIxVL8AIu8J18F420vpnGpoUAE+Hy3evBmp2nkrFAgmr055fAjpHeZFgDZBAPCwYd3TNMDeSyMta3Ka+oS7GRFDePkMEm+kH4/rITNKUF1sOvWBTSowk9TudEDyFqgGntcdu/l/zRxvx33y3LMG5USD0x4X4IKjRrRN1BbcKgi8dq10C3jdqNancTuPoqT3WWzRvVtB/q34B7F74/6JzgEoOCEHufBMp4ZFu54P0yEGtWfTwTzuoZobrChVVBt4w/XZagrRtUCDNwRpHNbpjxYudbqLqpi1MQpV9oht/BpTHVJG2i0ro=",
+            "coin": {
+                "guest_qualifier": "None"
+            },
+            "description": {
+                "en": "Dummy IDP"
+            },
+            "logo": [
+                {
+                    "url": "https://engine.dev.openconext.local/images/logo.png?v=dev"
+                }
+            ],
+            "name": {
+                "en": "Dummy IdP"
+            },
+            "keywords": {
+                "en": "idp keywords"
+            }
+        }
+    }
+}

--- a/tests/integration/OpenConext/EngineBlockBundle/Service/DiscoverySelectionServiceTest.php
+++ b/tests/integration/OpenConext/EngineBlockBundle/Service/DiscoverySelectionServiceTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Service;
+
+use OpenConext\EngineBlock\Metadata\Discovery;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Logo;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class DiscoverySelectionServiceTest extends TestCase
+{
+    /**
+     * @var DiscoverySelectionService
+     */
+    private $service;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var IdentityProvider
+     */
+    private $identityProvider;
+
+    /**
+     * @var Discovery
+     */
+    private $discovery;
+
+    protected function setUp(): void
+    {
+        $this->service = new DiscoverySelectionService();
+        $this->session = $this->createMock(SessionInterface::class);
+        $this->identityProvider = $this->createMock(IdentityProvider::class);
+        $this->discovery = Discovery::create(['en' => 'IdP'], [], new Logo('https://example.org/image.png'));
+    }
+
+    public function testDiscoveryMatchesHashReturnsTrue()
+    {
+        $hash = hash('sha256', json_encode($this->discovery));
+
+        $this->assertTrue(
+            $this->service->discoveryMatchesHash($this->discovery, $hash)
+        );
+    }
+
+    public function testDiscoveryMatchesHashReturnsFalse()
+    {
+        $hash = 'invalid_hash';
+
+        $this->assertFalse(
+            $this->service->discoveryMatchesHash($this->discovery, $hash)
+        );
+    }
+
+    public function testGetDiscoveryFromRequestReturnsMatchingDiscovery()
+    {
+        $hash = hash('sha256', json_encode($this->discovery));
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with(
+                'discovery',
+                false
+            )
+            ->willReturn($hash);
+
+        $this->identityProvider->expects($this->once())
+            ->method('getDiscoveries')
+            ->willReturn([$this->discovery]);
+
+        $result = $this->service->getDiscoveryFromRequest($this->session, $this->identityProvider);
+
+        $this->assertSame($this->discovery, $result);
+    }
+
+    public function testGetDiscoveryFromRequestReturnsNullWhenNoMatch()
+    {
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with(
+                'discovery',
+                false
+            )
+            ->willReturn('non_matching_hash');
+
+        $this->identityProvider->expects($this->once())
+            ->method('getDiscoveries')
+            ->willReturn([$this->discovery]);
+
+        $result = $this->service->getDiscoveryFromRequest($this->session, $this->identityProvider);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetDiscoveryFromRequestWithEmptySession()
+    {
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with(
+                'discovery',
+                false
+            )
+            ->willReturn(false);
+
+        $this->identityProvider->expects($this->once())
+            ->method('getDiscoveries')
+            ->willReturn([$this->discovery]);
+
+        $result = $this->service->getDiscoveryFromRequest($this->session, $this->identityProvider);
+
+        $this->assertNull($result);
+    }
+
+    public function testRegisterDiscoveryHashStoresHashInSession()
+    {
+        $hash = 'test_hash';
+
+        $this->session->expects($this->once())
+            ->method('set')
+            ->with('discovery', $hash);
+
+        $this->service->registerDiscoveryHash($this->session, $hash);
+    }
+
+    public function testClearDiscoveryHashRemovesHashFromSession()
+    {
+        $this->session->expects($this->once())
+            ->method('remove')
+            ->with('discovery');
+
+        $this->service->clearDiscoveryHash($this->session);
+    }
+
+    public function testGetDiscoveryFromRequestWithMultipleDiscoveries()
+    {
+        $discovery2 = $this->createMock(Discovery::class);
+        $hash = hash('sha256', json_encode($discovery2));
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with(
+                'discovery',
+                false
+            )
+            ->willReturn($hash);
+
+        $this->identityProvider->expects($this->once())
+            ->method('getDiscoveries')
+            ->willReturn([$this->discovery, $discovery2]);
+
+        $result = $this->service->getDiscoveryFromRequest($this->session, $this->identityProvider);
+
+        $this->assertEquals($discovery2, $result);
+    }
+
+    public function testHashGeneratesCorrectHash()
+    {
+        $discoveryJson = json_encode($this->discovery);
+        $expectedHash = hash('sha256', $discoveryJson);
+
+        $result = $this->service->hash($this->discovery);
+
+        $this->assertEquals($expectedHash, $result);
+    }
+
+}

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/ProvideConsentTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/ProvideConsentTest.php
@@ -28,6 +28,7 @@ use OpenConext\EngineBlock\Service\Dto\ProcessingStateStep;
 use OpenConext\EngineBlock\Service\ProcessingStateHelper;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
 use OpenConext\EngineBlockBundle\Authentication\AuthenticationStateInterface;
+use OpenConext\EngineBlockBundle\Service\DiscoverySelectionService;
 use PHPUnit\Framework\TestCase;
 use SAML2\Assertion;
 use SAML2\AuthnRequest;
@@ -83,6 +84,11 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends TestCase
      */
     private $sessionMock;
 
+    /**
+     * @var DiscoverySelectionService
+     */
+    private $discoverySelectionService;
+
     public function setUp(): void
     {
         $diContainer = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer();
@@ -97,6 +103,7 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends TestCase
         $this->twig = $this->mockTwig();
         $this->processingStateHelperMock = $this->mockProcessingStateHelper();
         $this->httpRequestMock = $this->mockHttpRequest();
+        $this->discoverySelectionService = Phake::mock(DiscoverySelectionService::class);
     }
 
     public function testConsentRequested()
@@ -327,7 +334,8 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends TestCase
             $this->consentService,
             $this->authStateHelperMock,
             $this->twig,
-            $this->processingStateHelperMock
+            $this->processingStateHelperMock,
+            $this->discoverySelectionService
         );
     }
 
@@ -366,6 +374,10 @@ class EngineBlock_Test_Corto_Module_Service_ProvideConsentTest extends TestCase
     private function mockHttpRequest()
     {
         $helperMock = Phake::mock(Request::class);
+
+        Phake::when($helperMock)
+            ->getSession(Phake::anyParameters())
+            ->thenReturn(new Session());
 
         return $helperMock;
     }

--- a/tests/unit/OpenConext/EngineBlock/Metadata/DiscoveryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/DiscoveryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Metadata;
+
+use OpenConext\EngineBlock\Exception\InvalidDiscoveryException;
+use PHPUnit\Framework\TestCase;
+
+class DiscoveryTest extends TestCase
+{
+    public function test_successful_create(): void
+    {
+        $discovery = Discovery::create(['en' => 'foo'], [], null);
+        $this->assertNotNull($discovery);
+    }
+
+    /**
+     * @dataProvider localeValueArrayProvider
+     */
+    public function test_validates_localized_names(array $names, string $expectedExceptionMessage = null): void
+    {
+        $this->expectException(InvalidDiscoveryException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        Discovery::create($names, [], null);
+    }
+
+    /**
+     * @dataProvider localeValueArrayProvider
+     */
+    public function test_validates_localized_keywords(array $keywords, string $expectedExceptionMessage): void
+    {
+        $this->expectException(InvalidDiscoveryException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        Discovery::create([], $keywords, null);
+    }
+
+    public function localeValueArrayProvider(): array
+    {
+        return [
+            'non-string locale key' => [
+                [1 => 'Some content'],
+                "Discovery language key must be a string, '1' given"
+            ],
+            'locale key too long' => [
+                ['eng' => 'English content'],
+                "Invalid discovery language key, 'eng' given"
+            ],
+            'locale key too short' => [
+                ['e' => 'English content'],
+                "Invalid discovery language key, 'e' given"
+            ],
+            'non-string value' => [
+                ['en' => 123],
+                "Discovery value must be a string, '123' given"
+            ],
+            'empty array' => [
+                [],
+                "The Discovery does not have a required english name."
+            ]
+        ];
+    }
+
+
+}

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/AbstractEntityTest.php
@@ -32,6 +32,7 @@ use OpenConext\EngineBlock\Metadata\Organization;
 use OpenConext\EngineBlock\Metadata\RequestedAttribute;
 use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\ShibMdScope;
+use OpenConext\EngineBlock\Metadata\Discovery;
 use OpenConext\EngineBlock\Metadata\X509\X509Certificate;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -104,11 +105,12 @@ abstract class AbstractEntityTest extends TestCase
             'singleSignOnServices' => function(IdentityProviderEntityInterface $entity) { return  $entity->getSingleSignOnServices(); },
             'consentSettings' => function(IdentityProviderEntityInterface $entity) { return  $entity->getConsentSettings(); },
             'shibMdScopes' => function(IdentityProviderEntityInterface $entity) { return  $entity->getShibMdScopes(); },
+            'discoveries' => function(IdentityProviderEntityInterface $entity) { return  $entity->getDiscoveries(); },
         ];
 
         $missing = array_diff_key($implemented, $assertions);
         $this->assertCount(0, $missing, 'missing tests for: '. json_encode($missing));
-        $this->assertCount(32, $implemented);
+        $this->assertCount(33, $implemented);
         $this->assertCount(count($implemented), $assertions);
 
         foreach ($assertions as $name => $assertion) {
@@ -201,6 +203,7 @@ abstract class AbstractEntityTest extends TestCase
             'setConsentSettings',
             'toggleWorkflowState',
             'hasCompleteOrganizationData',
+            'setDiscoveries'
         ];
 
         // Get all state from the old mutable entity
@@ -439,6 +442,9 @@ abstract class AbstractEntityTest extends TestCase
             'shibMdScopes' => [
                 $this->createMock(ShibMdScope::class),
                 $this->createMock(ShibMdScope::class),
+            ],
+            'discoveries' => [
+                $this->createMock(Discovery::class),
             ]
         ];
     }

--- a/tests/unit/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/WayfTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/WayfTest.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Tests\OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
+
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Wayf;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translation\TranslatorInterface;
+use OpenConext\EngineBlockBundle\Twig\Extensions\Extension\ConnectedIdps;
+
+
+class WayfTest extends TestCase
+{
+    private $requestStack;
+    private $translator;
+    private $wayf;
+
+    protected function setUp(): void
+    {
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->wayf = new Wayf($this->requestStack, $this->translator);
+    }
+
+    public function testGetConnectedIdpsWithEmptyPreviousSelection()
+    {
+        $idpList = [
+            [
+                'EntityID' => 'https://idp1.example.org',
+                'Access' => '1',
+                'Name' => 'IDP One',
+                'Keywords' => ['university', 'education'],
+                'Logo' => 'logo1.png',
+                'isDefaultIdp' => false,
+                'DiscoveryHash' => 'hash1'
+            ],
+            [
+                'EntityID' => 'https://idp2.example.org',
+                'Access' => '0',
+                'Name' => 'IDP Two',
+                'Keywords' => 'Undefined',
+                'Logo' => 'logo2.png',
+                'isDefaultIdp' => true,
+                'DiscoveryHash' => 'hash2'
+            ]
+        ];
+
+        $result = $this->wayf->getConnectedIdps($idpList);
+
+        $this->assertInstanceOf(ConnectedIdps::class, $result);
+        $this->assertEmpty($result->getFormattedPreviousSelectionList());
+
+        $formattedList = $result->getFormattedIdpList();
+        $this->assertCount(2, $formattedList);
+
+        // Check first IDP
+        $this->assertEquals('https://idp1.example.org', $formattedList[0]['entityId']);
+        $this->assertTrue($formattedList[0]['connected']);
+        $this->assertEquals('IDP One', $formattedList[0]['displayTitle']);
+        $this->assertEquals('idp one', $formattedList[0]['title']);
+        $this->assertEquals('university|education', $formattedList[0]['keywords']);
+        $this->assertEquals('logo1.png', $formattedList[0]['logo']);
+        $this->assertFalse($formattedList[0]['isDefaultIdp']);
+        $this->assertEquals('hash1', $formattedList[0]['discoveryHash']);
+
+        // Check second IDP
+        $this->assertEquals('https://idp2.example.org', $formattedList[1]['entityId']);
+        $this->assertFalse($formattedList[1]['connected']);
+        $this->assertEquals('IDP Two', $formattedList[1]['displayTitle']);
+        $this->assertEquals('idp two', $formattedList[1]['title']);
+        $this->assertEquals('', $formattedList[1]['keywords']);
+        $this->assertEquals('logo2.png', $formattedList[1]['logo']);
+        $this->assertTrue($formattedList[1]['isDefaultIdp']);
+        $this->assertEquals('hash2', $formattedList[1]['discoveryHash']);
+    }
+
+    public static function previousSelectionProvider(): array
+    {
+        return [
+            ['https://idp1.example.org', 'idp one'],
+            ['https://idp1.example.org|hash1', 'idp one discovery'],
+        ];
+    }
+
+    /**
+     * @dataProvider previousSelectionProvider
+     */
+    public function testGetConnectedIdpsWithPreviousSelection(string $storedCookieValue, string $expectedName)
+    {
+        // Create a mock request with cookie
+        $request = $this->createMock(Request::class);
+        $request->cookies = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['get'])
+            ->getMock();
+        $request->cookies->method('get')
+            ->willReturn(json_encode([
+                ['idp' => $storedCookieValue, 'time' => 12345]
+            ]));
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')
+            ->willReturn($request);
+
+        // Create new wayf instance with the mocked request
+        $wayf = new Wayf($requestStack, $this->translator);
+
+        $idpList = [
+            [
+                'EntityID' => 'https://idp1.example.org',
+                'Access' => '1',
+                'Name' => 'IDP One',
+                'Keywords' => ['university', 'education'],
+                'Logo' => 'logo1.png',
+                'isDefaultIdp' => false,
+                'DiscoveryHash' => ''
+            ],
+            [
+                'EntityID' => 'https://idp1.example.org',
+                'Access' => '1',
+                'Name' => 'IDP One Discovery',
+                'Keywords' => [],
+                'Logo' => 'logo2.png',
+                'isDefaultIdp' => false,
+                'DiscoveryHash' => 'hash1'
+            ]
+        ];
+
+        $result = $wayf->getConnectedIdps($idpList);
+
+        $this->assertInstanceOf(ConnectedIdps::class, $result);
+        $previousSelection = $result->getFormattedPreviousSelectionList();
+        $this->assertCount(1, $previousSelection);
+        $this->assertEquals($expectedName, $previousSelection[0]['title']);
+        $this->assertEquals('https://idp1.example.org', $previousSelection[0]['entityId']);
+    }
+
+    public function testGetWayfJsonConfig()
+    {
+        // Create mocks
+        $connectedIdps = $this->createMock(ConnectedIdps::class);
+        $serviceProvider = $this->createMock(ServiceProvider::class);
+
+        // Setup mock return values
+        $connectedIdps->method('getFormattedPreviousSelectionList')
+            ->willReturn([['idp' => 'https://idp1.example.org', 'time' => 12345]]);
+
+        $connectedIdps->method('getConnectedIdps')
+            ->willReturn([
+                [
+                    'entityId' => 'https://idp1.example.org',
+                    'connected' => true,
+                    'displayTitle' => 'IDP One',
+                    'title' => 'idp one',
+                    'keywords' => 'university|education',
+                    'logo' => 'logo1.png',
+                    'isDefaultIdp' => false,
+                    'discoveryHash' => 'hash1'
+                ]
+            ]);
+
+        $connectedIdps->method('getFormattedIdpList')
+            ->willReturn([
+                [
+                    'entityId' => 'https://idp1.example.org',
+                    'connected' => true,
+                    'displayTitle' => 'IDP One',
+                    'title' => 'idp one',
+                    'keywords' => 'university|education',
+                    'logo' => 'logo1.png',
+                    'isDefaultIdp' => false,
+                    'discoveryHash' => 'hash1'
+                ],
+                [
+                    'entityId' => 'https://idp2.example.org',
+                    'connected' => false,
+                    'displayTitle' => 'IDP Two',
+                    'title' => 'idp two',
+                    'keywords' => '',
+                    'logo' => 'logo2.png',
+                    'isDefaultIdp' => true,
+                    'discoveryHash' => 'hash2'
+                ]
+            ]);
+
+        $serviceProvider->entityId = 'https://sp.example.org';
+        $serviceProvider->method('getDisplayName')
+            ->willReturn('Test SP');
+
+        // Setup translator
+        $this->translator->method('trans')
+            ->willReturnMap([
+                ['more_idp_results', [], null, null, 'More results'],
+                ['request_access', [], null, null, 'Request Access']
+            ]);
+
+        // Test with showRequestAccess = true
+        $jsonConfig = $this->wayf->getWayfJsonConfig(
+            $connectedIdps,
+            $serviceProvider,
+            'en',
+            true,
+            true,
+            5
+        );
+
+        $config = json_decode($jsonConfig, true);
+
+        $this->assertEquals(Wayf::PREVIOUS_SELECTION_COOKIE_NAME, $config['previousSelectionCookieName']);
+        $this->assertEquals([['idp' => 'https://idp1.example.org', 'time' => 12345]], $config['previousSelectionList']);
+        $this->assertCount(1, $config['connectedIdps']);
+        $this->assertCount(1, $config['unconnectedIdps']);
+        $this->assertEquals(5, $config['cutoffPointForShowingUnfilteredIdps']);
+        $this->assertEquals(Wayf::REMEMBER_CHOICE_COOKIE_NAME, $config['rememberChoiceCookieName']);
+        $this->assertTrue($config['rememberChoiceFeature']);
+        $this->assertEquals('More results', $config['messages']['moreIdpResults']);
+        $this->assertEquals('Request Access', $config['messages']['requestAccess']);
+        $this->assertStringContainsString('/authentication/idp/requestAccess', $config['requestAccessUrl']);
+
+        // Test with showRequestAccess = false
+        $jsonConfig = $this->wayf->getWayfJsonConfig(
+            $connectedIdps,
+            $serviceProvider,
+            'en',
+            false,
+            true,
+            5
+        );
+
+        $config = json_decode($jsonConfig, true);
+        $this->assertEmpty($config['unconnectedIdps']);
+    }
+}

--- a/theme/base/javascripts/wayf/deleteDisable/addSelectedIdp.js
+++ b/theme/base/javascripts/wayf/deleteDisable/addSelectedIdp.js
@@ -9,14 +9,15 @@ import Cookies from 'js-cookie';
  */
 export const addSelectedIdp = (element) => {
   const cookieName = JSON.parse(document.getElementById(configurationId).innerHTML).previousSelectionCookieName;
-  const entityId = element.getAttribute('data-entityid');
+  const entryKey = element.getAttribute('data-idpkey');
+
   let alreadyInCookie = false;
   let cookie = Cookies.get(cookieName) || [];
 
   if (cookie.length) {
     cookie = JSON.parse(cookie);
     cookie.forEach(idp => {
-      if (idp.idp === entityId) {
+      if (idp.idp === entryKey) {
         idp.count += 1;
         savePreviousSelection(cookie, cookieName);
         alreadyInCookie = true;
@@ -26,7 +27,7 @@ export const addSelectedIdp = (element) => {
   }
 
   if (!alreadyInCookie) {
-    cookie = [...cookie, { idp: entityId, count: 1 }];
+    cookie = [...cookie, { idp: entryKey, count: 1 }];
     savePreviousSelection(cookie, cookieName);
   }
 };

--- a/theme/base/javascripts/wayf/matchPreviouslySelectedWithCookie.js
+++ b/theme/base/javascripts/wayf/matchPreviouslySelectedWithCookie.js
@@ -27,7 +27,7 @@ export const matchPreviouslySelectedWithCookie = () => {
       cookie = JSON.parse(cookie);
       // check if each idp in the cookie is in the list, if not add it
       cookie.forEach(idp => {
-        const id = `[data-entityid="${idp.idp}"]`;
+        const id = `[data-idpkey="${idp.idp}"]`;
         const inPreviouslySelected = document.querySelector(`${selectedIdpsSelector}${id}:first-of-type`);
 
         if (!inPreviouslySelected) {

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/list.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/list.html.twig
@@ -6,7 +6,13 @@
     {% set logoUrl = attributeSourceLogoUrl(attributeSource) %}
 {% else %}
     {% set organisationName = idpName %}
-    {% if idp.logo is not null %}
+    {% if idpDiscovery is defined and idpDiscovery is not null %}
+        {% if idpDiscovery.logo is not null and idpDiscovery.logo.url is not null %}
+            {% set logoUrl = idpDiscovery.logo.url %}
+        {% else %}
+            {% set logoUrl = '/images/placeholder.png' %}
+        {% endif %}
+    {% elseif idp.logo is not null %}
         {% set logoUrl = idp.logo.url %}
     {% else %}
         {% set logoUrl = '/images/placeholder.png' %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idp.html.twig
@@ -14,6 +14,7 @@
     tabindex="0"
     data-entityid="{{ idp['entityId'] }}"
     data-title="{{ idp['displayTitle'] }}"
+    data-idpkey="{{ idpDiscoveryHash(idp['entityId'], idp['discoveryHash']) }}"
 >
     <div class="idp__logo">
         {% if idp.logo is not null %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpForm.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpForm.html.twig
@@ -1,6 +1,7 @@
 <form class="idp__form" method="post" action="{{ action }}">
     <input type="hidden" name="ID" value="{{ requestId }}"/>
     <input type="hidden" name="idp" value="{{ idp['entityId'] }}"/>
+    <input type="hidden" name="discovery" value="{{ idp['discoveryHash'] }}"/>
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpSubmitButton.html.twig' with { hidden: true } %}
     <noscript>
         {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpSubmitButton.html.twig' %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -3,7 +3,11 @@
 {# SP and IdP name are stored in a local variable for convenience #}
 {% set spName = sp.displayName(locale()) %}
 {% set organizationName = sp.organizationName(locale())|default('unknown_organization_name'|trans) %}
-{% set idpName = idp.displayName(locale()) %}
+{% if idpDiscovery is defined and idpDiscovery is not null %}
+    {% set idpName = idpDiscovery.name(locale()) %}
+{% else %}
+    {% set idpName = idp.displayName(locale()) %}
+{% endif %}
 
 {# Prepare the page title #}
 {% if informationalConsent %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/wayf.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/wayf.html.twig
@@ -7,7 +7,7 @@
 {% set pageTitle = 'log_in_to'|trans({'%arg1%': spName, '%organisationNoun%': organisationNoun}) %}
 
 {# Data object containing the formatted IdP's #}
-{% set connectedIdps = connectedIdps(idpList, locale()) %}
+{% set connectedIdps = connectedIdps(idpList) %}
 
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 

--- a/theme/openconext/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -2,7 +2,11 @@
 
 {# SP and IdP name are stored in a local variable for convenience #}
 {% set spName = sp.displayName(locale()) %}
-{% set idpName = idp.displayName(locale()) %}
+{% if idpDiscovery is defined and idpDiscovery is not null %}
+    {% set idpName = idpDiscovery.name(locale()) %}
+{% else %}
+    {% set idpName = idp.displayName(locale()) %}
+{% endif %}
 
 {# Prepare the page title #}
 {% set pageTitle = 'consent_header_title'|trans({'%arg1%': spName}) %}

--- a/theme/openconext/templates/modules/Authentication/View/Proxy/wayf.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Proxy/wayf.html.twig
@@ -4,7 +4,7 @@
 {% set pageTitle = 'log_in_to'|trans %}
 
 {# Data object containing the formatted IdP's #}
-{% set connectedIdps = connectedIdps(idpList, locale()) %}
+{% set connectedIdps = connectedIdps(idpList) %}
 
 {% block title %}{{ parent() }} - {{ pageTitle }} {% endblock %}
 {% block pageHeading %}{{ parent() }} - {{ pageTitle }}{% endblock %}


### PR DESCRIPTION
Prior to this change, there were cases where it wasn't clear which
IdP end users should use. In these scenario's the users needed an IdP
which was not recognisable for them.

This change adds support for discovery IdP entries.
Which are additional names / ways of finding an IdP in the WAYF.
These can be configured in Manage.

A discovery requires at least an english name, but can also include
keywords or a custom logo, which is used on the consent page as well.

Resolves https://github.com/OpenConext/OpenConext-engineblock/issues/1338