### PR TITLE
Fix monitor db connection check

### DIFF
--- a/config/services/services.yml
+++ b/config/services/services.yml
@@ -8,7 +8,8 @@ services:
         autowire: true
         autoconfigure: true
 
-    OpenConext\EngineBlockBundle\HealthCheck\DoctrineConnectionHealthCheck:
+    openconext.monitor.database_health_check:
+        class: OpenConext\EngineBlockBundle\HealthCheck\DoctrineConnectionHealthCheck
         arguments:
             - '%monitor_database_health_check_query%'
         calls:


### PR DESCRIPTION
Prior to this change, the DoctrineConnectionCheck from the monitor bundle was used instead of the check from EB. This became apparent as the doctrine/dbal upgrade broke the DoctrineConnectionHealthCheck from the Monitor bundle.

See https://github.com/OpenConext/OpenConext-engineblock/issues/1902