### PR TITLE
Feat: Allow Dependency Injection from Symfony into Corto

### DIFF
--- a/config/services/services.yml
+++ b/config/services/services.yml
@@ -2,6 +2,12 @@ services:
     _defaults:
         public: true
 
+    OpenConext\EngineBlockBundle\Bridge\EngineBlockBootstrapper:
+        autowire: true
+        autoconfigure: true
+        tags:
+            - { name: kernel.event_subscriber }
+
     OpenConext\EngineBlock\Xml\:
         resource: '../../src/OpenConext/EngineBlock/Xml'
         exclude: '../../src/OpenConext/EngineBlock/Xml/ValueObjects'

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -28,8 +28,12 @@ use OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper;
 use OpenConext\EngineBlock\Validator\AllowedSchemeValidator;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\Mailer\MailerInterface;
-use Twig\Environment;
 
+/**
+ * This DiContainer relies on fetching services from the Symfony service container. This is no longer the way to go.
+ * Instead, going forward, inject new dependencies into \OpenConext\EngineBlockBundle\Bridge\DiContainerRuntime
+ * This way we no longer need to worry about Symfony purging services and Symfony can properly optimize it's service container.
+ */
 class EngineBlock_Application_DiContainer extends \Pimple\Container
 {
     const ATTRIBUTE_METADATA                    = 'attributeMetadata';
@@ -403,14 +407,6 @@ class EngineBlock_Application_DiContainer extends \Pimple\Container
     public function getEncryptionKeysConfiguration()
     {
         return $this->container->getParameter('encryption_keys');
-    }
-
-    /**
-     * @return Environment
-     */
-    public function getTwigEnvironment()
-    {
-        return $this->container->get('twig');
     }
 
     /**

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -17,12 +17,11 @@
  */
 
 use OpenConext\EngineBlock\Logger\Handler\FingersCrossed\ManualOrDecoratedActivationStrategy;
-use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
 use OpenConext\EngineBlock\Request\RequestId;
+use OpenConext\EngineBlockBundle\Bridge\DiContainerRuntime;
 use OpenConext\EngineBlockBundle\Exception\Art;
 use Psr\Log\LoggerInterface;
-use SAML2\XML\saml\Issuer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 define('ENGINEBLOCK_FOLDER_ROOT'       , realpath(__DIR__ . '/../../') . '/');
@@ -80,6 +79,8 @@ class EngineBlock_ApplicationSingleton
      */
     protected $_diContainer;
 
+    protected ?DiContainerRuntime $_diContainerRuntime = null;
+
     /**
      * @var ManualOrDecoratedActivationStrategy
      */
@@ -107,6 +108,20 @@ class EngineBlock_ApplicationSingleton
         }
 
         return self::$s_instance;
+    }
+
+    public function setDiContainerRuntime(DiContainerRuntime $diContainerRuntime): void
+    {
+        $this->_diContainerRuntime = $diContainerRuntime;
+    }
+
+    public function getDiContainerRuntime(): DiContainerRuntime
+    {
+        if ($this->_diContainerRuntime === null) {
+            throw new RuntimeException('The DiContainerRuntime is not ready yet!');
+        }
+
+        return $this->_diContainerRuntime;
     }
 
     /**

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -434,7 +434,7 @@ class EngineBlock_Corto_Adapter
 
     protected function _getCoreProxy()
     {
-        $twig = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getTwigEnvironment();
+        $twig = EngineBlock_ApplicationSingleton::getInstance()->getDiContainerRuntime()->twig;
         return new EngineBlock_Corto_ProxyServer($twig);
     }
 

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -116,7 +116,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         $diContainer                       = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer();
         $this->_featureConfiguration = $diContainer->getFeatureConfiguration();
         $this->_logger = EngineBlock_ApplicationSingleton::getLog();
-        $this->twig = $diContainer->getTwigEnvironment();
+        $this->twig = EngineBlock_ApplicationSingleton::getInstance()->getDiContainerRuntime()->twig;
         $this->acsLocationSchemeValidator = $diContainer->getAcsLocationSchemeValidator();
         $this->stepupIdentityProvider = $diContainer->getStepupIdentityProvider($this->_server);
     }

--- a/library/EngineBlock/Corto/Module/Services.php
+++ b/library/EngineBlock/Corto/Module/Services.php
@@ -75,6 +75,7 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
     private function factoryService($className, EngineBlock_Corto_ProxyServer $server)
     {
         $diContainer = EngineBlock_ApplicationSingleton::getInstance()->getDiContainer();
+        $diContainerRuntime = EngineBlock_ApplicationSingleton::getInstance()->getDiContainerRuntime();
 
         switch($className) {
             case EngineBlock_Corto_Module_Service_ProvideConsent::class :
@@ -84,7 +85,7 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
                     $diContainer->getConsentFactory(),
                     $diContainer->getConsentService(),
                     $diContainer->getAuthenticationStateHelper(),
-                    $diContainer->getTwigEnvironment(),
+                    $diContainerRuntime->twig,
                     $diContainer->getProcessingStateHelper(),
                     $diContainer->getDiscoverySelectionService()
                 );
@@ -122,7 +123,7 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
                 return new EngineBlock_Corto_Module_Service_SingleSignOn(
                     $server,
                     $diContainer->getXmlConverter(),
-                    $diContainer->getTwigEnvironment(),
+                    $diContainerRuntime->twig,
                     $diContainer->getServiceProviderFactory(),
                     $diContainer->getDiscoverySelectionService()
                 );
@@ -130,11 +131,11 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
                 return new EngineBlock_Corto_Module_Service_ContinueToIdp(
                     $server,
                     $diContainer->getXmlConverter(),
-                    $diContainer->getTwigEnvironment(),
+                    $diContainerRuntime->twig,
                     $diContainer->getServiceProviderFactory()
                 );
             default :
-                return new $className($server, $diContainer->getXmlConverter(), $diContainer->getTwigEnvironment());
+                return new $className($server, $diContainer->getXmlConverter(), $diContainerRuntime->twig);
         }
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Bridge/DiContainerRuntime.php
+++ b/src/OpenConext/EngineBlockBundle/Bridge/DiContainerRuntime.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Bridge;
+
+use Twig\Environment;
+
+/**
+ * In contrast to DiContainer, this provider is constructed 'runtime'.
+ * As in, the current DiContainer is needed very early in the bootstrapping process, so it's not possible to inject dependencies into it.
+ *
+ * This provider should be used for all new dependencies.
+ */
+final readonly class DiContainerRuntime
+{
+
+    public function __construct(public Environment $twig)
+    {
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Bridge/EngineBlockBootstrapper.php
+++ b/src/OpenConext/EngineBlockBundle/Bridge/EngineBlockBootstrapper.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Bridge;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Twig\Environment;
+
+class EngineBlockBootstrapper implements EventSubscriberInterface
+{
+    private readonly DiContainerRuntime $diContainerRuntime;
+
+    public function __construct(
+        Environment $twig,
+    ) {
+        $this->diContainerRuntime = new DiContainerRuntime($twig);
+    }
+
+    public function onKernelRequest(): void
+    {
+        $engineBlock = \EngineBlock_ApplicationSingleton::getInstance();
+        $engineBlock->setDiContainerRuntime($this->diContainerRuntime);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 100],
+        ];
+    }
+}

--- a/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
@@ -19,6 +19,7 @@
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlockBundle\Bridge\DiContainerRuntime;
 use PHPUnit\Framework\TestCase;
 use SAML2\Assertion;
 use SAML2\Assertion\Validation\ConstraintValidator\NotBefore;
@@ -48,6 +49,10 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends TestCase
                 new EngineBlock_X509_PrivateKey(__DIR__.'/test.pem.key')
             )
         );
+
+        $engineBlock = \EngineBlock_ApplicationSingleton::getInstance();
+        $engineBlock->setDiContainerRuntime(new DiContainerRuntime(Phake::mock(Twig\Environment::class)));
+
         $this->bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
     }
 


### PR DESCRIPTION
Prior to this change, it was not possible to inject dependencies into Corto in a modern way. Corto pulled all dependencies from the Symfony service container itself.
This caused issues, because it is no longer possible to pull twig from the service container in Symfony 6.4.

This change introduces a DiContainerRuntime, which can be used to inject dependencies into Corto. This was not possible using the DiContainer, because the DiContainer is constructed during bundle bootstrapping, where DI is not available. It is not possible to move it from there, as it is required by various constructions in the bootstapping process.
The DiContainerRuntime is injected into Corto after bootstrapping, but before the request is handled.

https://github.com/OpenConext/OpenConext-engineblock/pull/1874