### PR TITLE
Apply Symfony pathinfo vulnerability patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "behat/mink-goutte-driver": "~1.0",
         "behat/mink-selenium2-driver": "^1.3",
         "behat/symfony2-extension": "~2.0",
+        "cweagans/composer-patches": "^1.7",
         "ingenerator/behat-tableassert": "^1.1",
         "league/flysystem": "^2.5",
         "liip/functional-test-bundle": "^4.3",
@@ -110,7 +111,10 @@
         "platform": {
             "php": "7.2"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "cweagans/composer-patches": true
+        }
     },
     "extra": {
         "symfony-app-dir": "app",
@@ -124,7 +128,12 @@
             {
                 "file": "app/config/functional_testing.yml"
             }
-        ]
+        ],
+        "patches": {
+            "symfony/http-foundation": {
+                "CVE fix for PATH_INFO vulnerability": "patches/symfony-http-foundation-path-info-cve.patch"
+            }
+        }
     },
     "archive": {
         "exclude": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a2344673cd54385a01a30f9a8940f79",
+    "content-hash": "7dcd1508425a1b7a2d07485698a9c88c",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -4840,6 +4840,54 @@
             "time": "2022-02-24T20:20:32+00:00"
         },
         {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
+        },
+        {
             "name": "fabpot/goutte",
             "version": "v3.2.3",
             "source": {
@@ -7126,7 +7174,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -7142,5 +7190,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/patches/symfony-http-foundation-path-info-cve.patch
+++ b/patches/symfony-http-foundation-path-info-cve.patch
@@ -1,0 +1,15 @@
+--- a/vendor/symfony/http-foundation/Request.php
++++ b/vendor/symfony/http-foundation/Request.php
+@@ -1984,9 +1984,9 @@ class Request
+         }
+
+         $pathInfo = substr($requestUri, \strlen($baseUrl));
+-        if (false === $pathInfo || '' === $pathInfo) {
++        if (false === $pathInfo || '' === $pathInfo || '/' !== $pathInfo[0]) {
+             // If substr() returns false then PATH_INFO is set to an empty string
+-            return '/';
++            return '/'.$pathInfo;
+         }
+
+         return $pathInfo;
+


### PR DESCRIPTION
https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass

https://github.com/symfony/symfony/commit/9962b91b12bb791322fa73836b350836b6db7cac

https://nvd.nist.gov/vuln/detail/cve-2025-64500