### PR TITLE
Reinstate monitor endpoints

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -15,3 +15,7 @@ engineblock_api_controllers:
         domain: ".*"
     defaults:
         domain: "%domain%"
+
+open_conext_monitor:
+    resource: "@OpenConextMonitorBundle/Resources/config/routing.yml"
+    prefix: /

--- a/src/OpenConext/EngineBlockBundle/EventListener/AuthenticationStateInitializer.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/AuthenticationStateInitializer.php
@@ -23,7 +23,7 @@ use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
 use OpenConext\EngineBlockBundle\Controller\AuthenticationLoopThrottlingController;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 
 final class AuthenticationStateInitializer
 {
@@ -37,9 +37,14 @@ final class AuthenticationStateInitializer
         $this->session = $requestStack->getSession();
     }
 
-    public function onKernelController(\Symfony\Component\HttpKernel\Event\ControllerEvent $event)
+    public function onKernelController(ControllerEvent $event): void
     {
-        if (!$event->getController()[0] instanceof AuthenticationLoopThrottlingController) {
+        $controller = $event->getController();
+        if (is_array($controller)) {
+            $controller = $controller[0];
+        }
+
+        if (!$controller instanceof AuthenticationLoopThrottlingController) {
             return;
         }
 

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/MonitorControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/MonitorControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class MonitorControllerTest extends WebTestCase
+{
+    #[Test]
+    #[Group('Monitor')]
+    public function internal_info_returns_json()
+    {
+        $client = self::createClient();
+        $client->request('GET', 'https://engine.dev.openconext.local/internal/info');
+
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJson($response->getContent());
+    }
+
+    #[Test]
+    #[Group('Monitor')]
+    public function internal_health_returns_json()
+    {
+        $client = self::createClient();
+        $client->request('GET', 'https://engine.dev.openconext.local/internal/health');
+
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJson($response->getContent());
+
+        $json = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(['status' => 'UP'], $json);
+    }
+}


### PR DESCRIPTION
Prior to this change, the `/internal/health` and `/internal/info` routes did not exist.

This change re-introduces these routes and ensures they work.

In order to make this happen, the  `AuthenticationStateInitializer` listener needed to be made compatible with invokable controllers, which the monitor bundle uses.

Fixes: https://github.com/OpenConext/OpenConext-engineblock/issues/1902