### PR TITLE
Fix: Use correct database engine version

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -99,7 +99,7 @@ doctrine:
                 # when true, queries are logged to a 'doctrine' monolog channel
                 logging: '%kernel.debug%'
                 profiling: '%kernel.debug%'
-                server_version: 5.5
+                server_version: '10.4.0-MariaDB'
                 mapping_types:
                     enum: string
         types:


### PR DESCRIPTION
Prior to this change, doctrine would generate database migrations erroneously. It should not update anything.
This change sets the correct MariaDB version, so doctrine no longer detects changes.