### PR TITLE
Allow configurable user attributes for Stepup

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -29,6 +29,7 @@ open_conext_engine_block:
         eb.enable_sso_session_cookie: "%feature_enable_sso_session_cookie%"
         eb.feature_enable_idp_initiated_flow: "%feature_enable_idp_initiated_flow%"
         eb.stepup.sfo.override_engine_entityid: "%feature_stepup_sfo_override_engine_entityid%"
+        eb.stepup.send_user_attributes: "%feature_stepup_send_user_attributes%"
 
 
 swiftmailer:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -229,8 +229,9 @@ parameters:
     feature_run_all_manipulations_prior_to_consent: false
     feature_block_user_on_violation: false
     feature_enable_consent: true
-    feature_stepup_sfo_override_engine_entityid: false
     feature_enable_idp_initiated_flow: true
+    feature_stepup_sfo_override_engine_entityid: false
+    feature_stepup_send_user_attributes: false
 
     ##########################################################################################
     ## PROFILE SETTINGS
@@ -272,6 +273,9 @@ parameters:
     ## You can override the default entityID used by Engineblock for its callout to stepup gateway.
     ## You also need to enable the feature toggle feature_stepup_sfo_override_engine_entityid above.
     stepup.sfo.override_engine_entityid: "https://engine.dev.openconext.local/new/stepup/metadata"
+    ## The name of the SAML attributes to send to Stepup with the GSSP SAML extension
+    stepup.callout_user_attributes:
+      - urn:mace:dir:attribute-def:mail
 
     ##########################################################################################
     ## THEME SETTINGS

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -544,6 +544,12 @@ class EngineBlock_Application_DiContainer extends Pimple
         return $this->container->getParameter('stepup.sfo.override_engine_entityid');
     }
 
+    /** @return string[] */
+    public function getStepupUserAttributes(): array
+    {
+        return $this->container->getParameter('stepup.callout_user_attributes');
+    }
+
     public function getCookieDomain()
     {
         return $this->container->getParameter('cookie.locale.domain');

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -212,7 +212,8 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
             $currentProcessStep->getRole(),
             $authnClassRef,
             $nameId,
-            $sp->getCoins()->isStepupForceAuthn()
+            $sp->getCoins()->isStepupForceAuthn(),
+            $receivedResponse->getAssertions()[0]
         );
     }
 

--- a/src/OpenConext/EngineBlock/Stepup/StepupGatewayCallOutHelper.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupGatewayCallOutHelper.php
@@ -32,21 +32,19 @@ final class StepupGatewayCallOutHelper
      */
     private $gatewayLoaMapping;
 
-    /**
-     * @var StepupEndpoint
-     */
-    private $stepupEndpoint;
-
     private $logger;
+
+    /**
+     * @var LoaRepository
+     */
+    private $loaRepository;
 
     public function __construct(
         StepupGatewayLoaMapping $gatewayLoaMapping,
-        StepupEndpoint $stepupEndpoint,
         LoaRepository $loaRepository,
         LoggerInterface $logger
     ) {
         $this->gatewayLoaMapping = $gatewayLoaMapping;
-        $this->stepupEndpoint = $stepupEndpoint;
         $this->loaRepository = $loaRepository;
         $this->logger = $logger;
     }

--- a/src/OpenConext/EngineBlock/Stepup/StepupGsspUserAttributeExtension.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupGsspUserAttributeExtension.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Stepup;
+
+use SAML2\Assertion;
+use SAML2\DOMDocumentFactory;
+use SAML2\Message;
+use SAML2\XML\Chunk;
+
+class StepupGsspUserAttributeExtension
+{
+    /**
+     * @param string[] $userAttributes
+     */
+    public static function add(Message $message, Assertion $assertion, array $userAttributes)
+    {
+        $assertionAttributes = $assertion->getAttributes();
+        $stepupUserAttributes = array_filter($assertionAttributes, function ($attributeKey) use ($userAttributes) {
+            return in_array($attributeKey, $userAttributes);
+        }, ARRAY_FILTER_USE_KEY);
+
+
+        if (count($stepupUserAttributes) === 0) {
+            return;
+        }
+
+        $dom = DOMDocumentFactory::create();
+        $ce = $dom->createElementNS('urn:mace:surf.nl:stepup:gssp-extensions', 'gssp:UserAttributes');
+        $ce->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $ce->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xs', 'http://www.w3.org/2001/XMLSchema');
+
+        foreach ($stepupUserAttributes as $attributeKey => $attributeValues) {
+            self::addAttribute($ce, $attributeKey, $assertion->getAttributeNameFormat(), $attributeValues);
+        }
+
+        $ext = $message->getExtensions();
+        $ext['saml:Extensions'] = new Chunk($ce);
+
+        $message->setExtensions($ext);
+    }
+
+    /**
+     * @param string[] $values
+     */
+    public static function addAttribute(\DOMElement $parent, string $name, string $format, array $values): void
+    {
+        $attrib = $parent->ownerDocument->createElementNS('urn:oasis:names:tc:SAML:2.0:assertion', 'saml:Attribute');
+        $attrib->setAttribute('NameFormat', $format);
+        $attrib->setAttribute('Name', $name);
+
+        foreach ($values as $value) {
+            $attribValue = $parent->ownerDocument->createElementNS('urn:oasis:names:tc:SAML:2.0:assertion', 'saml:AttributeValue', $value);
+            $attribValue->setAttribute('xsi:type', 'xs:string');
+            $attrib->appendChild($attribValue);
+        }
+
+        $parent->appendChild($attrib);
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -47,6 +47,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.enable_sso_session_cookie', true));
         $this->setFeature(new Feature('eb.stepup.sfo.override_engine_entityid', false));
         $this->setFeature(new Feature('eb.feature_enable_idp_initiated_flow', true));
+        $this->setFeature(new Feature('eb.stepup.send_user_attributes', true));
     }
 
     public function setFeature(Feature $feature): void

--- a/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockBundle/Resources/config/services.yml
@@ -68,7 +68,6 @@ services:
         class: OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper
         arguments:
             - "@engineblock.configuration.stepup.gateway_loa_mapping"
-            - "@engineblock.configuration.stepup.endpoint"
             - "@engineblock.configuration.stepup.loa_repository"
             - "@logger"
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -647,6 +647,7 @@ class EngineBlockContext extends AbstractSubContext
         $authnRequest->loadXML($authnRequestXml);
 
         $xpathObject = new DOMXPath($authnRequest);
+        $xpathObject->registerNamespace('gssp', 'urn:mace:surf.nl:stepup:gssp-extensions');
         $nodeList = $xpathObject->query($xpath);
 
         if (!$nodeList || $nodeList->length === 0) {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -260,3 +260,23 @@ Feature:
        And Stepup will successfully verify a user with a LoA 2 token
       Then I should see "Error - An error occurred"
        And the url should match "/feedback/unknown-error"
+
+  Scenario: Stepup authentication should pass user attributes when configured
+    Given feature "eb.stepup.send_user_attributes" is enabled
+      And the IdP "SSO-IdP" sends attribute "urn:mace:dir:attribute-def:mail" with value "j.doe@institution-a.example.org"
+      And SP "SSO-SP" requests LoA "http://dev.openconext.local/assurance/loa3"
+    When I log in at "SSO-SP"
+      And I select "SSO-IdP" on the WAYF
+      And I pass through EngineBlock
+      And I pass through the IdP
+    Then the received AuthnRequest should match xpath '/samlp:AuthnRequest/samlp:Extensions/gssp:UserAttributes/saml:Attribute[@Name="urn:mace:dir:attribute-def:mail"]/saml:AttributeValue[text()="j.doe@institution-a.example.org"]'
+
+  Scenario: Stepup authentication should not pass user attributes when feature is disabled
+    Given feature "eb.stepup.send_user_attributes" is disabled
+      And the IdP "SSO-IdP" sends attribute "urn:mace:dir:attribute-def:mail" with value "j.doe@institution-a.example.org"
+      And SP "SSO-SP" requests LoA "http://dev.openconext.local/assurance/loa3"
+    When I log in at "SSO-SP"
+      And I select "SSO-IdP" on the WAYF
+      And I pass through EngineBlock
+      And I pass through the IdP
+    Then the received AuthnRequest should not match xpath '/samlp:AuthnRequest/samlp:Extensions/gssp:UserAttributes/saml:Attribute[@Name="urn:mace:dir:attribute-def:mail"]/saml:AttributeValue[text()="j.doe@institution-a.example.org"]'


### PR DESCRIPTION
This will add a feature to send a configurable set of attributes to Stepup. It shall be used to be able to validate an AzureMFA GSSP without the need to register it first in Stepup.

https://github.com/OpenConext/OpenConext-engineblock/issues/1826