### PR TITLE
Allow IdP to trigger PDP callout

### DIFF
--- a/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
+++ b/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
@@ -41,7 +41,7 @@ class EngineBlock_Corto_Filter_Command_EnforcePolicy extends EngineBlock_Corto_F
             $serviceProvider = $this->_serviceProvider;
         }
 
-        if (!$serviceProvider->getCoins()->policyEnforcementDecisionRequired()) {
+        if (!$serviceProvider->getCoins()->policyEnforcementDecisionRequired() && $this->_identityProvider->getCoins()->policyEnforcementDecisionRequired() === false) {
             return;
         }
 

--- a/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
+++ b/library/EngineBlock/Corto/Filter/Command/EnforcePolicy.php
@@ -41,7 +41,8 @@ class EngineBlock_Corto_Filter_Command_EnforcePolicy extends EngineBlock_Corto_F
             $serviceProvider = $this->_serviceProvider;
         }
 
-        if (!$serviceProvider->getCoins()->policyEnforcementDecisionRequired() && $this->_identityProvider->getCoins()->policyEnforcementDecisionRequired() === false) {
+        if ($serviceProvider->getCoins()->policyEnforcementDecisionRequired() === false
+            && $this->_identityProvider->getCoins()->policyEnforcementDecisionRequired() === false) {
             return;
         }
 

--- a/src/OpenConext/EngineBlock/Metadata/Coins.php
+++ b/src/OpenConext/EngineBlock/Metadata/Coins.php
@@ -76,7 +76,8 @@ class Coins
         $additionalLogging,
         $signatureMethod,
         $mfaEntities,
-        $defaultRAC
+        $defaultRAC,
+        $policyEnforcementDecisionRequired
     ) {
         return new self([
             'guestQualifier' => $guestQualifier,
@@ -88,6 +89,7 @@ class Coins
             'stepupConnections' => $stepupConnections,
             'mfaEntities' => $mfaEntities,
             'defaultRAC' => $defaultRAC,
+            'policyEnforcementDecisionRequired' => $policyEnforcementDecisionRequired,
         ]);
     }
 

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -269,6 +269,11 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         $properties += $this->discoveryAssembler->assembleDiscoveries($connection);
         $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:defaultRAC'), 'defaultRAC');
 
+        $properties += $this->setPathFromObjectBool(
+            [$connection, 'metadata:coin:policy_enforcement_decision_required'],
+            'policyEnforcementDecisionRequired'
+        );
+
         return Utils::instantiate(
             IdentityProvider::class,
             $properties

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -99,7 +99,7 @@ class IdentityProvider extends AbstractRole
 
     /**
      * WARNING: Please don't use this entity directly but use the dedicated factory instead.
-     * @see \OpenConext\EngineBlock\Factory\Factory\IdentityProviderFactory
+     * @see \OpenConext\EngineBlock\Metadata\Factory\Factory\IdentityProviderFactory
      */
     public function __construct(
         $entityId,
@@ -144,7 +144,8 @@ class IdentityProvider extends AbstractRole
         StepupConnections $stepupConnections = null,
         MfaEntityCollection $mfaEntities = null,
         array $discoveries = [],
-        ?string $defaultRAC = null
+        ?string $defaultRAC = null,
+        bool $policyEnforcementDecisionRequired = false
     ) {
         if (is_null($mdui)) {
             $mdui = Mdui::emptyMdui();
@@ -192,7 +193,8 @@ class IdentityProvider extends AbstractRole
             $additionalLogging,
             $signatureMethod,
             $mfaEntities,
-            $defaultRAC
+            $defaultRAC,
+            $policyEnforcementDecisionRequired
         );
 
         $this->assertAllDiscoveries($discoveries);

--- a/src/OpenConext/EngineBlock/Stepup/StepupEntityFactory.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupEntityFactory.php
@@ -78,7 +78,11 @@ class StepupEntityFactory
             [],
             $singleSignOnServices,
             null,
-            null
+            null,
+            null,
+            [],
+            null,
+            false
         );
 
         return $entity;

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockIdpContext.php
@@ -105,6 +105,19 @@ class MockIdpContext extends AbstractSubContext
     }
 
     /**
+     * @Given /^IDP "([^"]*)" requires a policy enforcement decision$/
+     * @param string $idpName
+     */
+    public function idpRequiresAPolicyEnforcementDecision($idpName)
+    {
+        $idp = $this->mockIdpRegistry->get($idpName);
+
+        $this->serviceRegistryFixture
+            ->requiresPolicyEnforcementDecisionForIdp($idp->entityId())
+            ->save();
+    }
+
+    /**
      * @Given /^an Identity Provider named "([^"]*)" with logo "([^"]*)"$/
      */
     public function anIdentityProviderNamedWithLogo($name, $logo)

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MockSpContext.php
@@ -594,7 +594,7 @@ class MockSpContext extends AbstractSubContext
         $sp = $this->anUnregisteredServiceProviderNamed($spName);
 
         $this->serviceRegistryFixture
-            ->spRequiresPolicyEnforcementDecisionForSp($sp->entityId())
+            ->requiresPolicyEnforcementDecisionForSp($sp->entityId())
             ->save();
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
@@ -23,6 +23,17 @@ Feature:
     And I should see "Students of MyIdP do not have access to this resource"
     And the response should contain "idp-logo.jpg"
 
+  Scenario: Access is denied because of an IdP specific Deny policy triggered by IdP
+    Given IDP "Dummy IdP" requires a policy enforcement decision
+    And pdp gives an IdP specific deny response for "MyIdP"
+    When I log in at "Dummy SP"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I should see "Error - Access denied"
+    And I should see "Message from your organisation:"
+    And I should see "Students of MyIdP do not have access to this resource"
+    And the response should contain "idp-logo.jpg"
+
   Scenario: Access is denied because of a Deny policy
     Given SP "Dummy SP" requires a policy enforcement decision
       And pdp gives a deny response

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Fixtures/ServiceRegistryFixture.php
@@ -310,9 +310,22 @@ QUERY;
         return $this;
     }
 
-    public function spRequiresPolicyEnforcementDecisionForSp($entityId)
+    public function requiresPolicyEnforcementDecisionForSp($entityId)
     {
-        $this->setCoin($this->getServiceProvider($entityId), 'policyEnforcementDecisionRequired', true);
+        $sp = $this->getServiceProvider($entityId);
+        assert($sp instanceof ServiceProvider);
+
+        $this->setCoin($sp, 'policyEnforcementDecisionRequired', true);
+
+        return $this;
+    }
+
+    public function requiresPolicyEnforcementDecisionForIdp($entityId)
+    {
+        $idp = $this->getIdentityProvider($entityId);
+        assert($idp instanceof IdentityProvider);
+
+        $this->setCoin($idp, 'policyEnforcementDecisionRequired', true);
 
         return $this;
     }

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -390,6 +390,7 @@ class PushMetadataAssemblerTest extends TestCase
             // IDP
             ['guest_qualifier', 'saml20-idp', 'guestQualifier', 'string-guest-qualifier'],
             ['schachomeorganization', 'saml20-idp', 'schacHomeOrganization', 'string'],
+            ['policy_enforcement_decision_required', 'saml20-idp', 'policyEnforcementDecisionRequired', 'bool'],
             ['hidden', 'saml20-idp', 'hidden', 'bool'],
 
             // Abstract


### PR DESCRIPTION
Prior to this change, the policyEnforcementDecisionRequired coin would only function for serviceproviders. This change reads the policyEnforcementDecisionRequired coin for Identity providers as well.

See https://github.com/OpenConext/OpenConext-engineblock/issues/1857