### PR TITLE
Validate attribute manipulation PHP syntax on metadata push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ More information about our release strategy can be found in
 the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes) on
 the EngineBlock wiki.
 
+## Unreleased
+
+Bugfixes:
+* Metadata push will now reject all metadata if any service contains invalid PHP syntax in its attribute manipulations (#1778)
+
 ## 7.0.0
 Breaking changes please see: [upgrading](UPGRADING.md#700)
 

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -647,7 +647,7 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
 
     private function validateManipulationCode(string $entityId, string $code): void
     {
-        if ($code === '') {
+        if (trim($code) === '') {
             return;
         }
 

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssembler.php
@@ -43,6 +43,7 @@ use OpenConext\EngineBlock\Metadata\X509\X509CertificateFactory;
 use OpenConext\EngineBlock\Metadata\X509\X509CertificateLazyProxy;
 use OpenConext\EngineBlock\Validator\ValidatorInterface;
 use OpenConext\EngineBlockBundle\Localization\LanguageSupportProvider;
+use ParseError;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use stdClass;
@@ -317,6 +318,11 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         $properties += $this->setPathFromObjectString(array($connection, 'metadata:coin:signature_method'), 'signatureMethod');
         $properties += $this->setPathFromObjectBool(array($connection, 'metadata:redirect:sign'), 'requestsMustBeSigned');
         $properties += $this->setPathFromObjectString(array($connection, 'manipulation_code'), 'manipulation');
+
+        if (is_string($properties['manipulation']) && $properties['manipulation'] !== '') {
+            $this->validateManipulationCode((string)$connection->name, $properties['manipulation']);
+        }
+
         $properties += $this->setPathFromObjectString(array($connection, 'metadata:url:en'), 'supportUrlEn');
         $properties += $this->setPathFromObjectString(array($connection, 'metadata:url:nl'), 'supportUrlNl');
         $properties += $this->setPathFromObjectString(array($connection, 'metadata:url:pt'), 'supportUrlPt');
@@ -637,5 +643,28 @@ class PushMetadataAssembler implements MetadataAssemblerInterface
         return [
             'mfaEntities' => MfaEntityCollection::fromMetadataPush($entities)
         ];
+    }
+
+    private function validateManipulationCode(string $entityId, string $code): void
+    {
+        if ($code === '') {
+            return;
+        }
+
+        // token_get_all() is primarily a tokeniser, but passing TOKEN_PARSE makes PHP run a
+        // full parse pass and throw a ParseError on any syntax error — without executing the
+        // code. Using eval() would also surface syntax errors, but it would also execute valid
+        // code in an empty context, causing unpredictable side-effects or secondary errors.
+        try {
+            token_get_all('<?php ' . $code, TOKEN_PARSE);
+        } catch (ParseError $e) {
+            throw new RuntimeException(
+                sprintf(
+                    'Attribute manipulation code for entity "%s" contains a syntax error: %s',
+                    $entityId,
+                    $e->getMessage()
+                )
+            );
+        }
     }
 }

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
@@ -350,6 +350,55 @@ class ConnectionsControllerTest extends WebTestCase
         }
     }
 
+    #[\PHPUnit\Framework\Attributes\Group('Api')]
+    #[\PHPUnit\Framework\Attributes\Group('Connections')]
+    #[\PHPUnit\Framework\Attributes\Group('MetadataPush')]
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function pushing_entity_with_invalid_manipulation_code_returns_bad_request()
+    {
+        $client = $this->createAuthorizedClient();
+
+        $payload = '{"connections":{"sp1":{
+            "allow_all_entities":true,
+            "allowed_connections":[],
+            "metadata":{"name":{"en":"Test SP"}},
+            "name":"https://sp.example.com",
+            "state":"prodaccepted",
+            "type":"saml20-sp",
+            "manipulation_code":"$attributes[\"foo\"] = [\"bar\""
+        }}}';
+
+        $client->request('POST', 'https://engine-api.dev.openconext.local/api/connections', [], [], [], $payload);
+
+        $this->assertStatusCode(Response::HTTP_BAD_REQUEST, $client);
+        $this->assertJson($client->getResponse()->getContent());
+        $message = json_decode($client->getResponse()->getContent());
+        $this->assertStringContainsString('https://sp.example.com', $message);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Group('Api')]
+    #[\PHPUnit\Framework\Attributes\Group('Connections')]
+    #[\PHPUnit\Framework\Attributes\Group('MetadataPush')]
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function pushing_entity_with_valid_manipulation_code_succeeds()
+    {
+        $client = $this->createAuthorizedClient();
+
+        $payload = '{"connections":{"sp1":{
+            "allow_all_entities":true,
+            "allowed_connections":[],
+            "metadata":{"name":{"en":"Test SP"}},
+            "name":"https://sp.example.com",
+            "state":"prodaccepted",
+            "type":"saml20-sp",
+            "manipulation_code":"$attributes[\"foo\"] = [\"bar\"];"
+        }}}';
+
+        $client->request('POST', 'https://engine-api.dev.openconext.local/api/connections', [], [], [], $payload);
+
+        $this->assertStatusCode(Response::HTTP_OK, $client);
+    }
+
     public static function invalidHttpMethodProvider()
     {
         return [


### PR DESCRIPTION
When entities are pushed to /api/connections, any manipulation_code is now syntax-checked using token_get_all() with TOKEN_PARSE before being stored. This catches PHP parse errors at push time instead of at login time.

If a syntax error is found, a RuntimeException is thrown with the entity ID, which the controller returns as a 400 Bad Request. The entire push is rejected if any entity has invalid manipulation code.

Resolves: #1778