### PR TITLE
Make metadata expiration time configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Maintenance:
 * `symfony/monolog-bundle` upgraded to ^4.0; review your monolog configuration if you have customised it outside of the defaults.
 
 Changes:
+* The metadata expiration time (`validUntil` attribute) is now configurable via the `metadata_expiration_time` parameter in `parameters.yml`.
+  * Action required: Add `metadata_expiration_time` to `parameters.yaml`, suggested value: `86400`. This is the old behaviour in which metadata is cached for 24 hours.
 * The `consent.deleted_at` should be not nullable, and have a default value of `0000-00-00 00:00:00`.
   * Because `deleted_at` is part of the PK, no migration is provided. The database engine should not allow this to be null in the first place, so it is probably not nullable already on your db.
   * The `0000-00-00 00:00:00` is added for clarity/consistency, as this is probably the default behaviour of your database already.

--- a/config/packages/parameters.yml.dist
+++ b/config/packages/parameters.yml.dist
@@ -55,6 +55,8 @@ parameters:
     ## Add RequestedAttributes to the AttributeConsumingService of the SP Proxy metadata of Engineblock, default is all
     ## Options are 'all' (optional and required attributes), 'required' (only required attributes) or 'none'
     metadata_add_requested_attributes: all
+    ## The number of seconds a Metadata document is deemed valid (default 24h)
+    metadata_expiration_time: 86400
 
     ##########################################################################################
     ## PHP SETTINGS

--- a/config/packages/parameters.yml.dist
+++ b/config/packages/parameters.yml.dist
@@ -55,7 +55,7 @@ parameters:
     ## Add RequestedAttributes to the AttributeConsumingService of the SP Proxy metadata of Engineblock, default is all
     ## Options are 'all' (optional and required attributes), 'required' (only required attributes) or 'none'
     metadata_add_requested_attributes: all
-    ## The number of seconds a Metadata document is deemed valid (default 24h)
+    ## The number of seconds a Metadata document is deemed valid (default 24h). Must be a positive integer.
     metadata_expiration_time: 86400
 
     ##########################################################################################

--- a/config/services/services.yml
+++ b/config/services/services.yml
@@ -158,6 +158,7 @@ services:
             - '@OpenConext\EngineBlock\Xml\DocumentSigner'
             - '@OpenConext\EngineBlock\Service\TimeProvider\TimeProvider'
             - '%metadata_add_requested_attributes%'
+            - "%metadata_expiration_time%"
 
     OpenConext\EngineBlock\Xml\MetadataProvider:
         arguments:

--- a/docs/metadata_generation.md
+++ b/docs/metadata_generation.md
@@ -58,7 +58,7 @@ the built-in metadata much more flexible than it is now.
 * Every document starts with a terms of use comment. This value can be configured in the `openconext.termsOfUse` ini
   setting.
 * The Metadata documents are signed.
-* The Metadata documents are deemed valid for a period of 86400 seconds (1 day).
+* The Metadata documents are deemed valid for a configurable period (default: 86400 seconds / 1 day), controlled via the `metadata_expiration_time` parameter in `parameters.yml`.
 * The EngineBlock UIInfo elements are generated from the `parameters.yml` config and are translated to English and
 Dutch when possible. Mainly English UI Info will be published.
 * The logo can be specified using the following `parameters.yml` settings

--- a/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
+++ b/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
@@ -37,7 +37,7 @@ class MetadataRenderer
     /**
      * The number of seconds a Metadata document is deemed valid
      */
-    const METADATA_EXPIRATION_TIME = 86400;
+    private $metadataExpirationTime;
 
     /**
      * @var Environment
@@ -83,7 +83,8 @@ class MetadataRenderer
         KeyPairFactory $keyPairFactory,
         DocumentSigner $documentSigner,
         TimeProvider $timeProvider,
-        string $addRequestedAttributes
+        string $addRequestedAttributes,
+        int $metadataExpirationTime
     ) {
         $this->languageSupportProvider = $languageSupportProvider;
         $this->twig = $twig;
@@ -92,6 +93,7 @@ class MetadataRenderer
         $this->documentSigner = $documentSigner;
         $this->timeProvider = $timeProvider;
         $this->addRequestedAttributes = $addRequestedAttributes;
+        $this->metadataExpirationTime = $metadataExpirationTime;
     }
 
     public function fromServiceProviderEntity(ServiceProviderEntityInterface $sp, string $keyId) : string
@@ -190,6 +192,6 @@ class MetadataRenderer
 
     private function getValidUntil(): string
     {
-        return $this->timeProvider->timestamp(self::METADATA_EXPIRATION_TIME);
+        return $this->timeProvider->timestamp($this->metadataExpirationTime);
     }
 }

--- a/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
+++ b/src/OpenConext/EngineBlock/Xml/MetadataRenderer.php
@@ -19,6 +19,7 @@
 namespace OpenConext\EngineBlock\Xml;
 
 use EngineBlock_Saml2_IdGenerator;
+use InvalidArgumentException;
 use OpenConext\EngineBlock\Metadata\Factory\Collection\IdentityProviderEntityCollection;
 use OpenConext\EngineBlock\Metadata\Factory\Helper\IdentityProviderMetadataHelper;
 use OpenConext\EngineBlock\Metadata\Factory\Helper\ServiceProviderMetadataHelper;
@@ -30,6 +31,9 @@ use OpenConext\EngineBlock\Service\TimeProvider\TimeProvider;
 use OpenConext\EngineBlockBundle\Localization\LanguageSupportProvider;
 use Twig\Environment;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class MetadataRenderer
 {
     const ID_PREFIX = 'EB';
@@ -37,7 +41,7 @@ class MetadataRenderer
     /**
      * The number of seconds a Metadata document is deemed valid
      */
-    private $metadataExpirationTime;
+    private int $metadataExpirationTime;
 
     /**
      * @var Environment
@@ -86,6 +90,13 @@ class MetadataRenderer
         string $addRequestedAttributes,
         int $metadataExpirationTime
     ) {
+        if ($metadataExpirationTime <= 0) {
+            throw new InvalidArgumentException(sprintf(
+                'metadataExpirationTime must be a positive integer, %d given',
+                $metadataExpirationTime
+            ));
+        }
+
         $this->languageSupportProvider = $languageSupportProvider;
         $this->twig = $twig;
         $this->samlIdGenerator = $samlIdGenerator;

--- a/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
@@ -20,6 +20,7 @@ namespace OpenConext\EngineBlock\Xml;
 use DOMDocument;
 use EngineBlock_Saml2_IdGenerator;
 use Exception;
+use InvalidArgumentException;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Metadata\ContactPerson;
@@ -295,8 +296,48 @@ class MetadataRendererTest extends TestCase
         $this->assertStringNotContainsString($this->getRequestedAttributeXml('attribute3', false), $xml);
     }
 
-    private function buildMetadataRenderer(string $addRequestedAttributes)
+    #[Group('Metadata')]
+    #[Test]
+    public function a_negative_metadata_expiration_time_throws_an_invalid_argument_exception()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->buildMetadataRenderer('all', -1);
+    }
+
+    #[Group('Metadata')]
+    #[Test]
+    public function a_zero_metadata_expiration_time_throws_an_invalid_argument_exception()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->buildMetadataRenderer('all', 0);
+    }
+
+    #[Group('Metadata')]
+    #[Test]
+    public function the_configured_metadata_expiration_time_is_reflected_in_the_valid_until_attribute()
+    {
+        $fixedTime = mktime(0, 0, 0, 1, 1, 2026);
+        $expirationTime = 3600;
+
+        $timeProvider = m::mock(TimeProvider::class);
+        $timeProvider->shouldReceive('timestamp')
+            ->andReturnUsing(function ($deltaSeconds) use ($fixedTime) {
+                return gmdate(TimeProvider::TIMESTAMP_FORMAT, $fixedTime + $deltaSeconds);
+            });
+
+        $renderer = $this->buildMetadataRenderer('all', $expirationTime, $timeProvider);
+
+        $expectedValidUntil = gmdate(TimeProvider::TIMESTAMP_FORMAT, $fixedTime + $expirationTime);
+
+        $spXml = $renderer->fromServiceProviderEntity($this->buildSp(), 'default');
+        $this->assertStringContainsString('validUntil="' . $expectedValidUntil . '"', $spXml);
+    }
+
+    private function buildMetadataRenderer(
+        string $addRequestedAttributes,
+        int $metadataExpirationTime = 86400,
+        ?TimeProvider $timeProvider = null
+    ) {
         $basePath = realpath(__DIR__ . '/../../../../../');
 
         $privateKey = new X509PrivateKey($basePath . '/tests/resources/key/engineblock.pem');
@@ -339,9 +380,9 @@ class MetadataRendererTest extends TestCase
             $samlIdGenerator,
             $keyPairFactory,
             $documentSigner,
-            new TimeProvider(),
+            $timeProvider ?? new TimeProvider(),
             $addRequestedAttributes,
-            86400
+            $metadataExpirationTime
         );
     }
 

--- a/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Xml/MetadataRendererTest.php
@@ -340,7 +340,8 @@ class MetadataRendererTest extends TestCase
             $keyPairFactory,
             $documentSigner,
             new TimeProvider(),
-            $addRequestedAttributes
+            $addRequestedAttributes,
+            86400
         );
     }
 


### PR DESCRIPTION
The expiration time of the metadata defines the validUntil until attribute in the metadata of Engineblock. By default this a constant in the code set to 86.400 seconds (24 hours).

At the request of one of the connected Service Providers, we want to increase this value to 1,814,400 seconds (21 days). If something goes wrong with the automatic reading of our metadata, they will have more time to fix this error before users experience login problems.

To avoid having to set this up again with every release, we want to make this configurable, I left the default at 24 hours as before.