### PR TITLE
Read & store metadata coin collab_enabled

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -44,7 +44,8 @@ class Coins
         $disableScoping,
         $additionalLogging,
         $signatureMethod,
-        $stepupForceAuthn
+        $stepupForceAuthn,
+        $collabEnabled
     ) {
         return new self([
             'isConsentRequired' => $isConsentRequired,
@@ -62,6 +63,7 @@ class Coins
             'stepupAllowNoToken' => $stepupAllowNoToken,
             'stepupRequireLoa' => $stepupRequireLoa,
             'stepupForceAuthn' => $stepupForceAuthn,
+            'collabEnabled' => $collabEnabled,
         ]);
     }
 
@@ -227,6 +229,11 @@ class Coins
     public function signatureMethod()
     {
         return $this->getValue('signatureMethod', XMLSecurityKey::RSA_SHA256);
+    }
+
+    public function collabEnabled()
+    {
+        return $this->getValue('collabEnabled', false);
     }
 
     public function mfaEntities(): MfaEntityCollection

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -210,88 +210,26 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
 
         $properties += $this->assembleAttributeReleasePolicy($connection);
         $properties += $this->assembleAssertionConsumerServices($connection);
-        $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:transparant_issuer'
-            ),
-            'isTransparentIssuer'
-        );
-        $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:trusted_proxy'
-            ),
-            'isTrustedProxy'
-        );
-        $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:display_unconnected_idps_wayf'
-            ),
-            'displayUnconnectedIdpsWayf'
-        );
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:transparant_issuer'], 'isTransparentIssuer');
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:trusted_proxy'], 'isTrustedProxy');
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:display_unconnected_idps_wayf'], 'displayUnconnectedIdpsWayf');
 
         $properties += $this->assembleIsConsentRequired($connection);
 
-        $properties += $this->setPathFromObjectString(
-            array(
-                $connection,
-                'metadata:coin:eula'
-            ),
-            'termsOfServiceUrl'
-        );
+        $properties += $this->setPathFromObjectString([$connection, 'metadata:coin:eula'], 'termsOfServiceUrl');
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:do_not_add_attribute_aliases'], 'skipDenormalization');
         $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:do_not_add_attribute_aliases'
-            ),
-            'skipDenormalization'
-        );
-        $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:policy_enforcement_decision_required'
-            ),
+            [$connection, 'metadata:coin:policy_enforcement_decision_required'],
             'policyEnforcementDecisionRequired'
         );
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:requesterid_required'], 'requesteridRequired');
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:sign_response'], 'signResponse');
+        $properties += $this->setPathFromObjectString([$connection, 'metadata:coin:stepup:requireloa'], 'stepupRequireLoa');
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:stepup:allow_no_token'], 'stepupAllowNoToken');
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:stepup:forceauthn'], 'stepupForceAuthn');
 
-        $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:requesterid_required'
-            ),
-            'requesteridRequired'
-        );
+        $properties += $this->setPathFromObjectBool([$connection, 'metadata:coin:collab_enabled'], 'collabEnabled');
 
-        $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:sign_response'
-            ),
-            'signResponse'
-        );
-        $properties += $this->setPathFromObjectString(
-            array(
-                $connection,
-                'metadata:coin:stepup:requireloa'
-            ),
-            'stepupRequireLoa'
-        );
-        $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:stepup:allow_no_token'
-            ),
-            'stepupAllowNoToken'
-        );
-        $properties += $this->setPathFromObjectBool(
-            array(
-                $connection,
-                'metadata:coin:stepup:forceauthn'
-            ),
-            'stepupForceAuthn'
-        );
         return Utils::instantiate(
             ServiceProvider::class,
             $properties

--- a/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/ServiceProvider.php
@@ -157,7 +157,8 @@ class ServiceProvider extends AbstractRole
         ?string $supportUrlPt = null,
         ?bool $stepupAllowNoToken = null,
         ?string $stepupRequireLoa = null,
-        bool $stepupForceAuthn = false
+        bool $stepupForceAuthn = false,
+        bool $collabEnabled = false
     ) {
         if (is_null($mdui)) {
             $mdui = Mdui::emptyMdui();
@@ -215,7 +216,8 @@ class ServiceProvider extends AbstractRole
             $disableScoping,
             $additionalLogging,
             $signatureMethod,
-            $stepupForceAuthn
+            $stepupForceAuthn,
+            $collabEnabled
         );
     }
 

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -465,4 +465,44 @@ class PushMetadataAssemblerTest extends TestCase
             ["0", false]
         ];
     }
+
+    public function test_it_assembles_coin_collab_enabled()
+    {
+        $input = $this->readFixture('metadata_coin_collab.json');
+        $connections = $this->assembler->assemble($input->connections);
+
+        /** @var ServiceProvider $sp */
+        $sp = $connections[0];
+        $this->assertInstanceOf(ServiceProvider::class, $sp);
+
+        $this->assertSame('sp coin_collab_true', $sp->nameEn);
+        $this->assertSame(true, $sp->getCoins()->collabEnabled());
+
+        /** @var ServiceProvider $sp */
+        $sp = $connections[1];
+        $this->assertInstanceOf(ServiceProvider::class, $sp);
+
+        $this->assertSame('sp coin_collab_false', $sp->nameEn);
+        $this->assertSame(false, $sp->getCoins()->collabEnabled());
+
+        /** @var ServiceProvider $sp */
+        $sp = $connections[2];
+        $this->assertInstanceOf(ServiceProvider::class, $sp);
+
+        $this->assertSame('sp coin_collab_unset', $sp->nameEn);
+        $this->assertSame(false, $sp->getCoins()->collabEnabled());
+
+
+        /** @var IdentityProvider $idp */
+        $idp = $connections[3];
+        $this->assertInstanceOf(IdentityProvider::class, $idp);
+
+        $this->assertSame('Dummy IdP', $idp->nameEn);
+        $this->assertSame(false, $idp->getCoins()->collabEnabled());
+    }
+
+    private function readFixture(string $file): object
+    {
+        return json_decode(file_get_contents(__DIR__ . '/fixtures/'. basename($file)), false);
+    }
 }

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/fixtures/metadata_coin_collab.json
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/fixtures/metadata_coin_collab.json
@@ -1,0 +1,141 @@
+{
+    "connections": {
+        "ccd61cb5-5c59-4608-b037-a39a92ad5bca": {
+            "allow_all_entities": true,
+            "allowed_connections": [],
+            "metadata": {
+                "AssertionConsumerService": [
+                    {
+                        "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                        "Location": "https://spdashboard.dev.openconext.local/saml/acs"
+                    }
+                ],
+                "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                "OrganizationName": {
+                    "en": "OpenConext DEV"
+                },
+                "coin": {
+                    "no_consent_required": "1",
+                    "collab_enabled": "1",
+                    "signature_method": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+                },
+                "description": {
+                    "en": "spdashboard OpenConext DEV"
+                },
+                "name": {
+                    "en": "sp coin_collab_true"
+                }
+            },
+            "name": "https://spdashboard.dev.openconext.local/saml/metadata",
+            "state": "prodaccepted",
+            "type": "saml20-sp"
+        },
+        "377f0366-c593-43fa-880a-169469d6990b": {
+            "allow_all_entities": true,
+            "allowed_connections": [],
+            "metadata": {
+                "AssertionConsumerService": [
+                    {
+                        "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                        "Location": "https://spdashboard.dev.openconext.local/saml/acs"
+                    }
+                ],
+                "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                "OrganizationName": {
+                    "en": "OpenConext DEV"
+                },
+                "coin": {
+                    "no_consent_required": "1",
+                    "collab_enabled": "0",
+                    "signature_method": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+                },
+                "description": {
+                    "en": "spdashboard OpenConext DEV"
+                },
+                "name": {
+                    "en": "sp coin_collab_false"
+                }
+            },
+            "name": "https://spdashboard.dev.openconext.local/saml/metadata",
+            "state": "prodaccepted",
+            "type": "saml20-sp"
+        },
+        "a2592ad5-7288-4443-9529-45484ae36254": {
+            "allow_all_entities": true,
+            "allowed_connections": [],
+            "metadata": {
+                "AssertionConsumerService": [
+                    {
+                        "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                        "Location": "https://spdashboard.dev.openconext.local/saml/acs"
+                    }
+                ],
+                "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                "OrganizationName": {
+                    "en": "OpenConext DEV"
+                },
+                "coin": {
+                    "no_consent_required": "1",
+                    "signature_method": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+                },
+                "description": {
+                    "en": "spdashboard OpenConext DEV"
+                },
+                "name": {
+                    "en": "sp coin_collab_unset"
+                }
+            },
+            "name": "https://spdashboard.dev.openconext.local/saml/metadata",
+            "state": "prodaccepted",
+            "type": "saml20-sp"
+        },
+        "43468888-4f10-494e-80a1-c7f8569c0fdd": {
+            "allow_all_entities": true,
+            "allowed_connections": [],
+            "disable_consent_connections": [],
+            "metadata": {
+                "OrganizationName": {
+                    "en": "OpenConext DEV"
+                },
+                "SingleSignOnService": [
+                    {
+                        "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                        "Location": "https://mujina-idp.dev.openConext.local/SingleSignOnService"
+                    }
+                ],
+                "certData": "MIIDEzCCAfugAwIBAgIJAKoK/heBjcOYMA0GCSqGSIb3DQEBBQUAMCAxHjAcBgNVBAoMFU9yZ2FuaXphdGlvbiwgQ049T0lEQzAeFw0xNTExMTExMDEyMTVaFw0yNTExMTAxMDEyMTVaMCAxHjAcBgNVBAoMFU9yZ2FuaXphdGlvbiwgQ049T0lEQzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANBGwJ/qpTQNiSgUglSE2UzEkUow+wS8r67etxoEhlzJZfgK/k5TfG1wICDqapHAxEVgUM10aBHRctNocA5wmlHtxdidhzRZroqHwpKy2BmsKX5Z2oK25RLpsyusB1KroemgA/CjUnI6rIL1xxFn3KyOFh1ZBLUQtKNQeMS7HFGgSDAp+sXuTFujz12LFDugX0T0KB5a1+0l8y0PEa0yGa1oi6seONx849ZHxM0PRvUunWkuTM+foZ0jZpFapXe02yWMqhc/2iYMieE/3GvOguJchJt6R+cut8VBb6ubKUIGK7pmoq/TB6DVXpvsHqsDJXechxcicu4pdKVDHSec850CAwEAAaNQME4wHQYDVR0OBBYEFK7RqjoodSYVXGTVEdLf3kJflP/sMB8GA1UdIwQYMBaAFK7RqjoodSYVXGTVEdLf3kJflP/sMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBADNZkxlFXh4F45muCbnQd+WmaXlGvb9tkUyAIxVL8AIu8J18F420vpnGpoUAE+Hy3evBmp2nkrFAgmr055fAjpHeZFgDZBAPCwYd3TNMDeSyMta3Ka+oS7GRFDePkMEm+kH4/rITNKUF1sOvWBTSowk9TudEDyFqgGntcdu/l/zRxvx33y3LMG5USD0x4X4IKjRrRN1BbcKgi8dq10C3jdqNancTuPoqT3WWzRvVtB/q34B7F74/6JzgEoOCEHufBMp4ZFu54P0yEGtWfTwTzuoZobrChVVBt4w/XZagrRtUCDNwRpHNbpjxYudbqLqpi1MQpV9oht/BpTHVJG2i0ro=",
+                "coin": {
+                    "guest_qualifier": "None"
+                },
+                "description": {
+                    "en": "Dummy IDP"
+                },
+                "discoveries": [
+                    {
+                        "keywords_en": "idp keyword 1",
+                        "logo_url": "https://engine.dev.openconext.local/images/logo.png?v=dev",
+                        "name_en": "Dummy IdP",
+                        "name_nl": "Dummy IdP"
+                    }
+                ],
+                "keywords": {
+                    "en": "idp keyword 1"
+                },
+                "logo": [
+                    {
+                        "url": "https://engine.dev.openconext.local/images/logo.png?v=dev"
+                    }
+                ],
+                "name": {
+                    "en": "Dummy IdP",
+                    "nl": "Dummy IdP"
+                }
+            },
+            "mfa_entities": [],
+            "name": "http://mock-idp",
+            "state": "prodaccepted",
+            "stepup_connections": [],
+            "type": "saml20-idp"
+        }
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Metadata/Factory/Factory/ServiceProviderFactoryTest.php
@@ -238,6 +238,7 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
             false,
             false,
             XMLSecurityKey::RSA_SHA256,
+            false,
             false
         );
         $overrides['attributeReleasePolicy'] = null;
@@ -391,6 +392,7 @@ class ServiceProviderFactoryTest extends AbstractEntityTest
             false,
             false,
             XMLSecurityKey::RSA_SHA256,
+            false,
             false
         );
         $overrides['attributeReleasePolicy'] = null;


### PR DESCRIPTION
Prior to this change, the coin value was ignored.
Within the `coin:collab_enabled`, EB will not know wheter to perform an external SBS authorization check (not yet implemented).

This change reads and stores `coin:collab_enabled` from the metadata push for ServiceProviders.

See https://github.com/OpenConext/OpenConext-engineblock/issues/1804