### PR TITLE
Only use discoveries on Wayf to prevent double entries

### DIFF
--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -516,22 +516,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
                 continue;
             }
 
-            $additionalInfo = AdditionalInfo::create()->setIdp($identityProvider->entityId);
-
             $isAccessible = $identityProvider->enabledInWayf || $isDebugRequest;
-
-            $name = $this->getName($currentLocale, $identityProvider, $additionalInfo);
-
-            $wayfIdp = $this->buildIdp(
-                $name,
-                $identityProvider->getMdui()->hasLogo() ? $identityProvider->getMdui()->getLogo()->url : '/images/placeholder.png',
-                $this->getKeywords($currentLocale, $identityProvider),
-                $identityProvider->entityId,
-                $isAccessible,
-                $isDefaultIdP,
-                null
-            );
-            $wayfIdps[] = $wayfIdp;
 
             foreach ($identityProvider->getDiscoveries() as $discovery) {
                 /** @var Discovery $discovery */
@@ -607,96 +592,6 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             ->setBody($output, 'text/plain');
 
         $diContainer->getMailer()->send($message);
-    }
-
-    private function getName(string $locale, IdentityProvider $identityProvider, AdditionalInfo $additionalInfo)
-    {
-        switch ($locale) {
-            case "nl":
-                return $this->getNameNl($identityProvider, $additionalInfo);
-            case "en":
-                return $this->getNameEn($identityProvider, $additionalInfo);
-            case "pt":
-                return $this->getNamePt($identityProvider, $additionalInfo);
-            default:
-                throw new EngineBlockBundleInvalidArgumentException(
-                    sprintf('Trying to get the IdP name for an unsupported language (%s)', $locale)
-                );
-        }
-    }
-
-    private function getNameNl(
-        IdentityProvider $identityProvider,
-        AdditionalInfo $additionalLogInfo
-    ) {
-        if ($identityProvider->getMdui()->hasDisplayName('nl')) {
-            return $identityProvider->getMdui()->getDisplayName('nl');
-        }
-
-        if ($identityProvider->nameNl) {
-            return $identityProvider->nameNl;
-        }
-
-        EngineBlock_ApplicationSingleton::getLog()->notice(
-            'No NL displayName and name found for idp: ' . $identityProvider->entityId,
-            array('additional_info' => $additionalLogInfo->toArray())
-        );
-
-        return $identityProvider->entityId;
-    }
-
-    private function getNameEn(
-        IdentityProvider $identityProvider,
-        AdditionalInfo $additionalInfo
-    ) {
-        if ($identityProvider->getMdui()->hasDisplayName('en')) {
-            return $identityProvider->getMdui()->getDisplayName('en');
-        }
-
-        if ($identityProvider->nameEn) {
-            return $identityProvider->nameEn;
-        }
-
-        EngineBlock_ApplicationSingleton::getLog()->notice(
-            'No EN displayName and name found for idp: ' . $identityProvider->entityId,
-            array('additional_info' => $additionalInfo->toArray())
-        );
-
-        return $identityProvider->entityId;
-    }
-
-    private function getNamePt(
-        IdentityProvider $identityProvider,
-        AdditionalInfo $additionalInfo
-    ) {
-        if ($identityProvider->getMdui()->hasDisplayName('pt')) {
-            return $identityProvider->getMdui()->getDisplayName('pt');
-        }
-
-        if ($identityProvider->namePt) {
-            return $identityProvider->namePt;
-        }
-
-        EngineBlock_ApplicationSingleton::getLog()->notice(
-            'No PT displayName and name found for idp: ' . $identityProvider->entityId,
-            array('additional_info' => $additionalInfo->toArray())
-        );
-
-        return $identityProvider->entityId;
-    }
-
-    private function getKeywords(string $locale, IdentityProvider $identityProvider)
-    {
-        if ($identityProvider->getMdui()->hasKeywords($locale)) {
-            return explode(' ', $identityProvider->getMdui()->getKeywords($locale));
-        }
-
-        // Fall back to EN if current language has no keywords
-        if ($identityProvider->getMdui()->hasKeywords('en')) {
-            return explode(' ', $identityProvider->getMdui()->getKeywords('en'));
-        }
-
-        return 'Undefined';
     }
 
     /**

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/Discoveries.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/Discoveries.feature
@@ -29,7 +29,7 @@ Feature:
         | Name                                      |  Value | Source |
         | urn:mace:dir:attribute-def:eduPersonOrcid | 123456 | voot   |
 
-  Scenario: The user is asked for consent to share information with the SP showing the discovery name instead of the IdP name
+  Scenario: The user is asked for consent to share information with the SP showing the discovery name
     Given I log in at "Dummy-SP"
     And I select IdP by label "Dummy Discovery" on the WAYF
     And I pass through EngineBlock
@@ -38,19 +38,6 @@ Feature:
     And the response should not contain "Yes, proceed to Dummy-SP"
     And the response should contain "Dummy-SP will receive"
     And the response should contain "provided by  <strong>Dummy Discovery</strong>"
-    And the response should contain "Proceed to Dummy-SP"
-    When I give my consent
-    Then I pass through EngineBlock
-
-  Scenario: Showing the IdP name when the main IdP is used instead of the discovery
-    Given I log in at "Dummy-SP"
-    And I select IdP by label "Dummy-IdP" on the WAYF
-    And I pass through EngineBlock
-    And I pass through the IdP
-    Then the response should not contain "Do you agree with sharing this data?"
-    And the response should not contain "Yes, proceed to Dummy-SP"
-    And the response should contain "Dummy-SP will receive"
-    And the response should contain "provided by  <strong>Dummy-IdP</strong>"
     And the response should contain "Proceed to Dummy-SP"
     When I give my consent
     Then I pass through EngineBlock

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -88,6 +88,8 @@ class MockIdpContext extends AbstractSubContext
         $discoveries = [];
         if ($discoveryName !== null) {
             $discoveries[] = Discovery::create(['en' => $discoveryName], [], null);
+        } else {
+            $discoveries[] = Discovery::create(['en' => $name], [], null);
         }
 
         $mockIdp = $this->mockIdpFactory->createNew($name);


### PR DESCRIPTION
https://github.com/OpenConext/OpenConext-engineblock/issues/1852

Be aware that the assumption is made that all entries will have an appropriate discovery entries. Because the name entries won't be used on the Wayf anymore. It seems a valid assumption because of the change in Manage which has a migration.

@pmeulen @baszoetekouw is that a safe assumption?