### PR TITLE
Correct the db server version based on production.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -99,7 +99,7 @@ doctrine:
                 # when true, queries are logged to a 'doctrine' monolog channel
                 logging: '%kernel.debug%'
                 profiling: '%kernel.debug%'
-                server_version: '10.4.0-MariaDB'
+                server_version: '10.6.0-MariaDB'
                 mapping_types:
                     enum: string
         types:

--- a/app/config/config_ci.yml
+++ b/app/config/config_ci.yml
@@ -8,7 +8,7 @@ doctrine:
         connections:
             engineblock:
                 driver:   pdo_mysql         # This must be PDO until all database interaction runs through doctrine
-                server_version: 5.5
+                server_version: '10.6.0-MariaDB'
                 dbname:   "%database.dbname%"
                 host:     "mariadb"
                 port:     "%database.port%"
@@ -16,7 +16,7 @@ doctrine:
                 password: "%database.password%"
             engineblock_test:
                 driver:   pdo_mysql         # This must be PDO until all database interaction runs through doctrine
-                server_version: 5.5
+                server_version: '10.6.0-MariaDB'
                 dbname:   "%database.test.dbname%"
                 host:     "mariadb"
                 port:     "%database.test.port%"

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -69,7 +69,7 @@ doctrine:
         connections:
             engineblock_test:
                 driver:   pdo_mysql         # This must be PDO until all database interaction runs through doctrine
-                server_version: 5.5
+                server_version: '10.6.0-MariaDB'
                 dbname:   "%database.test.dbname%"
                 host:     "%database.test.host%"
                 port:     "%database.test.port%"


### PR DESCRIPTION
This is needed so the correct migrations are generated.