### PR TITLE
Replace abandoned twig/extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/swiftmailer-bundle": "^2.6",
         "symfony/symfony": "3.4.*",
-        "twig/extensions": "^1.5",
         "twig/twig": "^2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a90b70e06dff9ca0ddc5cdf9a1b27ba7",
+    "content-hash": "b606a6fef58941d1a2701e1858f2ac07",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -3854,62 +3854,6 @@
                 }
             ],
             "time": "2021-05-19T12:07:19+00:00"
-        },
-        {
-            "name": "twig/extensions",
-            "version": "v1.5.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/twigphp/Twig-extensions.git",
-                "reference": "57873c8b0c1be51caa47df2cdb824490beb16202"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/57873c8b0c1be51caa47df2cdb824490beb16202",
-                "reference": "57873c8b0c1be51caa47df2cdb824490beb16202",
-                "shasum": ""
-            },
-            "require": {
-                "twig/twig": "^1.27|^2.0"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "^3.4",
-                "symfony/translation": "^2.7|^3.4"
-            },
-            "suggest": {
-                "symfony/translation": "Allow the time_diff output to be translated"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Twig_Extensions_": "lib/"
-                },
-                "psr-4": {
-                    "Twig\\Extensions\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Common additional features for Twig that do not directly belong in core",
-            "keywords": [
-                "i18n",
-                "text"
-            ],
-            "abandoned": true,
-            "time": "2018-12-05T18:34:18+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Debug.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Debug.php
@@ -18,15 +18,15 @@
 
 namespace OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
 
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Twig_Extension;
 
 /**
  * The debug extension is used to provide var_dump, var_export and print_r functions for usage in Twig templates.
  */
-class Debug extends Twig_Extension
+class Debug extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('var_export', [$this, 'varExport']),
@@ -39,7 +39,7 @@ class Debug extends Twig_Extension
      * @param mixed $expression
      * @return string
      */
-    public function varExport($expression)
+    public function varExport($expression): string
     {
         return var_export($expression, true);
     }
@@ -49,7 +49,7 @@ class Debug extends Twig_Extension
      * @param mixed $expression
      * @return string
      */
-    public function printHumanReadable($expression)
+    public function printHumanReadable($expression): string
     {
         return print_r($expression, true);
     }

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
@@ -28,10 +28,10 @@ use OpenConext\EngineBlockBundle\Configuration\WikiLink;
 use OpenConext\EngineBlockBundle\Value\FeedbackInformation;
 use OpenConext\EngineBlockBundle\Value\FeedbackInformationMap;
 use SAML2\XML\saml\Issuer;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Twig_Extension;
 
-class Feedback extends Twig_Extension
+class Feedback extends AbstractExtension
 {
     /**
      * @var EngineBlock_ApplicationSingleton
@@ -65,7 +65,7 @@ class Feedback extends Twig_Extension
         $this->samlResponseHelper = $samlResponseHelper;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('feedbackInfo', [$this, 'getFeedbackInfo']),
@@ -82,7 +82,7 @@ class Feedback extends Twig_Extension
         ];
     }
 
-    public function flushLog($message)
+    public function flushLog($message): void
     {
         // For now use the EngineBlock_ApplicationSingleton to flush the log
         $this->application->flushLog($message);
@@ -91,16 +91,16 @@ class Feedback extends Twig_Extension
     /**
      * @return FeedbackInformationMap
      */
-    public function getFeedbackInfo()
+    public function getFeedbackInfo(): FeedbackInformationMap
     {
         return $this->retrieveFeedbackInfo();
     }
 
     /**
-     * @param string $templateName
+     * @param string|null $templateName
      * @return bool
      */
-    public function hasWikiLink($templateName)
+    public function hasWikiLink(?string $templateName = null): bool
     {
         return $this->errorFeedbackConfiguration->hasWikiLink($templateName);
     }
@@ -109,16 +109,16 @@ class Feedback extends Twig_Extension
      * @param string $templateName
      * @return string
      */
-    public function getWikiLink($templateName)
+    public function getWikiLink(string $templateName): string
     {
         return $this->errorFeedbackConfiguration->getWikiLink($templateName);
     }
 
     /**
-     * @param string $templateName
+     * @param string|null $templateName
      * @return bool
      */
-    public function hasIdPContactMailLink($templateName)
+    public function hasIdPContactMailLink(string $templateName = null): bool
     {
         return $this->errorFeedbackConfiguration->isIdPContactPage($templateName) && $this->getIdPContactMailLink();
     }
@@ -127,7 +127,7 @@ class Feedback extends Twig_Extension
      * @param string $templateName
      * @return string
      */
-    public function getIdpContactShortLabel($templateName)
+    public function getIdpContactShortLabel(string $templateName): string
     {
         return $this->errorFeedbackConfiguration->getIdpContactShortLabel($templateName);
     }
@@ -135,7 +135,7 @@ class Feedback extends Twig_Extension
     /**
      * @return string
      */
-    public function getIdPContactMailLink()
+    public function getIdPContactMailLink(): string
     {
         $feedbackInfo = $this->retrieveFeedbackInfo();
         if ($feedbackInfo->has('identityProvider')) {
@@ -203,7 +203,7 @@ class Feedback extends Twig_Extension
      *
      * @return FeedbackInformationMap
      */
-    private function retrieveFeedbackInfo()
+    private function retrieveFeedbackInfo(): FeedbackInformationMap
     {
         $session = $this->application->getSession();
         $feedbackInfo = $session->get('feedbackInfo');

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/FunctionalTestingGlobalSiteNotice.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/FunctionalTestingGlobalSiteNotice.php
@@ -19,15 +19,15 @@
 namespace OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
 
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Twig_Extension;
 
-class FunctionalTestingGlobalSiteNotice extends Twig_Extension implements GlobalSiteNoticeInterface
+class FunctionalTestingGlobalSiteNotice extends AbstractExtension implements GlobalSiteNoticeInterface
 {
     private $request;
 
     /**
-     * @var String
+     * @var string
      */
     private $allowedHtml;
 
@@ -39,7 +39,7 @@ class FunctionalTestingGlobalSiteNotice extends Twig_Extension implements Global
         $this->allowedHtml = $allowedHtml;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('shouldDisplayGlobalSiteNotice', [$this, 'shouldDisplayGlobalSiteNotice']),
@@ -48,7 +48,7 @@ class FunctionalTestingGlobalSiteNotice extends Twig_Extension implements Global
         ];
     }
 
-    public function shouldDisplayGlobalSiteNotice() : bool
+    public function shouldDisplayGlobalSiteNotice(): bool
     {
         return (bool) $this->request->get('showGlobalSiteNotice', false);
     }

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/GlobalSiteNotice.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/GlobalSiteNotice.php
@@ -19,10 +19,10 @@
 namespace OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
 
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Twig_Extension;
 
-class GlobalSiteNotice extends Twig_Extension
+class GlobalSiteNotice extends AbstractExtension
 {
     /**
      * @var bool
@@ -30,7 +30,7 @@ class GlobalSiteNotice extends Twig_Extension
     private $shouldDisplayGlobalSiteNotice;
 
     /**
-     * @var String
+     * @var string
      */
     private $allowedHtml;
 
@@ -49,7 +49,7 @@ class GlobalSiteNotice extends Twig_Extension
         $this->translator = $translator;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('shouldDisplayGlobalSiteNotice', [$this, 'shouldDisplayGlobalSiteNotice']),
@@ -58,7 +58,7 @@ class GlobalSiteNotice extends Twig_Extension
         ];
     }
 
-    public function shouldDisplayGlobalSiteNotice() : bool
+    public function shouldDisplayGlobalSiteNotice(): bool
     {
         return $this->shouldDisplayGlobalSiteNotice;
     }

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/I18n.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/I18n.php
@@ -18,11 +18,11 @@
 
 namespace OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
 
-use Twig_Extensions_Extension_I18n;
+use Twig\Extension\AbstractExtension;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig_SimpleFilter;
 
-class I18n extends Twig_Extensions_Extension_I18n
+class I18n extends AbstractExtension
 {
 
     /**
@@ -40,7 +40,7 @@ class I18n extends Twig_Extensions_Extension_I18n
      *
      * @return array An array of filters
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return array(
             new Twig_SimpleFilter('trans', array($this, 'translateSingular')),
@@ -51,7 +51,7 @@ class I18n extends Twig_Extensions_Extension_I18n
     /**
      * @return string
      */
-    public function translateSingular()
+    public function translateSingular(): string
     {
         $args = func_get_args();
         return call_user_func_array(
@@ -63,7 +63,7 @@ class I18n extends Twig_Extensions_Extension_I18n
     /**
      * @return string
      */
-    public function translatePlural()
+    public function translatePlural(): string
     {
         $args = func_get_args();
         return call_user_func_array(
@@ -76,7 +76,7 @@ class I18n extends Twig_Extensions_Extension_I18n
      * @param array $args
      * @return array
      */
-    private function prepareDefaultPlaceholders(array $args)
+    private function prepareDefaultPlaceholders(array $args): array
     {
         $args[1]['%suiteName%'] = $this->translator->trans('suite_name');
         $args[1]['%supportUrl%'] = $this->translator->trans('openconext_support_url');

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Locale.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Locale.php
@@ -21,14 +21,14 @@ namespace OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
 use OpenConext\EngineBlockBundle\Localization\LanguageSupportProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Twig_Extension;
 
 /**
  * The Locale extension can be used to retrieve the currently active locale. By default returns the locale that
  * can be found in the RequestStack. If none can be found in the request stack, the default locale is returned.
  */
-class Locale extends Twig_Extension
+class Locale extends AbstractExtension
 {
     /**
      * @var string
@@ -39,19 +39,23 @@ class Locale extends Twig_Extension
      * @var null|Request
      */
     private $request;
+
     /**
      * @var LanguageSupportProvider
      */
     private $languageSupportProvider;
 
-    public function __construct(RequestStack $requestStack, LanguageSupportProvider $languageSupportProvider, $defaultLocale)
-    {
+    public function __construct(
+        RequestStack $requestStack,
+        LanguageSupportProvider $languageSupportProvider,
+        string $defaultLocale
+    ) {
         $this->request = $requestStack->getCurrentRequest();
         $this->locale = $this->retrieveLocale($requestStack, $defaultLocale);
         $this->languageSupportProvider = $languageSupportProvider;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('locale', [$this, 'getLocale']),
@@ -62,7 +66,7 @@ class Locale extends Twig_Extension
         ];
     }
 
-    public function getPostData()
+    public function getPostData(): array
     {
         $postArray = [];
         if ($this->request->isMethod(Request::METHOD_POST)) {
@@ -73,10 +77,10 @@ class Locale extends Twig_Extension
 
     /**
      * Reads the query string parameters, adds the lang parameter and returns the merged query string.
-     * @param $locale
+     * @param string $locale
      * @return string
      */
-    public function getQueryStringFor($locale)
+    public function getQueryStringFor(string $locale): string
     {
         $params = ['lang' => $locale];
         // re-create URL from GET parameters
@@ -94,17 +98,17 @@ class Locale extends Twig_Extension
         return $query;
     }
 
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale;
     }
 
-    public function getSupportedLocales()
+    public function getSupportedLocales(): array
     {
         return $this->languageSupportProvider->getSupportedLanguages();
     }
 
-    private function retrieveLocale(RequestStack $requestStack, $defaultLocale)
+    private function retrieveLocale(RequestStack $requestStack, string $defaultLocale): string
     {
         $currentRequest = $requestStack->getCurrentRequest();
         $locale = $defaultLocale;

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Metadata.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Metadata.php
@@ -22,14 +22,14 @@ use EngineBlock_Attributes_Metadata;
 use OpenConext\Value\Saml\NameIdFormat;
 use SAML2\XML\saml\NameID;
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Twig_Extension;
 
 /**
  * Used to perform certain view related operations on metadata. For example this extension provides a function that
  * can sort metadata by display order.
  */
-class Metadata extends Twig_Extension
+class Metadata extends AbstractExtension
 {
     /**
      * @var string
@@ -47,7 +47,7 @@ class Metadata extends Twig_Extension
         $this->translator = $translator;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(
@@ -88,7 +88,7 @@ class Metadata extends Twig_Extension
      * @param NaneID|null $nameId
      * @return array
      */
-    public function sortByDisplayOrder($attributes, array $attributeSources = null, NameID $nameId = null)
+    public function sortByDisplayOrder($attributes, array $attributeSources = null, NameID $nameId = null): array
     {
         $sortedAttributes = $this->attributeMetadata->sortByDisplayOrder($attributes);
         $normalizedAttributes = $this->attributeMetadata->normalizeEptiAttributeValue($sortedAttributes);
@@ -106,7 +106,7 @@ class Metadata extends Twig_Extension
      * @param string $source Source identifier (e.g. "voot")
      * @return string URL
      */
-    public function getAttributeSourceLogoUrl($source)
+    public function getAttributeSourceLogoUrl(string $source): string
     {
         return $this->translator->trans('consent_attribute_source_logo_url_' . strtolower($source));
     }
@@ -117,7 +117,7 @@ class Metadata extends Twig_Extension
      * @param string $source Source identifier (e.g. "voot")
      * @return string
      */
-    public function getAttributeSourceDisplayName($source)
+    public function getAttributeSourceDisplayName(string $source): string
     {
         return $this->translator->trans('consent_attribute_source_' . strtolower($source));
     }
@@ -126,11 +126,11 @@ class Metadata extends Twig_Extension
      * Looks up the Attribute Id in the attribute metadata definition. If it is found, the name defined in the
      * definition list is used. Otherwise, falls back on the attribute id that was passed in the first place.
      *
-     * @param $attributeId
+     * @param string $attributeId
      * @param string $preferecLocale
-     * @return mixed
+     * @return string
      */
-    public function getAttributeShortName($attributeId, $preferecLocale = 'en')
+    public function getAttributeShortName(string $attributeId, string $preferecLocale = 'en'): string
     {
         $attributeShortName = $this->getAttributeName($attributeId, $preferecLocale);
         if (trim($attributeShortName) === '') {
@@ -141,20 +141,20 @@ class Metadata extends Twig_Extension
     }
 
     /**
-     * @param $attributeId
+     * @param string $attributeId
      * @param string $preferedLocale
      * @return string
      */
-    public function getAttributeName($attributeId, $preferedLocale = 'en')
+    public function getAttributeName(string $attributeId, string $preferedLocale = 'en'): string
     {
         return $this->attributeMetadata->getName($attributeId, $preferedLocale);
     }
 
-    private function groupAttributesBySource($attributes, array $attributeSources = array(), NameID $nameID = null)
+    private function groupAttributesBySource(array $attributes, array $attributeSources = array(), NameID $nameID = null): array
     {
-        $groupedAttributes = array(
-            'idp' => array(),
-        );
+        $groupedAttributes = [
+            'idp' => [],
+        ];
 
         if ($nameID && ($nameID->getFormat() == NameIdFormat::PERSISTENT_IDENTIFIER || $nameID->getFormat() == NameIdFormat::UNSPECIFIED)) {
             $groupedAttributes['engineblock']['name_id'] = $nameID->getValue();

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
@@ -22,10 +22,10 @@ use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlockBundle\Service\IdpHistoryService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Twig_Extension;
 
-class Wayf extends Twig_Extension
+class Wayf extends AbstractExtension
 {
     const PREVIOUS_SELECTION_COOKIE_NAME = 'selectedidps';
     const REMEMBER_CHOICE_COOKIE_NAME = 'rememberchoice';
@@ -48,7 +48,7 @@ class Wayf extends Twig_Extension
         $this->translator = $translator;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(
@@ -169,7 +169,7 @@ class Wayf extends Twig_Extension
         $showRequestAccess,
         $rememberChoiceFeature,
         $cutoffPointForShowingUnfilteredIdps
-    ) {
+    ): string {
 
         if ($showRequestAccess === true) {
             $unconnectedIdps = array_filter(
@@ -207,7 +207,7 @@ class Wayf extends Twig_Extension
         );
     }
 
-    private function loadPreviousSelectionFromCookie(RequestStack $requestStack)
+    private function loadPreviousSelectionFromCookie(RequestStack $requestStack): array
     {
         $request = $requestStack->getCurrentRequest();
         $previousSelection = null;


### PR DESCRIPTION
> Package twig/extensions is abandoned, you should avoid using it. No replacement was suggested.

> WARNING: [This repository](https://github.com/twigphp/Twig-extensions/blob/master/README.rst) is abandoned in favor of Twig Core Extra extensions.