### PR TITLE
Fix bug: remember Choice cookie has double quotes around the entityID

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -215,7 +215,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
         if (($application->getDiContainer()->getRememberChoice() === true) && !($request->getForceAuthn() || $request->isDebugRequest())) {
             $cookies = $application->getDiContainer()->getSymfonyRequest()->cookies->all();
             if (array_key_exists('rememberchoice', $cookies)) {
-                $remembered = $cookies['rememberchoice'];
+                $remembered = json_decode($cookies['rememberchoice']);
                 if (array_search($remembered, $candidateIDPs) !== false) {
                     $log->info("Auto-selecting IdP ('$remembered'): omitting WAYF, sending authentication request");
                     $this->_server->sendAuthenticationRequest($request, $remembered);


### PR DESCRIPTION
decode entityID from json.stringify

Fixes Bug: Remember Choice cookie has double quotes around the entityID #1326

closes #1326
