### PR TITLE
Remove trailing slash on void elements

### DIFF
--- a/theme/base/templates/modules/Authentication/View/Feedback/partial/saml_response_form.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Feedback/partial/saml_response_form.html.twig
@@ -1,4 +1,4 @@
 <p class="footer-button__text footer-button__text--small">{{ 'error_return-sp-link-text-short'|trans }}</p>
 <form method="post" action="{{ getAcu() }}" id="backToSPForm">
-    <input type="hidden" name="SAMLResponse" value="{{ getSamlFailedResponse() }}"/>
+    <input type="hidden" name="SAMLResponse" value="{{ getSamlFailedResponse() }}">
 </form>

--- a/theme/base/templates/modules/Authentication/View/IdentityProvider/request-access.html.twig
+++ b/theme/base/templates/modules/Authentication/View/IdentityProvider/request-access.html.twig
@@ -40,12 +40,12 @@
 
       <div class="input">
         <label for="email">{{ 'email'|trans }}:</label>
-        <input name="email" type="email" id="email" value="{{ queryParameters['email']|default('') }}" />
+        <input name="email" type="email" id="email" value="{{ queryParameters['email']|default('') }}">
       </div>
 
       <div class="input">
         <label for="institution">{{ 'institution'|trans|capitalize }}:</label>
-        <input name="institution" type="text" id="institution" value="{{ queryParameters['institution']|default('') }}" />
+        <input name="institution" type="text" id="institution" value="{{ queryParameters['institution']|default('') }}">
       </div>
 
       <div class="input">

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/defaultAttribute.html.twig
@@ -12,7 +12,7 @@
     {% if attributeValues|length == 1 %}
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: attributeValues|first } %}
         {% if addTooltip %}
-            <input type="checkbox" tabindex="-1" class="tooltip visually-hidden" aria-expanded="false" role="button" aria-pressed="false" id="{{ id }}" name="{{ id }}" />
+            <input type="checkbox" tabindex="-1" class="tooltip visually-hidden" aria-expanded="false" role="button" aria-pressed="false" id="{{ id }}" name="{{ id }}">
             {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with { tooltipValue: attributeMotivations[attributeIdentifier] } %}
         {% endif %}
     {# Multiple attribute values #}
@@ -30,7 +30,7 @@
                 <li {% if not addTooltip %}class="consent__attributeNested--noTooltip"{% endif %}>
                     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: value } %}
                     {% if addTooltip and loop.first %}
-                        <input type="checkbox" tabindex="-1" aria-expanded="false" role="button" aria-pressed="false" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}" />
+                        <input type="checkbox" tabindex="-1" aria-expanded="false" role="button" aria-pressed="false" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}">
                         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with { tooltipValue: attributeMotivations[attributeIdentifier], id: id } %}
                     {% endif %}
                 </li>
@@ -48,4 +48,3 @@
         </div>
     {% endif %}
 </li>
-

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/engineBlockAttribute.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/engineBlockAttribute.html.twig
@@ -10,7 +10,7 @@
     {% endif %}
     {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/value.html.twig' with { attributeValue: attributeValues } %}
     {% if addTooltip %}
-        <input type="checkbox" tabindex="-1" aria-expanded="false" role="button" aria-pressed="false" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}" />
+        <input type="checkbox" tabindex="-1" aria-expanded="false" role="button" aria-pressed="false" class="tooltip visually-hidden" id="{{ id }}" name="{{ id }}">
         {% include '@theme/Authentication/View/Proxy/Partials/Consent/Attributes/tooltip.html.twig' with {
             tooltipValue: 'consent_name_id_value_tooltip'|trans({'%arg1%': 'suite_name'|trans })
         } %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/toggleCheckbox.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/Attributes/toggleCheckbox.html.twig
@@ -1,1 +1,1 @@
-<input type="checkbox" id="{{ id }}" name="{{ id }}" aria-expanded="false" role="button" aria-pressed="false" class="visually-hidden{% if className is defined %} {{ className }}{% endif %}" tabindex="-1" />
+<input type="checkbox" id="{{ id }}" name="{{ id }}" aria-expanded="false" role="button" aria-pressed="false" class="visually-hidden{% if className is defined %} {{ className }}{% endif %}" tabindex="-1">

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/ctas.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/ctas.html.twig
@@ -3,7 +3,7 @@
           action="{{ action }}">
         <input type="hidden" name="ID"
                value="{{ responseId }}">
-        <input type="hidden" name="consent" value="yes"/>
+        <input type="hidden" name="consent" value="yes">
 
         {% if informationalConsent %}
             {% set text_ok = 'consent_buttons_ok_informational'|trans({'%sp%': spName}) %}
@@ -21,7 +21,7 @@
             }
         %}
     </form>
-    <input type="checkbox" tabindex="-1" role="button" aria-expanded="false" aria-pressed="false" class="modal visually-hidden" id="cta_consent_nok" name="cta_consent_nok" />
+    <input type="checkbox" tabindex="-1" role="button" aria-expanded="false" aria-pressed="false" class="modal visually-hidden" id="cta_consent_nok" name="cta_consent_nok">
     <div class="button--tertiary" tabindex="0">
         <div>
             {% include '@theme/Default/Partials/label.html.twig' with

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
@@ -1,5 +1,5 @@
 <img class="logo-small" src="{{ logoUrl }}"
-     alt="" />
+     alt="">
 {% if attributeSource == 'engineblock' %}
     {# note: the div is here only for IE11, as soon as IE11 support is scrapped, this can be removed along with the CSS/JS for it  #}
     <p>{{ text|raw }}</p>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Consent/idpRow.html.twig
@@ -10,7 +10,7 @@
     {% set id %}
         incorrect_{{ attributeSource }}
     {% endset %}
-    <input type="checkbox" tabindex="-1" aria-hidden="true" class="modal visually-hidden" id="{{ id|trim }}" name="{{ id|trim }}" />
+    <input type="checkbox" tabindex="-1" aria-hidden="true" class="modal visually-hidden" id="{{ id|trim }}" name="{{ id|trim }}">
     {# note: the empty label is for display on mobile #}
     <p>{{ text|raw }}<label tabindex="0" for="{{ id|trim }}" class="modal"></label>
     </p>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/Shared/spinner.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/Shared/spinner.html.twig
@@ -1,3 +1,3 @@
 <div class="logo">
-    <img class="rotate-img" src="/images/spinner.svg?v={{ assetsVersion }}" alt=""/>
+    <img class="rotate-img" src="/images/spinner.svg?v={{ assetsVersion }}" alt="">
 </div>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/contentHeader.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/contentHeader.html.twig
@@ -2,6 +2,6 @@
 {% if showForm %}
     <form method="post" action="{{ action }}">
         <label for="rememberChoice">{{ 'remember_choice'|trans }}</label>
-        <input type="checkbox" name="rememberChoice" id="rememberChoice"/>
+        <input type="checkbox" name="rememberChoice" id="rememberChoice">
     </form>
 {% endif %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpForm.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/idp/idpForm.html.twig
@@ -1,7 +1,7 @@
 <form class="idp__form" method="post" action="{{ action }}">
-    <input type="hidden" name="ID" value="{{ requestId }}"/>
-    <input type="hidden" name="idp" value="{{ idp['entityId'] }}"/>
-    <input type="hidden" name="discovery" value="{{ idp['discoveryHash'] }}"/>
+    <input type="hidden" name="ID" value="{{ requestId }}">
+    <input type="hidden" name="idp" value="{{ idp['entityId'] }}">
+    <input type="hidden" name="discovery" value="{{ idp['discoveryHash'] }}">
     {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpSubmitButton.html.twig' with { hidden: true } %}
     <noscript>
         {% include '@theme/Authentication/View/Proxy/Partials/WAYF/idp/idpSubmitButton.html.twig' %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/requestForm.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/noAccess/requestForm.html.twig
@@ -10,10 +10,10 @@
         data-announcement="{{ 'wayf_noaccess_form_announcement_screenreader'|trans }}"
         id="requestFormAnnouncement"
     ></div>
-    <input type="hidden" name="spName" value="{{ serviceProvider.displayName(locale()) }}" />
-    <input type="hidden" name="spEntityId" value="{{ serviceProvider.entityId }}" />
-    <input type="hidden" name="idpEntityId" value="" />
-    <input type="hidden" name="institution" value="" />
+    <input type="hidden" name="spName" value="{{ serviceProvider.displayName(locale()) }}">
+    <input type="hidden" name="spEntityId" value="{{ serviceProvider.entityId }}">
+    <input type="hidden" name="idpEntityId" value="">
+    <input type="hidden" name="institution" value="">
     <fieldset class="hidden">
         <legend class="hidden">Name</legend>
         <label for="name">
@@ -27,7 +27,7 @@
             id="name"
             minlength="2"
             type="text"
-        />
+        >
         <p class="form__error hidden" data-labelfor="name" id="nameerror">
             {{ 'form_error_name'|trans }}
         </p>
@@ -43,7 +43,7 @@
             id="email"
             name="email"
             type="email"
-        />
+        >
         <p class="form__error hidden" id="emailerror" data-labelfor="email">
             {{ 'form_error_email'|trans }}
         </p>

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/preselection.html.twig
@@ -3,7 +3,7 @@
     <h2 id="previousSelection__title" class="previousSelection__title">
         {{ 'wayf_your_accounts'|trans }}
     </h2>
-    <input type="checkbox" name="previousSelectionToggle" id="previousSelectionToggle" class="visually-hidden previousSelection__toggle" tabindex="-1" role="button" aria-pressed="false" />
+    <input type="checkbox" name="previousSelectionToggle" id="previousSelectionToggle" class="visually-hidden previousSelection__toggle" tabindex="-1" role="button" aria-pressed="false">
     {% spaceless %}
     <div class="ie11__label">
         <label for="previousSelectionToggle" tabindex="0" class="previousSelection__toggleLabel">

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/rememberChoice.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/rememberChoice.html.twig
@@ -1,6 +1,6 @@
 {% if rememberChoiceFeature %}
     <form method="post" action="{{ action }}" class="wayf__rememberChoice">
         <label for="rememberChoice">{{ 'remember_choice'|trans }}</label>
-        <input type="checkbox" name="rememberChoice" id="rememberChoice"/>
+        <input type="checkbox" name="rememberChoice" id="rememberChoice">
     </form>
 {% endif %}

--- a/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/search.html.twig
+++ b/theme/base/templates/modules/Authentication/View/Proxy/Partials/WAYF/search.html.twig
@@ -1,6 +1,6 @@
 <form class="wayf__search" method="post" action="{{ action }}" role="search" aria-label="{{ 'wayf_search_screenreader'|trans }}">
-    <input type="hidden" name="ID" value="{{ requestId }}"/>{# needed for the ContinueToIdp module #}
-    <input type="hidden" id="form-idp" name="idp" value=""/>{# needed for the ContinueToIdp module #}
+    <input type="hidden" name="ID" value="{{ requestId }}">{# needed for the ContinueToIdp module #}
+    <input type="hidden" id="form-idp" name="idp" value="">{# needed for the ContinueToIdp module #}
     <label for="wayf_search" class="visually-hidden">{{ 'search_screenreader'|trans }}</label>
     <input
         autofocus
@@ -9,7 +9,7 @@
         name="wayf_search"
         placeholder="{{ 'wayf_search_placeholder'|trans }}"
         type="search"
-    />
+    >
     <button type="reset" class="search__reset visually-hidden" tabindex="-1"><span class="visually-hidden">{{ 'wayf_search_reset_screenreader'|trans }}</span></button>
     <button type="submit" class="search__submit"><span class="visually-hidden">{{ 'search_screenreader'|trans }}</span></button>
     <div class="visually-hidden" aria-live="polite" id="searchResultAnnouncement" data-announcementOne=" {{ 'wayf_search_results_screenreader'|trans({'%orgNoun%': 'organisation_noun'|trans }) }}" data-announcementMultiple=" {{ 'wayf_search_results_screenreader'|trans({'%orgNoun%': 'organisation_noun_plural'|trans}) }}"></div>

--- a/theme/openconext/templates/modules/Authentication/View/IdentityProvider/request-access.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/IdentityProvider/request-access.html.twig
@@ -40,12 +40,12 @@
 
       <div class="input">
         <label for="email">{{ 'email'|trans }}:</label>
-        <input name="email" type="email" id="email" value="{{ queryParameters['email']|default('') }}" />
+        <input name="email" type="email" id="email" value="{{ queryParameters['email']|default('') }}">
       </div>
 
       <div class="input">
         <label for="institution">{{ 'institution'|trans|capitalize }}:</label>
-        <input name="institution" type="text" id="institution" value="{{ queryParameters['institution']|default('') }}" />
+        <input name="institution" type="text" id="institution" value="{{ queryParameters['institution']|default('') }}">
       </div>
 
       <div class="input">

--- a/theme/openconext/templates/modules/Authentication/View/Proxy/consent.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Proxy/consent.html.twig
@@ -52,17 +52,17 @@
                             <td colspan="2">
                                 {% if attributeSource == 'engineblock' %}
                                     <img class="logo-small" src="{{ defaultLogo }}?v={{ assetsVersion }}"
-                                         alt=""/>
+                                         alt="">
                                     <h2>{{ 'suite_name'|trans }}</h2>
                                 {% elseif attributeSource != 'idp' %}
                                     <img class="logo-small" src="{{ attributeSourceLogoUrl(attributeSource)|escape('html_attr') }}"
-                                         alt=""/>
+                                         alt="">
                                     <h2>{{ attributeSourceDisplayName(attributeSource) }}</h2>
                                 {% else %}
                                     {% if idp.mdui.hasLogo %}
-                                        <img class="logo-small" src="{{ idp.mdui.logo.url }}" alt=""/>
+                                        <img class="logo-small" src="{{ idp.mdui.logo.url }}" alt="">
                                     {% else %}
-                                        <img class="logo-small" src="/images/placeholder.png?v={{ assetsVersion }}" alt=""/>
+                                        <img class="logo-small" src="/images/placeholder.png?v={{ assetsVersion }}" alt="">
                                     {% endif %}
                                     <h2>{{ idpName }}</h2>
                                 {% endif %}
@@ -161,7 +161,7 @@
             <section class="idp-consent-explanation">
                 {% if idp.mdui.hasLogo %}
                     <div class="idp-logo">
-                        <img class="idp-logo logo-small" src="{{ idp.mdui.logo.url }}?v={{ assetsVersion }}" alt=""/>
+                        <img class="idp-logo logo-small" src="{{ idp.mdui.logo.url }}?v={{ assetsVersion }}" alt="">
                     </div>
                 {% endif %}
                 <p class="title">{{ 'consent_explanation_title'|trans }}</p>
@@ -179,7 +179,7 @@
                       action="{{ action }}">
                     <input type="hidden" name="ID"
                            value="{{ responseId }}">
-                    <input type="hidden" name="consent" value="yes"/>
+                    <input type="hidden" name="consent" value="yes">
                     <input id="accept_terms_button"
                            class="submit c-button"
                            type="submit"
@@ -188,7 +188,7 @@
                             {% else %}
                                 value="{{ 'consent_buttons_ok'|trans({'%arg1%': spName}) }}"
                             {% endif %}
-                    />
+                    >
                 </form>
 
                 <!-- NO -->

--- a/theme/openconext/templates/modules/Authentication/View/Proxy/debug-idp-response.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Proxy/debug-idp-response.html.twig
@@ -38,8 +38,8 @@
             </p>
 
             <form method="post">
-                <input type="hidden" name="clear" value="true"/>
-                <input type="submit" class="c-button" value="{{ 'retry'|trans }}"/>
+                <input type="hidden" name="clear" value="true">
+                <input type="submit" class="c-button" value="{{ 'retry'|trans }}">
             </form>
 
             <h2>Identity Provider</h2>
@@ -52,7 +52,7 @@
                         <td>
                             <img class="logo"
                                  src="{% if idp.mdui.hasLogo %}{{ idp.mdui.logo.url }}{% else %} {{ '/images/placeholder.png' }}{% endif %}"
-                                 alt="IdP logo"/>
+                                 alt="IdP logo">
                         </td>
                     </tr>
                     <tr>
@@ -172,8 +172,8 @@
             <p>{{ 'idp_debugging_mail_explain'|trans }}</p>
 
             <form method="post">
-                <input type="hidden" name="mail" value="true"/>
-                <input type="submit" class="c-button" value="{{ 'idp_debugging_mail_button'|trans }}"/>
+                <input type="hidden" name="mail" value="true">
+                <input type="submit" class="c-button" value="{{ 'idp_debugging_mail_button'|trans }}">
             </form>
         </div>
     </div>

--- a/theme/openconext/templates/modules/Authentication/View/Proxy/wayf.html.twig
+++ b/theme/openconext/templates/modules/Authentication/View/Proxy/wayf.html.twig
@@ -13,8 +13,8 @@
     {% include '@theme/Authentication/View/Proxy/site-notice.html.twig' with { className: 'full-width' } %}
 
     <form class="mod-search hidden" method="post" action="{{ action }}">
-        <input type="hidden" name="ID" value="{{ requestId }}"/>
-        <input type="hidden" id="form-idp" name="idp" value=""/>
+        <input type="hidden" name="ID" value="{{ requestId }}">
+        <input type="hidden" id="form-idp" name="idp" value="">
 
         <h2 class="search-institutions">{{ 'search'|trans }}</h2>
         <input placeholder="{{ 'search'|trans }}" type="search" tabindex="0" class="mod-search-input active">
@@ -47,7 +47,7 @@
                 <h2>{{ 'idps_with_access'|trans|capitalize }}</h2>
                 <form method="post" action="{{ action }}">
                     <label for="rememberChoice">{{ 'remember_choice'|trans }}</label>
-                    <input type="checkbox" name="rememberChoice" id="rememberChoice"/>
+                    <input type="checkbox" name="rememberChoice" id="rememberChoice">
                 </form>
             </header>
             {% else %}
@@ -59,7 +59,7 @@
 
                 <div class="loading spinner hidden">
                     <div class="logo">
-                        <img class="rotate-img" src="/images/spinner.svg?v={{ assetsVersion }}" alt=""/>
+                        <img class="rotate-img" src="/images/spinner.svg?v={{ assetsVersion }}" alt="">
                     </div>
                     {{ 'loading_idps'|trans }}
                 </div>
@@ -76,10 +76,10 @@
                                 </div>
                                 <h3>{{ idp['displayTitle'] }}</h3>
                                 <form class="mod-search login" method="post" action="{{ action }}">
-                                    <input type="hidden" name="ID" value="{{ requestId }}"/>
-                                    <input type="hidden" name="idp" value="{{ idp['entityId'] }}"/>
+                                    <input type="hidden" name="ID" value="{{ requestId }}">
+                                    <input type="hidden" name="idp" value="{{ idp['entityId'] }}">
                                     <input type="submit" data-entityid="{{ idp['entityId'] }}" class="c-button white"
-                                           value="Login"/>
+                                           value="Login">
                                 </form>
                             </a>
                         {% endfor %}


### PR DESCRIPTION
Fixes various cases reported in the W3c HTML validator

![afbeelding](https://github.com/user-attachments/assets/60beea5b-16ed-4afb-ad8b-513720aea846)
