### PR TITLE
add use IDP LOA (authnContextClassReff) in Stepup Decision

### DIFF
--- a/config/packages/engineblock_features.yaml
+++ b/config/packages/engineblock_features.yaml
@@ -15,3 +15,4 @@ parameters:
         eb.feature_enable_idp_initiated_flow: "%feature_enable_idp_initiated_flow%"
         eb.stepup.sfo.override_engine_entityid: "%feature_stepup_sfo_override_engine_entityid%"
         eb.stepup.send_user_attributes: "%feature_stepup_send_user_attributes%"
+        eb.stepup_use_idp_response_loa: "%feature_use_idp_loa_in_stepup_decision%"

--- a/config/packages/engineblock_features.yaml
+++ b/config/packages/engineblock_features.yaml
@@ -15,4 +15,4 @@ parameters:
         eb.feature_enable_idp_initiated_flow: "%feature_enable_idp_initiated_flow%"
         eb.stepup.sfo.override_engine_entityid: "%feature_stepup_sfo_override_engine_entityid%"
         eb.stepup.send_user_attributes: "%feature_stepup_send_user_attributes%"
-        eb.stepup_use_idp_response_loa: "%feature_use_idp_loa_in_stepup_decision%"
+        eb.stepup.use_idp_response_loa: "%feature_use_idp_loa_in_stepup_decision%"

--- a/config/packages/parameters.yml.dist
+++ b/config/packages/parameters.yml.dist
@@ -223,6 +223,7 @@ parameters:
     feature_enable_idp_initiated_flow: true
     feature_stepup_sfo_override_engine_entityid: false
     feature_stepup_send_user_attributes: false
+    feature_use_idp_loa_in_stepup_decision: false
 
     ##########################################################################################
     ## PROFILE SETTINGS

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -188,8 +188,15 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         $pdpLoas = $receivedResponse->getPdpRequestedLoas();
         $loaRepository = $application->getDiContainer()->getLoaRepository();
         $authnRequestLoas = $receivedRequest->getStepupObligations($loaRepository->getStepUpLoas());
+
+        $idpResponseLoa = null;
+        // Determine the IdP response LoA if feature is enabled
+        if($application->getDiContainer()->getFeatureConfiguration()->isEnabled('eb.stepup_use_idp_response_loa')) {
+            $idpResponseLoa = $originalAssertions->getAuthnContextClassRef();
+        } 
+
         // Goto consent if no Stepup authentication is needed
-        if (!$this->_stepupGatewayCallOutHelper->shouldUseStepup($idp, $sp, $authnRequestLoas, $pdpLoas)) {
+        if (!$this->_stepupGatewayCallOutHelper->shouldUseStepup($idp, $sp, $authnRequestLoas, $pdpLoas, $idpResponseLoa)) {
             $this->_server->sendConsentAuthenticationRequest($receivedResponse, $receivedRequest, $currentProcessStep->getRole(), $this->getAuthenticationState());
             return;
         }

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -191,7 +191,7 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
 
         $idpResponseLoa = null;
         // Determine the IdP response LoA if feature is enabled
-        if($application->getDiContainer()->getFeatureConfiguration()->isEnabled('eb.stepup_use_idp_response_loa')) {
+        if($application->getDiContainer()->getFeatureConfiguration()->isEnabled('eb.stepup.use_idp_response_loa')) {
             $idpResponseLoa = $originalAssertions->getAuthnContextClassRef();
         } 
 

--- a/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
@@ -298,7 +298,7 @@ class EngineBlock_Corto_Module_Service_StepupAssertionConsumer implements Engine
         $pdpLoas = $originalResponse->getPdpRequestedLoas();
         $authnRequestLoas = $receivedRequest->getStepupObligations($this->_loaRepository->getStepUpLoas());
 
-        $stepupDecision = new StepupDecision($idp, $sp, $authnRequestLoas, $pdpLoas, $this->_loaRepository, $log);
+        $stepupDecision = new StepupDecision($idp, $sp, $authnRequestLoas, $pdpLoas, null ,$this->_loaRepository, $log);
         $requiredLoa = $stepupDecision->getStepupLoa();
         $receivedLoa = $this->_stepupGatewayCallOutHelper->getEbLoa(
             $receivedResponse->getAssertion()->getAuthnContextClassRef()

--- a/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/StepupAssertionConsumer.php
@@ -298,7 +298,7 @@ class EngineBlock_Corto_Module_Service_StepupAssertionConsumer implements Engine
         $pdpLoas = $originalResponse->getPdpRequestedLoas();
         $authnRequestLoas = $receivedRequest->getStepupObligations($this->_loaRepository->getStepUpLoas());
 
-        $stepupDecision = new StepupDecision($idp, $sp, $authnRequestLoas, $pdpLoas, null ,$this->_loaRepository, $log);
+        $stepupDecision = new StepupDecision($idp, $sp, $authnRequestLoas, $pdpLoas, null, $this->_loaRepository, $log);
         $requiredLoa = $stepupDecision->getStepupLoa();
         $receivedLoa = $this->_stepupGatewayCallOutHelper->getEbLoa(
             $receivedResponse->getAssertion()->getAuthnContextClassRef()

--- a/src/OpenConext/EngineBlock/Stepup/StepupDecision.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupDecision.php
@@ -44,13 +44,12 @@ class StepupDecision
      */
     private $pdpLoas = [];
     /**
-     * @var bool
-     */
-    /**
      * @var string|null
      */
     private $idpResponseLoa = null;
-
+    /**
+     * @var bool
+     */
     private $spNoToken;
 
     private $logger;

--- a/src/OpenConext/EngineBlock/Stepup/StepupDecision.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupDecision.php
@@ -173,16 +173,10 @@ class StepupDecision
      */
     private function checkIDPLoaIsSufficient($isLoaAsked): bool
     {
-        if ($this->idpResponseLoa) {
-            return false;
-        }
-
-        // If the IdP did not provide a LoA in the response, it cannot satisfy the requirement
         if (!$this->idpResponseLoa) {
             return false;
         }
 
-        // Check whether the IdP response LoA level meets or exceeds the requested LoA
         return $this->idpResponseLoa->levelIsHigherOrEqualTo($isLoaAsked);
     }
 

--- a/src/OpenConext/EngineBlock/Stepup/StepupGatewayCallOutHelper.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupGatewayCallOutHelper.php
@@ -53,13 +53,15 @@ final class StepupGatewayCallOutHelper
         IdentityProvider $identityProvider,
         ServiceProvider $serviceProvider,
         array $authnRequestLoas,
-        array $pdpLoas
+        array $pdpLoas,
+        string|null $idpResponseLoa
     ) : bool {
         $stepupDecision = new StepupDecision(
             $identityProvider,
             $serviceProvider,
             $authnRequestLoas,
             $pdpLoas,
+            $idpResponseLoa,
             $this->loaRepository,
             $this->logger
         );
@@ -77,6 +79,7 @@ final class StepupGatewayCallOutHelper
             $serviceProvider,
             $authnRequestLoas,
             $pdpLoas,
+            null,
             $this->loaRepository,
             $this->logger
         );
@@ -100,7 +103,7 @@ final class StepupGatewayCallOutHelper
 
     public function allowNoToken(IdentityProvider $identityProvider, ServiceProvider $serviceProvider) : bool
     {
-        $stepupDecision = new StepupDecision($identityProvider, $serviceProvider, [], [], $this->loaRepository, $this->logger);
+        $stepupDecision = new StepupDecision($identityProvider, $serviceProvider, [], [], null, $this->loaRepository, $this->logger);
         return $stepupDecision->allowNoToken();
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -48,6 +48,8 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.stepup.sfo.override_engine_entityid', false));
         $this->setFeature(new Feature('eb.feature_enable_idp_initiated_flow', true));
         $this->setFeature(new Feature('eb.stepup.send_user_attributes', true));
+        $this->setFeature(new Feature('eb.stepup.use_idp_response_loa', false));
+    }
     }
 
     public function setFeature(Feature $feature): void

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -50,7 +50,6 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.stepup.send_user_attributes', true));
         $this->setFeature(new Feature('eb.stepup.use_idp_response_loa', false));
     }
-    }
 
     public function setFeature(Feature $feature): void
     {

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
@@ -21,6 +21,7 @@ namespace OpenConext\EngineBlock\Stepup;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Exception\InvalidStepupConfigurationException;
+use OpenConext\EngineBlock\Exception\LoaNotFoundException;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\Loa;
@@ -251,7 +252,7 @@ class StepupDecisionTest extends TestCase
         // SP expects loa30
         $repo->shouldReceive('getByIdentifier')->with('loa30')->andReturn(Loa::create(30, 'loa30'));
         // The idp response contains an unknown LoA
-        $repo->shouldReceive('getByIdentifier')->with('bad-loa')->andThrow(new \OpenConext\EngineBlock\Exception\LoaNotFoundException('not found'));
+        $repo->shouldReceive('getByIdentifier')->with('bad-loa')->andThrow(new LoaNotFoundException('not found'));
 
         $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
 

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupDecisionTest.php
@@ -69,7 +69,7 @@ class StepupDecisionTest extends TestCase
         $repo = $this->buildMockRepository($input);
         $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
 
-        $stepupDecision = new StepupDecision($idp, $sp, $input[2], $input[3], $repo, $logger);
+        $stepupDecision = new StepupDecision($idp, $sp, $input[2], $input[3], null, $repo, $logger);
 
         $useStepup = $stepupDecision->shouldUseStepup();
         $stepupLoa = $stepupDecision->getStepupLoa();
@@ -159,5 +159,104 @@ class StepupDecisionTest extends TestCase
         $level = (int) reset($matches[0]);
         $loa = Loa::create($level, $loaLevel);
         return $loa;
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    #[\PHPUnit\Framework\Attributes\Group('Stepup')]
+    public function idp_response_loa_is_sufficient_prevents_stepup()
+    {
+        $sp = Utils::instantiate(
+            ServiceProvider::class,
+            [
+                'entityId' => 'sp',
+                'stepupRequireLoa' => 'loa20',
+                'stepupAllowNoToken' => false,
+            ]
+        );
+
+        $idp = Utils::instantiate(
+            IdentityProvider::class,
+            [
+                'entityId' => 'idp',
+                'stepupConnections' => new StepupConnections([]),
+            ]
+        );
+
+        $repo = m::mock(LoaRepository::class);
+        $repo->shouldReceive('getByIdentifier')->with('loa20')->andReturn(Loa::create(20, 'loa20'));
+        $repo->shouldReceive('getByIdentifier')->with('loa30')->andReturn(Loa::create(30, 'loa30'));
+
+        $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
+
+        $stepupDecision = new StepupDecision($idp, $sp, [], [], 'loa30', $repo, $logger);
+
+        $this->assertFalse($stepupDecision->shouldUseStepup());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    #[\PHPUnit\Framework\Attributes\Group('Stepup')]
+    public function idp_response_loa_is_insufficient_triggers_stepup()
+    {
+        $sp = Utils::instantiate(
+            ServiceProvider::class,
+            [
+                'entityId' => 'sp',
+                'stepupRequireLoa' => 'loa30',
+                'stepupAllowNoToken' => false,
+            ]
+        );
+
+        $idp = Utils::instantiate(
+            IdentityProvider::class,
+            [
+                'entityId' => 'idp',
+                'stepupConnections' => new StepupConnections([]),
+            ]
+        );
+
+        $repo = m::mock(LoaRepository::class);
+        $repo->shouldReceive('getByIdentifier')->with('loa30')->andReturn(Loa::create(30, 'loa30'));
+        $repo->shouldReceive('getByIdentifier')->with('loa20')->andReturn(Loa::create(20, 'loa20'));
+
+        $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
+
+        $stepupDecision = new StepupDecision($idp, $sp, [], [], 'loa20', $repo, $logger);
+
+        $this->assertTrue($stepupDecision->shouldUseStepup());
+        $this->assertEquals('loa30', $stepupDecision->getStepupLoa()->getIdentifier());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    #[\PHPUnit\Framework\Attributes\Group('Stepup')]
+    public function unknown_idp_response_loa_is_ignored_and_triggers_stepup()
+    {
+        $sp = Utils::instantiate(
+            ServiceProvider::class,
+            [
+                'entityId' => 'sp',
+                'stepupRequireLoa' => 'loa30',
+                'stepupAllowNoToken' => false,
+            ]
+        );
+
+        $idp = Utils::instantiate(
+            IdentityProvider::class,
+            [
+                'entityId' => 'idp',
+                'stepupConnections' => new StepupConnections([]),
+            ]
+        );
+
+        $repo = m::mock(LoaRepository::class);
+        // SP expects loa30
+        $repo->shouldReceive('getByIdentifier')->with('loa30')->andReturn(Loa::create(30, 'loa30'));
+        // The idp response contains an unknown LoA
+        $repo->shouldReceive('getByIdentifier')->with('bad-loa')->andThrow(new \OpenConext\EngineBlock\Exception\LoaNotFoundException('not found'));
+
+        $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
+
+        $stepupDecision = new StepupDecision($idp, $sp, [], [], 'bad-loa', $repo, $logger);
+
+        $this->assertTrue($stepupDecision->shouldUseStepup());
     }
 }


### PR DESCRIPTION
adds a feature flag to enable engineblock to use the AuthnContextClassReff in the response from the IDP in the stepupDecision.
This allows for IDPs to use their own MFA in combination with stepup.
 