### PR TITLE
Fix: show real SP name on error pages when SP is a trusted proxy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,6 +33,12 @@ services:
         depends_on:
             mariadb:
                 condition: service_healthy
+        # Ensure this container resolves engine.dev.openconext.local to itself.
+        # Without this, the OpenConext-devconf HAProxy on the same Docker network
+        # intercepts the hostname and routes Behat requests to the devconf engine
+        # instead of the engine under test.
+        extra_hosts:
+          - "engine.dev.openconext.local:127.0.0.1"
         environment:
           APP_ENV: ci
           APP_SECRET: secret

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,12 +33,6 @@ services:
         depends_on:
             mariadb:
                 condition: service_healthy
-        # Ensure this container resolves engine.dev.openconext.local to itself.
-        # Without this, the OpenConext-devconf HAProxy on the same Docker network
-        # intercepts the hostname and routes Behat requests to the devconf engine
-        # instead of the engine under test.
-        extra_hosts:
-          - "engine.dev.openconext.local:127.0.0.1"
         environment:
           APP_ENV: ci
           APP_SECRET: secret

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -249,9 +249,9 @@ class EngineBlock_ApplicationSingleton
 
         // @todo  reset this when login is succesful
         // Find the current identity provider
-        if (isset($_SESSION['currentServiceProvider'])) {
-            $feedbackInfo['serviceProvider'] = $_SESSION['currentServiceProvider'];
-            $spEntityId = $_SESSION['currentServiceProvider'];
+        $spEntityId = $_SESSION['originalServiceProvider'] ?? $_SESSION['currentServiceProvider'] ?? null;
+        if ($spEntityId !== null) {
+            $feedbackInfo['serviceProvider'] = $spEntityId;
             $feedbackInfo['serviceProviderName'] = $this->getServiceProviderName($spEntityId);
         }
 

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -120,6 +120,14 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
             $sp = $this->_server->getRepository()->fetchServiceProviderByEntityId($issuer);
         }
 
+        // Store real and proxy SP in session so error screens display the correct SP name
+        if ($sp->getCoins()->isTrustedProxy()) {
+            $proxySp = $sp;
+            $sp = $this->_server->findOriginalServiceProvider($receivedRequest, $log);
+            $_SESSION['currentServiceProvider'] = $sp->entityId;
+            $_SESSION['proxyServiceProvider'] = $proxySp->entityId;
+        }
+
         // Verify the SP requester chain.
         EngineBlock_SamlHelper::getSpRequesterChain(
             $sp,

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -120,11 +120,13 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
             $sp = $this->_server->getRepository()->fetchServiceProviderByEntityId($issuer);
         }
 
-        // Store real and proxy SP in session so error screens display the correct SP name
+        // When the SP is a trusted proxy (e.g. stepup-gateway), we look up the original SP on whose behalf the proxy
+        // is acting. We overwrite $sp so that downstream processing (attribute release, policy, consent) applies to
+        // the original SP, and we store both entity IDs in the session so error pages display the correct SP name.
         if ($sp->getCoins()->isTrustedProxy()) {
             $proxySp = $sp;
             $sp = $this->_server->findOriginalServiceProvider($receivedRequest, $log);
-            $_SESSION['currentServiceProvider'] = $sp->entityId;
+            $_SESSION['originalServiceProvider'] = $sp->entityId;
             $_SESSION['proxyServiceProvider'] = $proxySp->entityId;
         }
 

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -176,10 +176,10 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
 
         // 0 IdPs found! Throw an exception.
         if (count($candidateIDPs) === 0) {
-            // When a trusted proxy is used, the currentServiceProvider is set to the entityId of the original issuing
+            // When a trusted proxy is used, the originalServiceProvider is set to the entityId of the original issuing
             // SP. This prevents the display of the Proxy in the feedback information.
             if (isset($proxySp) && $proxySp->getCoins()->isTrustedProxy()) {
-                $_SESSION['currentServiceProvider'] = $sp->entityId;
+                $_SESSION['originalServiceProvider'] = $sp->entityId;
                 $_SESSION['proxyServiceProvider'] = $proxySp->entityId;
             }
             throw new EngineBlock_Corto_Module_Service_SingleSignOn_NoIdpsException('No candidate IdPs found');

--- a/library/EngineBlock/SamlHelper.php
+++ b/library/EngineBlock/SamlHelper.php
@@ -19,6 +19,7 @@
 use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use Psr\Log\LoggerInterface;
 
 class EngineBlock_SamlHelper
 {
@@ -90,7 +91,7 @@ class EngineBlock_SamlHelper
         ServiceProvider $serviceProvider,
         EngineBlock_Saml2_AuthnRequestAnnotationDecorator $request,
         MetadataRepositoryInterface $repository,
-        \Psr\Log\LoggerInterface $logger = null
+        LoggerInterface $logger = null
     ) {
         if (!$serviceProvider->getCoins()->isTrustedProxy()) {
             return null;
@@ -119,7 +120,7 @@ class EngineBlock_SamlHelper
         // The filters will log any additional information that is available.
         $lastRequesterEntity = $repository->findServiceProviderByEntityId($lastRequesterEntityId, $logger);
         if (!$lastRequesterEntity) {
-            $_SESSION['currentServiceProvider'] = $lastRequesterEntityId;
+            $_SESSION['originalServiceProvider'] = $lastRequesterEntityId;
             $_SESSION['proxyServiceProvider'] = $serviceProvider->entityId;
             throw new EngineBlock_Exception_UnknownServiceProvider(
                 'Invalid RequesterID specified',

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/FeedbackController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/FeedbackController.php
@@ -114,7 +114,7 @@ class FeedbackController extends AbstractController
         $feedbackInfo = $request->get('feedback-info', $default);
 
         $feedbackInfo = json_decode($feedbackInfo, true);
-        if ($feedbackInfo['IdentityProvider'] || $feedbackInfo['IdP']) {
+        if (!empty($feedbackInfo['IdentityProvider']) || !empty($feedbackInfo['IdP'])) {
             $feedbackInfo['identityProviderName'] = 'OpenConext Identities Inc';
         }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -197,7 +197,6 @@ class EngineBlockContext extends AbstractSubContext
     public function iPassThroughEngineblock()
     {
         $mink = $this->getMinkContext();
-
         $mink->pressButton('Submit');
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
@@ -80,6 +80,19 @@ Feature:
     And I should see "Error - Access denied"
     And I should see "Message from your organisation:"
 
+  Scenario: Error page shows the end-SP name, not the trusted proxy name
+    Given SP "Stepup SelfService" requires a policy enforcement decision
+    And SP "Stepup Gateway" is authenticating for SP "Stepup SelfService"
+    And SP "Stepup Gateway" is a trusted proxy
+    And SP "Stepup Gateway" signs its requests
+    And pdp gives a deny response
+    When I log in at "Stepup Gateway"
+    And I pass through EngineBlock
+    And I pass through the IdP
+    Then I should see "Error - Access denied"
+    And I should see "Stepup SelfService"
+    And I should not see "Stepup Gateway"
+
   Scenario: Access is denied because of an Indeterminate policy, End-SP behind Trusted Proxy
     Given SP "Stepup SelfService" requires a policy enforcement decision
     And SP "Stepup Gateway" is authenticating for SP "Stepup SelfService"

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/AssertionConsumerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/AssertionConsumerTest.php
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use OpenConext\EngineBlock\Metadata\Coins;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactory;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
+use OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper;
+use PHPUnit\Framework\TestCase;
+use SAML2\Assertion;
+use SAML2\Constants;
+use SAML2\XML\saml\Issuer;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Twig\Environment;
+
+class EngineBlock_Test_Corto_Module_Service_AssertionConsumerTest extends TestCase
+{
+    private const PROXY_SP_ENTITY_ID = 'https://proxy.example.com';
+    private const REAL_SP_ENTITY_ID  = 'https://realsp.example.com';
+    private const IDP_ENTITY_ID      = 'https://idp.example.com';
+    private const ENGINE_URL         = 'https://engine.example.com/some-service';
+
+    /** @var EngineBlock_Corto_ProxyServer */
+    private $proxyServerMock;
+
+    /** @var EngineBlock_Corto_Module_Bindings */
+    private $bindingsModuleMock;
+
+    /** @var EngineBlock_Saml2_ResponseAnnotationDecorator */
+    private $responseMock;
+
+    /** @var EngineBlock_Saml2_AuthnRequestAnnotationDecorator */
+    private $requestMock;
+
+    public function setUp(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'engine.example.com';
+
+        $this->bindingsModuleMock = Phake::mock('EngineBlock_Corto_Module_Bindings');
+        $this->proxyServerMock    = $this->mockProxyServer();
+        $this->responseMock       = $this->mockResponse();
+        $this->requestMock        = $this->mockRequest();
+
+        Phake::when($this->bindingsModuleMock)
+            ->receiveResponse(Phake::anyParameters())
+            ->thenReturn($this->responseMock);
+
+        Phake::when($this->proxyServerMock)
+            ->getReceivedRequestFromResponse(Phake::anyParameters())
+            ->thenReturn($this->requestMock);
+
+        Phake::when($this->proxyServerMock)
+            ->checkResponseSignatureMethods(Phake::anyParameters())
+            ->thenReturn(null);
+
+        Phake::when($this->proxyServerMock)
+            ->filterInputAssertionAttributes(Phake::anyParameters())
+            ->thenReturn(null);
+
+        // Stop the serve() flow before it reaches the processing pipeline
+        Phake::when($this->proxyServerMock)
+            ->addConsentProcessStep(Phake::anyParameters())
+            ->thenThrow(new RuntimeException('test-stop'));
+    }
+
+    public function testTrustedProxySetsCurrentAndProxySessionVariables(): void
+    {
+        [$proxySp, $proxyCoins] = $this->buildMockedServiceProvider(self::PROXY_SP_ENTITY_ID, isTrustedProxy: true);
+        [$realSp,  $realCoins]  = $this->buildMockedServiceProvider(self::REAL_SP_ENTITY_ID,  isTrustedProxy: false);
+        $idp = $this->buildMockedIdentityProvider(self::IDP_ENTITY_ID);
+
+        $repo = $this->buildMockedRepository($proxySp, $realSp, $idp);
+        $this->proxyServerMock->setRepository($repo);
+
+        $this->configureRequestIssuer(self::PROXY_SP_ENTITY_ID);
+
+        Phake::when($this->proxyServerMock)
+            ->findOriginalServiceProvider(Phake::anyParameters())
+            ->thenReturn($realSp);
+
+        $_SESSION = [];
+
+        $this->runServe();
+
+        $this->assertSame(
+            self::REAL_SP_ENTITY_ID,
+            $_SESSION['currentServiceProvider'],
+            'currentServiceProvider must be set to the real SP entity ID behind the trusted proxy'
+        );
+        $this->assertSame(
+            self::PROXY_SP_ENTITY_ID,
+            $_SESSION['proxyServiceProvider'],
+            'proxyServiceProvider must be set to the trusted proxy SP entity ID'
+        );
+    }
+
+    public function testNonTrustedSpDoesNotSetProxySessionVariables(): void
+    {
+        [$regularSp, $regularCoins] = $this->buildMockedServiceProvider(self::REAL_SP_ENTITY_ID, isTrustedProxy: false);
+        $idp = $this->buildMockedIdentityProvider(self::IDP_ENTITY_ID);
+
+        $repo = $this->buildMockedRepository($regularSp, $regularSp, $idp);
+        $this->proxyServerMock->setRepository($repo);
+
+        $this->configureRequestIssuer(self::REAL_SP_ENTITY_ID);
+
+        $_SESSION = [];
+
+        $this->runServe();
+
+        $this->assertArrayNotHasKey(
+            'currentServiceProvider',
+            $_SESSION,
+            'currentServiceProvider must NOT be written when the SP is not a trusted proxy'
+        );
+        $this->assertArrayNotHasKey(
+            'proxyServiceProvider',
+            $_SESSION,
+            'proxyServiceProvider must NOT be written when the SP is not a trusted proxy'
+        );
+    }
+
+    /**
+     * Runs serve() and swallows only the deliberate "test-stop" exception injected via
+     * addConsentProcessStep(). Any other exception is re-thrown to fail the test.
+     */
+    private function runServe(): void
+    {
+        $service = new EngineBlock_Corto_Module_Service_AssertionConsumer(
+            $this->proxyServerMock,
+            Phake::mock('EngineBlock_Corto_XmlToArray'),
+            new Session(new MockArraySessionStorage()),
+            Phake::mock(ProcessingStateHelperInterface::class),
+            // StepupGatewayCallOutHelper is declared final and cannot be Phake-mocked;
+            // use the real instance from the DI container (never called in this code path).
+            EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getStepupGatewayCallOutHelper(),
+            Phake::mock(ServiceProviderFactory::class)
+        );
+
+        try {
+            $service->serve('assertionConsumerService', Phake::mock(Request::class));
+        } catch (RuntimeException $e) {
+            if ($e->getMessage() !== 'test-stop') {
+                throw $e;
+            }
+        }
+    }
+
+    private function mockProxyServer(): EngineBlock_Corto_ProxyServer
+    {
+        $twig = Phake::mock(Environment::class);
+
+        /** @var EngineBlock_Corto_ProxyServer $proxyServerMock */
+        $proxyServerMock = Phake::partialMock('EngineBlock_Corto_ProxyServer', $twig);
+        $proxyServerMock->setBindingsModule($this->bindingsModuleMock);
+
+        Phake::when($proxyServerMock)
+            ->getUrl(Phake::anyParameters())
+            ->thenReturn(self::ENGINE_URL);
+
+        return $proxyServerMock;
+    }
+
+    private function mockResponse(): EngineBlock_Saml2_ResponseAnnotationDecorator
+    {
+        /** @var EngineBlock_Saml2_ResponseAnnotationDecorator $responseMock */
+        $responseMock = Phake::mock('EngineBlock_Saml2_ResponseAnnotationDecorator');
+
+        // Avoid triggering the transparent-error and no-passive early-return branches
+        Phake::when($responseMock)->isTransparentErrorResponse()->thenReturn(false);
+        Phake::when($responseMock)->getStatus()->thenReturn([Constants::STATUS_SUCCESS]);
+
+        $idpIssuer = new Issuer();
+        $idpIssuer->setValue(self::IDP_ENTITY_ID);
+        Phake::when($responseMock)->getIssuer()->thenReturn($idpIssuer);
+
+        // getAssertions()[0] is cloned by serve() before filterInputAssertionAttributes()
+        Phake::when($responseMock)->getAssertions()->thenReturn([new Assertion()]);
+
+        return $responseMock;
+    }
+
+    private function mockRequest(): EngineBlock_Saml2_AuthnRequestAnnotationDecorator
+    {
+        /** @var EngineBlock_Saml2_AuthnRequestAnnotationDecorator $requestMock */
+        $requestMock = Phake::mock('EngineBlock_Saml2_AuthnRequestAnnotationDecorator');
+
+        Phake::when($requestMock)->isDebugRequest()->thenReturn(false);
+        Phake::when($requestMock)->getKeyId()->thenReturn(null);
+        Phake::when($requestMock)->wasSigned()->thenReturn(false);
+        Phake::when($requestMock)->getRequesterIds()->thenReturn([]);
+
+        return $requestMock;
+    }
+
+    private function configureRequestIssuer(string $entityId): void
+    {
+        $issuer = new Issuer();
+        $issuer->setValue($entityId);
+        Phake::when($this->requestMock)->getIssuer()->thenReturn($issuer);
+    }
+
+    /**
+     * @return array{0: ServiceProvider, 1: Coins}
+     */
+    private function buildMockedServiceProvider(string $entityId, bool $isTrustedProxy): array
+    {
+        /** @var Coins $coins */
+        $coins = Phake::mock(Coins::class);
+        Phake::when($coins)->isTrustedProxy()->thenReturn($isTrustedProxy);
+        Phake::when($coins)->additionalLogging()->thenReturn(false);
+
+        /** @var ServiceProvider $sp */
+        $sp = Phake::mock(ServiceProvider::class);
+        $sp->entityId = $entityId;
+        Phake::when($sp)->getCoins()->thenReturn($coins);
+
+        return [$sp, $coins];
+    }
+
+    private function buildMockedIdentityProvider(string $entityId): IdentityProvider
+    {
+        /** @var Coins $coins */
+        $coins = Phake::mock(Coins::class);
+        Phake::when($coins)->additionalLogging()->thenReturn(false);
+
+        /** @var IdentityProvider $idp */
+        $idp = Phake::mock(IdentityProvider::class);
+        $idp->entityId = $entityId;
+        Phake::when($idp)->getCoins()->thenReturn($coins);
+
+        return $idp;
+    }
+
+    private function buildMockedRepository(
+        ServiceProvider  $spByIssuer,
+        ServiceProvider  $spByRealId,
+        IdentityProvider $idp
+    ): MetadataRepositoryInterface {
+        /** @var MetadataRepositoryInterface $repo */
+        $repo = Phake::mock(MetadataRepositoryInterface::class);
+
+        Phake::when($repo)
+            ->fetchServiceProviderByEntityId($spByIssuer->entityId)
+            ->thenReturn($spByIssuer);
+
+        // Also register the real SP so secondary lookups (e.g. inside getSpRequesterChain) resolve
+        if ($spByRealId->entityId !== $spByIssuer->entityId) {
+            Phake::when($repo)
+                ->fetchServiceProviderByEntityId($spByRealId->entityId)
+                ->thenReturn($spByRealId);
+        }
+
+        Phake::when($repo)
+            ->fetchIdentityProviderByEntityId(self::IDP_ENTITY_ID)
+            ->thenReturn($idp);
+
+        return $repo;
+    }
+}

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/AssertionConsumerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/AssertionConsumerTest.php
@@ -103,8 +103,8 @@ class EngineBlock_Test_Corto_Module_Service_AssertionConsumerTest extends TestCa
 
         $this->assertSame(
             self::REAL_SP_ENTITY_ID,
-            $_SESSION['currentServiceProvider'],
-            'currentServiceProvider must be set to the real SP entity ID behind the trusted proxy'
+            $_SESSION['originalServiceProvider'],
+            'originalServiceProvider must be set to the real SP entity ID behind the trusted proxy'
         );
         $this->assertSame(
             self::PROXY_SP_ENTITY_ID,
@@ -128,9 +128,9 @@ class EngineBlock_Test_Corto_Module_Service_AssertionConsumerTest extends TestCa
         $this->runServe();
 
         $this->assertArrayNotHasKey(
-            'currentServiceProvider',
+            'originalServiceProvider',
             $_SESSION,
-            'currentServiceProvider must NOT be written when the SP is not a trusted proxy'
+            'originalServiceProvider must NOT be written when the SP is not a trusted proxy'
         );
         $this->assertArrayNotHasKey(
             'proxyServiceProvider',


### PR DESCRIPTION
  When a request goes through a trusted proxy SP, store the real (proxied)
  SP entity ID in $_SESSION['currentServiceProvider'] so error pages
  (e.g. PEP denial) display the correct SP name instead of the proxy's name.

  Also:
  - Add unit tests for the trusted proxy session variable behaviour
  - Fix undefined array key warning in FeedbackController::getFeedbackInfo()
  - Add extra_hosts to docker-compose to prevent devconf HAProxy from intercepting Behat requests during local development
  
before:
<img width="1200" height="907" alt="before-fix-proxy-sp-name" src="https://github.com/user-attachments/assets/85a4ce7a-4220-40c5-97e4-41617d010f31" />

after:
<img width="1200" height="907" alt="after-fix-real-sp-name" src="https://github.com/user-attachments/assets/7dbd6943-0722-4422-9a0b-476681af7b72" />

solves: [issue 1778](https://github.com/OpenConext/OpenConext-engineblock/issues/1778) 


  