### PR TITLE
Feat: configurable default RequestedAuthnContext

### DIFF
--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -426,6 +426,7 @@ class EngineBlock_Corto_ProxyServer
             // entity which does not reside in the database.
             $originalSpEnitytId = $spEntityId;
         }
+
         // Add authncontextclassref if configured
         $service = $identityProvider->getCoins()->mfaEntities()->findByEntityId($originalSpEnitytId);
         if ($service instanceof MfaEntity) {
@@ -438,6 +439,16 @@ class EngineBlock_Corto_ProxyServer
             // When transparent_authn_context is configured, forward the SP AuthnClassRefContext to the IdP
             // See: https://www.pivotaltracker.com/story/show/173305494
             $sspMessage->setRequestedAuthnContext($spRequest->getRequestedAuthnContext());
+        } elseif ($spRequest->getRequestedAuthnContext() === null) {
+            // The request didn't have a RequestedAuthnContext set, but we do have a default to fall back to
+            $defaultRAC = $identityProvider->getCoins()->defaultRAC();
+            if ($defaultRAC !== null) {
+                $sspMessage->setRequestedAuthnContext([
+                    'AuthnContextClassRef' => [
+                        $defaultRAC,
+                    ],
+                ]);
+            }
         }
 
         $authenticationState = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()

--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -75,7 +75,8 @@ class Coins
         $disableScoping,
         $additionalLogging,
         $signatureMethod,
-        $mfaEntities
+        $mfaEntities,
+        $defaultRAC
     ) {
         return new self([
             'guestQualifier' => $guestQualifier,
@@ -86,6 +87,7 @@ class Coins
             'signatureMethod' => $signatureMethod,
             'stepupConnections' => $stepupConnections,
             'mfaEntities' => $mfaEntities,
+            'defaultRAC' => $defaultRAC,
         ]);
     }
 
@@ -192,6 +194,11 @@ class Coins
     }
 
     // IDP
+    public function defaultRAC()
+    {
+        return $this->getValue('defaultRAC');
+    }
+
     public function guestQualifier()
     {
         return $this->getValue('guestQualifier', IdentityProvider::GUEST_QUALIFIER_ALL);

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -267,6 +267,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         $properties += $this->assembleMfaEntities($connection);
 
         $properties += $this->discoveryAssembler->assembleDiscoveries($connection);
+        $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:defaultRAC'), 'defaultRAC');
 
         return Utils::instantiate(
             IdentityProvider::class,

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Disassembler/CortoDisassembler.php
@@ -122,6 +122,10 @@ class CortoDisassembler
             );
         }
 
+        if ($entity->getCoins()->defaultRAC()) {
+            $cortoEntity['DefaultRAC'] = $entity->getCoins()->defaultRAC();
+        }
+
         return $cortoEntity;
     }
 

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -143,7 +143,8 @@ class IdentityProvider extends AbstractRole
         ConsentSettings $consentSettings = null,
         StepupConnections $stepupConnections = null,
         MfaEntityCollection $mfaEntities = null,
-        array $discoveries = []
+        array $discoveries = [],
+        ?string $defaultRAC = null
     ) {
         if (is_null($mdui)) {
             $mdui = Mdui::emptyMdui();
@@ -190,7 +191,8 @@ class IdentityProvider extends AbstractRole
             $disableScoping,
             $additionalLogging,
             $signatureMethod,
-            $mfaEntities
+            $mfaEntities,
+            $defaultRAC
         );
 
         $this->assertAllDiscoveries($discoveries);

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MfaEntitiesContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MfaEntitiesContext.php
@@ -71,4 +71,17 @@ class MfaEntitiesContext extends AbstractSubContext
             ]])
             ->save();
     }
+
+    /**
+     * @Given /^the IdP "([^"]*)" has a default RequestedAuthnContext configured as "([^"]*)"$/
+     */
+    public function setIdpConfiguredAuthnContext(string $idpName, string $authnContextClassRef): void
+    {
+        /** @var MockIdentityProvider $mockIdp */
+        $mockIdp = $this->mockIdpRegistry->get($idpName);
+
+        $this->serviceRegistryFixture
+            ->setDefaultRequestedAuthContext($mockIdp->entityId(), $authnContextClassRef)
+            ->save();
+    }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -688,4 +688,15 @@ class MockSpContext extends AbstractSubContext
         $request->setRequestedAuthnContext(['AuthnContextClassRef' => [$authnContextClassRefValue]]);
         $this->mockSpRegistry->save();
     }
+
+    /**
+     * @Given /^the SP "([^"]*)" sends no AuthnContextClassRef$/
+     */
+    public function theSPSendsNoAuthnContextClassRef(string $spName): void
+    {
+        $mockSp = $this->mockSpRegistry->get($spName);
+        $request = $mockSp->getAuthnRequest();
+        $request->setRequestedAuthnContext();
+        $this->mockSpRegistry->save();
+    }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/MfaAuthnContextClassRef.feature
@@ -103,3 +103,15 @@ Feature:
    Then the url should match "/functional-testing/SSO-SP/acs"
     And the response should contain "urn:oasis:names:tc:SAML:2.0:status:Responder"
     And the response should contain "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
+
+  Scenario: A login should succeed if the we don't have a RequestedAuthnContext but a default authn class ref is configured
+    Given the IdP "SSO-IdP" has a default RequestedAuthnContext configured as "http://default-context.example.com/authn"
+    And the SP "SSO-SP" sends no AuthnContextClassRef
+    When I log in at "SSO-SP"
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/SSO-IdP/sso"
+    And the response should contain "http://default-context.example.com/authn"
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+    Then the url should match "/functional-testing/SSO-SP/acs"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -492,6 +492,13 @@ QUERY;
         return $this;
     }
 
+    public function setDefaultRequestedAuthContext(string $entityId, string $defaultRAC): self
+    {
+        $this->setCoin($this->getIdentityProvider($entityId), 'defaultRAC', $defaultRAC);
+
+        return $this;
+    }
+
     public function setIdpLogo($entityId, $url)
     {
         $logo = new Logo($url);


### PR DESCRIPTION
As discussed on Slack with Peter, I have a use-case for sending a custom RequestedAuthnContext towards an IdP _by default_. MfaEntities-settings always take precedence over this default value.