### PR TITLE
Tame doctrine migrations / determine which we want to apply. 

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -26,6 +26,7 @@ doctrine:
 
             array: OpenConext\EngineBlockBundle\Doctrine\Type\SerializedArrayType
             object: OpenConext\EngineBlockBundle\Doctrine\Type\SerializedObjectType
+            legacy_json: OpenConext\EngineBlockBundle\Doctrine\Type\LegacyJsonType
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"

--- a/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/IdentityProvider.php
@@ -33,6 +33,7 @@ use OpenConext\EngineBlock\Metadata\Organization;
 use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\ShibMdScope;
 use OpenConext\EngineBlock\Metadata\StepupConnections;
+use OpenConext\EngineBlockBundle\Doctrine\Type\LegacyJsonType;
 use OpenConext\EngineBlockBundle\Doctrine\Type\SerializedArrayType;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Constants;
@@ -90,7 +91,7 @@ class IdentityProvider extends AbstractRole
      * with green/blue deployment strategies.
      *
      */
-    #[ORM\Column(name: 'consent_settings', type: Types::JSON, length: 16777215)]
+    #[ORM\Column(name: 'consent_settings', type: LegacyJsonType::NAME)]
     private $consentSettings;
 
     /**
@@ -102,7 +103,7 @@ class IdentityProvider extends AbstractRole
     /**
      * @var array<int, Discovery>
      */
-    #[ORM\Column(name: 'idp_discoveries', type: Types::JSON)]
+    #[ORM\Column(name: 'idp_discoveries', type: LegacyJsonType::NAME)]
     private $discoveries;
 
     /**

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/LegacyJsonType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/LegacyJsonType.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Exception\SerializationFailed;
+use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
+use Doctrine\DBAL\Types\Type;
+use JsonException;
+
+use function is_resource;
+use function json_decode;
+use function json_encode;
+use function stream_get_contents;
+
+use const JSON_PRESERVE_ZERO_FRACTION;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * This type stores JSON data in a longtext column, deliberately avoiding migration to a native MySQL JSON column type.
+ * The native JSON column type (declared via getJsonTypeDeclarationSQL) was introduced when upgrading to doctrine/dbal:^4,
+ * but migrating existing longtext columns to JSON columns is not desirable at this time.
+ *
+ * Use this type instead of Doctrine\DBAL\Types\Types::JSON for columns that should remain as longtext.
+ *
+ * Note: Doctrine column definition data passed to the SQL declaration are not taken into account to
+ * ensure a consistent schema.
+ */
+class LegacyJsonType extends Type
+{
+    public const NAME = 'legacy_json';
+
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getClobTypeDeclarationSQL(
+            ['length' => null]
+        );
+    }
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return json_encode($value, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
+        } catch (JsonException $e) {
+            throw SerializationFailed::new($value, 'json', $e->getMessage(), $e);
+        }
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_resource($value)) {
+            $value = stream_get_contents($value);
+        }
+
+        try {
+            return json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw ValueNotConvertible::new($value, self::NAME, $e->getMessage(), $e);
+        }
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/MetadataCoinType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/MetadataCoinType.php
@@ -30,10 +30,8 @@ class MetadataCoinType extends Type
 
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        // We want a `TEXT` field declaration in our column, the `LONGTEXT` default causes issues when running the
-        // DBMS in strict mode.
-        $column['length'] = 65535;
-        return $platform->getJsonTypeDeclarationSQL($column);
+        $column['length'] = null; // Ensure a longtext
+        return $platform->getClobTypeDeclarationSQL($column);
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform): mixed

--- a/src/OpenConext/EngineBlockBundle/Doctrine/Type/MetadataMduiType.php
+++ b/src/OpenConext/EngineBlockBundle/Doctrine/Type/MetadataMduiType.php
@@ -30,10 +30,8 @@ class MetadataMduiType extends Type
 
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        // We want a `TEXT` field declaration in our column, the `LONGTEXT` default causes issues when running the
-        // DBMS in strict mode.
-        $column['length'] = 65535;
-        return $platform->getJsonTypeDeclarationSQL($column);
+        $column['length'] = null; // Ensure a longtext
+        return $platform->getClobTypeDeclarationSQL($column);
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform): mixed

--- a/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/LegacyJsonTypeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Doctrine/Type/LegacyJsonTypeTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class LegacyJsonTypeTest extends TestCase
+{
+    private MySQLPlatform $platform;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!Type::hasType(LegacyJsonType::NAME)) {
+            Type::addType(LegacyJsonType::NAME, LegacyJsonType::class);
+        }
+    }
+
+    public function setUp(): void
+    {
+        $this->platform = new MySQLPlatform();
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function null_converts_to_null_in_database(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        $result = $type->convertToDatabaseValue(null, $this->platform);
+
+        $this->assertNull($result);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function a_value_round_trips_correctly(): void
+    {
+        $type  = Type::getType(LegacyJsonType::NAME);
+        $input = ['foo' => 'bar', 'baz' => [1, 2, 3]];
+
+        $dbValue  = $type->convertToDatabaseValue($input, $this->platform);
+        $phpValue = $type->convertToPHPValue($dbValue, $this->platform);
+
+        $this->assertSame($input, $phpValue);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function a_scalar_value_is_encoded_to_json(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        $result = $type->convertToDatabaseValue('hello', $this->platform);
+
+        $this->assertSame('"hello"', $result);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function a_float_with_zero_fraction_preserves_decimal_point(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        // JSON_PRESERVE_ZERO_FRACTION ensures 1.0 encodes as "1.0", not "1"
+        $result = $type->convertToDatabaseValue(1.0, $this->platform);
+
+        $this->assertSame('1.0', $result);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function an_unserializable_value_throws_a_conversion_exception(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        // A recursive reference cannot be JSON-encoded and triggers SerializationFailed
+        $recursive = [];
+        $recursive[] = &$recursive;
+
+        $this->expectException(ConversionException::class);
+        $type->convertToDatabaseValue($recursive, $this->platform);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function null_from_database_converts_to_null(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        $result = $type->convertToPHPValue(null, $this->platform);
+
+        $this->assertNull($result);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function empty_string_from_database_converts_to_null(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        $result = $type->convertToPHPValue('', $this->platform);
+
+        $this->assertNull($result);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function valid_json_from_database_converts_to_php_value(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        $result = $type->convertToPHPValue('{"key":"value","num":42}', $this->platform);
+
+        $this->assertSame(['key' => 'value', 'num' => 42], $result);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function invalid_json_from_database_throws_a_conversion_exception(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        $this->expectException(ConversionException::class);
+        $type->convertToPHPValue('this is not valid json }{', $this->platform);
+    }
+
+    #[Group('EngineBlockBundle')]
+    #[Group('Doctrine')]
+    #[Test]
+    public function sql_declaration_uses_clob_not_native_json(): void
+    {
+        $type = Type::getType(LegacyJsonType::NAME);
+
+        $declaration = $type->getSQLDeclaration([], $this->platform);
+
+        // Must produce longtext, not the native MySQL JSON column type
+        $this->assertSame('LONGTEXT', $declaration);
+        $this->assertStringNotContainsStringIgnoringCase('json', $declaration);
+    }
+}


### PR DESCRIPTION
Prior to this change, doctrine wants to change the longtext types of consent_settings and idp_discoveries to `json`. This has some implications, as at a db level, as it requires a migration. This migration is not strictly needed.

Ensure no database migrations are applied by configuring doctrine to use the old legacy mappings, until we have reason to upgrade in a coordinated operation.

Even with this change, doctrine wants to remove the comments. But we can safely apply this in the next release, without causing any big migrations.

After this change, doctrine wants to create a migration for this. 
```diff
--- <unnamed>
+++ <unnamed>
@@ -10,37 +10,37 @@
   `display_name_nl` varchar(255) NOT NULL,
   `display_name_en` varchar(255) NOT NULL,
   `display_name_pt` varchar(255) NOT NULL,
-  `logo` longtext NOT NULL COMMENT '(DC2Type:object)',
-  `organization_nl_name` text DEFAULT NULL COMMENT '(DC2Type:object)',
-  `organization_en_name` text DEFAULT NULL COMMENT '(DC2Type:object)',
-  `organization_pt_name` text DEFAULT NULL COMMENT '(DC2Type:object)',
+  `logo` longtext NOT NULL,
+  `organization_nl_name` text DEFAULT NULL,
+  `organization_en_name` text DEFAULT NULL,
+  `organization_pt_name` text DEFAULT NULL,
   `keywords_nl` varchar(255) NOT NULL,
   `keywords_en` varchar(255) NOT NULL,
   `keywords_pt` varchar(255) NOT NULL,
-  `certificates` text NOT NULL COMMENT '(DC2Type:array)',
+  `certificates` text NOT NULL,
   `workflow_state` varchar(255) NOT NULL,
-  `contact_persons` text NOT NULL COMMENT '(DC2Type:array)',
+  `contact_persons` text NOT NULL,
   `name_id_format` varchar(255) DEFAULT NULL,
-  `name_id_formats` text NOT NULL COMMENT '(DC2Type:array)',
-  `single_logout_service` text DEFAULT NULL COMMENT '(DC2Type:object)',
+  `name_id_formats` text NOT NULL,
+  `single_logout_service` text DEFAULT NULL,
   `requests_must_be_signed` tinyint(1) NOT NULL,
   `manipulation` text NOT NULL,
   `type` varchar(255) NOT NULL,
-  `attribute_release_policy` text DEFAULT NULL COMMENT '(DC2Type:array)',
-  `assertion_consumer_services` text DEFAULT NULL COMMENT '(DC2Type:array)',
-  `allowed_idp_entity_ids` mediumtext DEFAULT NULL COMMENT '(DC2Type:array)',
+  `attribute_release_policy` text DEFAULT NULL,
+  `assertion_consumer_services` text DEFAULT NULL,
+  `allowed_idp_entity_ids` mediumtext DEFAULT NULL,
   `allow_all` tinyint(1) DEFAULT NULL,
-  `requested_attributes` text DEFAULT NULL COMMENT '(DC2Type:array)',
+  `requested_attributes` text DEFAULT NULL,
   `enabled_in_wayf` tinyint(1) DEFAULT NULL,
-  `single_sign_on_services` text DEFAULT NULL COMMENT '(DC2Type:array)',
-  `shib_md_scopes` text DEFAULT NULL COMMENT '(DC2Type:array)',
+  `single_sign_on_services` text DEFAULT NULL,
+  `shib_md_scopes` text DEFAULT NULL,
   `support_url_en` varchar(255) DEFAULT NULL,
   `support_url_pt` varchar(255) DEFAULT NULL,
   `support_url_nl` varchar(255) DEFAULT NULL,
-  `consent_settings` longtext DEFAULT NULL COMMENT '(DC2Type:json)',
-  `coins` longtext NOT NULL COMMENT '(DC2Type:engineblock_metadata_coins)',
-  `mdui` longtext NOT NULL COMMENT '(DC2Type:engineblock_metadata_mdui)',
-  `idp_discoveries` longtext DEFAULT NULL COMMENT '(DC2Type:json)',
+  `consent_settings` longtext DEFAULT NULL,
+  `coins` longtext NOT NULL,
+  `mdui` longtext NOT NULL,
+  `idp_discoveries` longtext DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_sso_provider_roles_entity_id_type` (`type`,`entity_id`),
   KEY `idx_sso_provider_roles_type` (`type`),
```

Before this change, Doctrine wanted to migrate to this:
```diff
--- <unnamed>
+++ <unnamed>
@@ -10,37 +10,37 @@
   `display_name_nl` varchar(255) NOT NULL,
   `display_name_en` varchar(255) NOT NULL,
   `display_name_pt` varchar(255) NOT NULL,
-  `logo` longtext NOT NULL COMMENT '(DC2Type:object)',
-  `organization_nl_name` text DEFAULT NULL COMMENT '(DC2Type:object)',
-  `organization_en_name` text DEFAULT NULL COMMENT '(DC2Type:object)',
-  `organization_pt_name` text DEFAULT NULL COMMENT '(DC2Type:object)',
+  `logo` longtext NOT NULL,
+  `organization_nl_name` text DEFAULT NULL,
+  `organization_en_name` text DEFAULT NULL,
+  `organization_pt_name` text DEFAULT NULL,
   `keywords_nl` varchar(255) NOT NULL,
   `keywords_en` varchar(255) NOT NULL,
   `keywords_pt` varchar(255) NOT NULL,
-  `certificates` text NOT NULL COMMENT '(DC2Type:array)',
+  `certificates` text NOT NULL,
   `workflow_state` varchar(255) NOT NULL,
-  `contact_persons` text NOT NULL COMMENT '(DC2Type:array)',
+  `contact_persons` text NOT NULL,
   `name_id_format` varchar(255) DEFAULT NULL,
-  `name_id_formats` text NOT NULL COMMENT '(DC2Type:array)',
-  `single_logout_service` text DEFAULT NULL COMMENT '(DC2Type:object)',
+  `name_id_formats` text NOT NULL,
+  `single_logout_service` text DEFAULT NULL,
   `requests_must_be_signed` tinyint(1) NOT NULL,
   `manipulation` text NOT NULL,
   `type` varchar(255) NOT NULL,
-  `attribute_release_policy` text DEFAULT NULL COMMENT '(DC2Type:array)',
-  `assertion_consumer_services` text DEFAULT NULL COMMENT '(DC2Type:array)',
-  `allowed_idp_entity_ids` mediumtext DEFAULT NULL COMMENT '(DC2Type:array)',
+  `attribute_release_policy` text DEFAULT NULL,
+  `assertion_consumer_services` text DEFAULT NULL,
+  `allowed_idp_entity_ids` mediumtext DEFAULT NULL,
   `allow_all` tinyint(1) DEFAULT NULL,
-  `requested_attributes` text DEFAULT NULL COMMENT '(DC2Type:array)',
+  `requested_attributes` text DEFAULT NULL,
   `enabled_in_wayf` tinyint(1) DEFAULT NULL,
-  `single_sign_on_services` text DEFAULT NULL COMMENT '(DC2Type:array)',
-  `shib_md_scopes` text DEFAULT NULL COMMENT '(DC2Type:array)',
+  `single_sign_on_services` text DEFAULT NULL,
+  `shib_md_scopes` text DEFAULT NULL,
   `support_url_en` varchar(255) DEFAULT NULL,
   `support_url_pt` varchar(255) DEFAULT NULL,
   `support_url_nl` varchar(255) DEFAULT NULL,
-  `consent_settings` longtext DEFAULT NULL COMMENT '(DC2Type:json)',
-  `coins` longtext NOT NULL COMMENT '(DC2Type:engineblock_metadata_coins)',
-  `mdui` longtext NOT NULL COMMENT '(DC2Type:engineblock_metadata_mdui)',
-  `idp_discoveries` longtext DEFAULT NULL COMMENT '(DC2Type:json)',
+  `consent_settings` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`consent_settings`)),
+  `coins` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL CHECK (json_valid(`coins`)),
+  `mdui` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL CHECK (json_valid(`mdui`)),
+  `idp_discoveries` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`idp_discoveries`)),
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_sso_provider_roles_entity_id_type` (`type`,`entity_id`),
   KEY `idx_sso_provider_roles_type` (`type`),
```