### PR TITLE
Functional testing: add test for 'feature' that allows manipulating the ACR of the SP

### DIFF
--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/AttributeManipulation.feature
@@ -120,6 +120,21 @@ Feature:
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="urn:mace:dir:attribute-def:eduPersonTargetedID"]/saml:AttributeValue/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="NOOT"]'
      And the response should match xpath '/samlp:Response/saml:Assertion/saml:Subject/saml:NameID[@Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" and text()="NOOT"]'
 
+  Scenario: The Service Provider can replace the ACR by setting it deep within the response array
+    Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:
+      """
+      $response['saml:Assertion']['saml:AuthnStatement']['saml:AuthnContext']['saml:AuthnContextClassRef']['__v'] = 'http://bakkerijaalders.nl/mfa-done';
+      """
+    When I log in at "SP-with-Attribute-Manipulations"
+     And I select "Dummy-IdP" on the WAYF
+     And I pass through EngineBlock
+     And I pass through the IdP
+    Then I should not see "bakkerijaalders.nl"
+    When I give my consent
+     And I pass through EngineBlock
+    Then the url should match "functional-testing/SP-with-Attribute-Manipulations/acs"
+     And the response should match xpath '/samlp:Response/saml:Assertion/saml:AuthnStatement/saml:AuthnContext/saml:AuthnContextClassRef[text()="http://bakkerijaalders.nl/mfa-done"]'
+
   # See: https://www.pivotaltracker.com/story/show/159760842
   Scenario: The Service Provider can replace the NameID by setting the CustomNameID with an object representation of the NameID
     Given SP "SP-with-Attribute-Manipulations" has the following Attribute Manipulation:


### PR DESCRIPTION
This is quite an esoteric AM but it's in production use, so we want to ensure that this remains working (or is only knowingly removed)