### PR TITLE
Replace abandoned behat/symfony2-extension

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -36,6 +36,9 @@ class AppKernel extends Kernel
 
             // own bundles
             $bundles[] = new OpenConext\EngineBlockFunctionalTestingBundle\OpenConextEngineBlockFunctionalTestingBundle();
+
+            // Friendsof-behat
+            $bundles[] = new FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle();
         }
 
         return $bundles;

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "behat/mink-extension": "~2.0",
         "behat/mink-goutte-driver": "~1.0",
         "behat/mink-selenium2-driver": "^1.3",
-        "behat/symfony2-extension": "~2.0",
+        "friends-of-behat/symfony-extension": "~1.4.0",
         "ingenerator/behat-tableassert": "^1.1",
         "league/flysystem": "^2.5",
         "liip/functional-test-bundle": "^4.3",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "behat/mink-extension": "~2.0",
         "behat/mink-goutte-driver": "~1.0",
         "behat/mink-selenium2-driver": "^1.3",
-        "friends-of-behat/symfony-extension": "~1.4.0",
+        "friends-of-behat/symfony-extension": "~2.0.11",
         "ingenerator/behat-tableassert": "^1.1",
         "league/flysystem": "^2.5",
         "liip/functional-test-bundle": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d22a7f1435d058723c130519f7532ecb",
+    "content-hash": "3392d555486ca42594c31366f216dda8",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -4856,39 +4856,49 @@
         },
         {
             "name": "friends-of-behat/symfony-extension",
-            "version": "v1.4.0",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfBehat/SymfonyExtension.git",
-                "reference": "3ef0d0dcf32c48edc928e7a188a94c3afe1c1a31"
+                "reference": "18c04731efaef67db660175ada560c26b9092a0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfBehat/SymfonyExtension/zipball/3ef0d0dcf32c48edc928e7a188a94c3afe1c1a31",
-                "reference": "3ef0d0dcf32c48edc928e7a188a94c3afe1c1a31",
+                "url": "https://api.github.com/repos/FriendsOfBehat/SymfonyExtension/zipball/18c04731efaef67db660175ada560c26b9092a0a",
+                "reference": "18c04731efaef67db660175ada560c26b9092a0a",
                 "shasum": ""
             },
             "require": {
                 "behat/behat": "^3.4",
                 "php": "^7.1",
-                "symfony/dotenv": "^3.4|^4.1",
-                "symfony/http-kernel": "^3.4|^4.1"
+                "symfony/dependency-injection": "^3.4|^4.1",
+                "symfony/http-kernel": "^3.4|^4.1",
+                "symfony/proxy-manager-bridge": "^3.4|^4.1"
+            },
+            "conflict": {
+                "symfony/stopwatch": "^5.0"
             },
             "require-dev": {
                 "behat/mink": "^1.7",
                 "behat/mink-browserkit-driver": "^1.3",
                 "behat/mink-extension": "^2.2",
-                "friends-of-behat/cross-container-extension": "^1.0",
-                "friends-of-behat/test-context": "^1.0",
-                "phpstan/phpstan-shim": "^0.10",
+                "behat/mink-selenium2-driver": "^1.3",
+                "friends-of-behat/service-container-extension": "^1.0",
+                "phpstan/phpstan-shim": "^0.11",
                 "sylius-labs/coding-standard": "^3.0",
-                "symfony/framework-bundle": "^3.4|^4.1"
+                "symfony/framework-bundle": "^3.4|^4.1",
+                "symfony/process": "^3.4|^4.1",
+                "symfony/yaml": "^3.4|^4.1"
             },
             "suggest": {
-                "behat/mink-browserkit-driver": "^1.3",
-                "friends-of-behat/cross-container-extension": "^1.0"
+                "behat/mink-browserkit-driver": "^1.3"
             },
-            "type": "library",
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "FriendsOfBehat\\SymfonyExtension\\": "src/"
@@ -4902,15 +4912,15 @@
                 {
                     "name": "Kamil Kokot",
                     "email": "kamil@kokot.me",
-                    "homepage": "http://kamil.kokot.me"
+                    "homepage": "https://kamilkokot.com"
                 }
             ],
             "description": "Integrates Behat with Symfony.",
             "support": {
                 "issues": "https://github.com/FriendsOfBehat/SymfonyExtension/issues",
-                "source": "https://github.com/FriendsOfBehat/SymfonyExtension/tree/master"
+                "source": "https://github.com/FriendsOfBehat/SymfonyExtension/tree/v2.0.11"
             },
-            "time": "2018-12-19T14:42:27+00:00"
+            "time": "2020-04-04T12:33:55+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a90b70e06dff9ca0ddc5cdf9a1b27ba7",
+    "content-hash": "d22a7f1435d058723c130519f7532ecb",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -4587,68 +4587,6 @@
             "time": "2016-03-05T09:10:18+00:00"
         },
         {
-            "name": "behat/symfony2-extension",
-            "version": "2.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Behat/Symfony2Extension.git",
-                "reference": "d7c834487426a784665f9c1e61132274dbf2ea26"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Symfony2Extension/zipball/d7c834487426a784665f9c1e61132274dbf2ea26",
-                "reference": "d7c834487426a784665f9c1e61132274dbf2ea26",
-                "shasum": ""
-            },
-            "require": {
-                "behat/behat": "^3.4.3",
-                "php": ">=5.3.3",
-                "symfony/framework-bundle": "~2.0|~3.0|~4.0"
-            },
-            "require-dev": {
-                "behat/mink": "~1.7@dev",
-                "behat/mink-browserkit-driver": "~1.3@dev",
-                "behat/mink-extension": "~2.0",
-                "phpspec/phpspec": "~2.0|~3.0|~4.0",
-                "phpunit/phpunit": "~4.0|~5.0",
-                "symfony/symfony": "~2.1|~3.0|~4.0"
-            },
-            "type": "behat-extension",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Behat\\Symfony2Extension": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christophe Coevoet",
-                    "email": "stof@notk.org"
-                },
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com"
-                }
-            ],
-            "description": "Symfony2 framework extension for Behat",
-            "homepage": "http://behat.org",
-            "keywords": [
-                "BDD",
-                "framework",
-                "symfony"
-            ],
-            "abandoned": "friends-of-behat/symfony-extension",
-            "time": "2018-04-20T15:48:23+00:00"
-        },
-        {
             "name": "behat/transliterator",
             "version": "v1.2.0",
             "source": {
@@ -4915,6 +4853,64 @@
                 "scraper"
             ],
             "time": "2018-06-29T15:13:57+00:00"
+        },
+        {
+            "name": "friends-of-behat/symfony-extension",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfBehat/SymfonyExtension.git",
+                "reference": "3ef0d0dcf32c48edc928e7a188a94c3afe1c1a31"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfBehat/SymfonyExtension/zipball/3ef0d0dcf32c48edc928e7a188a94c3afe1c1a31",
+                "reference": "3ef0d0dcf32c48edc928e7a188a94c3afe1c1a31",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "^3.4",
+                "php": "^7.1",
+                "symfony/dotenv": "^3.4|^4.1",
+                "symfony/http-kernel": "^3.4|^4.1"
+            },
+            "require-dev": {
+                "behat/mink": "^1.7",
+                "behat/mink-browserkit-driver": "^1.3",
+                "behat/mink-extension": "^2.2",
+                "friends-of-behat/cross-container-extension": "^1.0",
+                "friends-of-behat/test-context": "^1.0",
+                "phpstan/phpstan-shim": "^0.10",
+                "sylius-labs/coding-standard": "^3.0",
+                "symfony/framework-bundle": "^3.4|^4.1"
+            },
+            "suggest": {
+                "behat/mink-browserkit-driver": "^1.3",
+                "friends-of-behat/cross-container-extension": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FriendsOfBehat\\SymfonyExtension\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kamil Kokot",
+                    "email": "kamil@kokot.me",
+                    "homepage": "http://kamil.kokot.me"
+                }
+            ],
+            "description": "Integrates Behat with Symfony.",
+            "support": {
+                "issues": "https://github.com/FriendsOfBehat/SymfonyExtension/issues",
+                "source": "https://github.com/FriendsOfBehat/SymfonyExtension/tree/master"
+            },
+            "time": "2018-12-19T14:42:27+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",

--- a/tests/behat-ci.yml
+++ b/tests/behat-ci.yml
@@ -85,7 +85,10 @@ default:
                                     - "--disable-gpu"
                                     - "--window-size=1920,1080"
                                     - "--no-sandbox"
-        Behat\Symfony2Extension:
+        FriendsOfBehat\SymfonyExtension:
             kernel:
+                bootstrap: 'vendor/autoload.php'
+                path: app/AppKernel.php
+                class: 'AppKernel'
                 env: ci
                 debug: true

--- a/tests/behat-ci.yml
+++ b/tests/behat-ci.yml
@@ -86,9 +86,9 @@ default:
                                     - "--window-size=1920,1080"
                                     - "--no-sandbox"
         FriendsOfBehat\SymfonyExtension:
+            bootstrap: 'vendor/autoload.php'
             kernel:
-                bootstrap: 'vendor/autoload.php'
                 path: app/AppKernel.php
                 class: 'AppKernel'
-                env: ci
+                environment: ci
                 debug: true

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -86,8 +86,10 @@ default:
                                     - "--window-size=1920,1080"
                                     - "--no-sandbox"
                                     - "--disable-dev-shm-usage"
-        Behat\Symfony2Extension:
+        FriendsOfBehat\SymfonyExtension:
             kernel:
+                bootstrap: 'vendor/autoload.php'
+                path: app/AppKernel.php
+                class: 'AppKernel'
                 env: ci
                 debug: true
-

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -87,9 +87,9 @@ default:
                                     - "--no-sandbox"
                                     - "--disable-dev-shm-usage"
         FriendsOfBehat\SymfonyExtension:
+            bootstrap: 'vendor/autoload.php'
             kernel:
-                bootstrap: 'vendor/autoload.php'
                 path: app/AppKernel.php
                 class: 'AppKernel'
-                env: ci
+                environment: ci
                 debug: true


### PR DESCRIPTION
> Package behat/symfony2-extension is abandoned, you should avoid using it. Use friends-of-behat/symfony-extension instead.

See: https://raw.githubusercontent.com/FriendsOfBehat/SymfonyExtension/refs/heads/master/UPGRADE-2.0.md