### PR TITLE
Fix: add time to error screen.

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -55,6 +55,8 @@ return $overrides + [
     'ipAddress'             => 'IP',
     'statusCode'            => 'Status Code',
     'artCode'               => 'EC',
+    'datetime'              => 'Time',
+    'requestUrl'            => 'Request URL',
     'statusMessage'         => 'Status Message',
     'attributeName'         => 'Attribute Name',
     'attributeValue'        => 'Attribute Value',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -55,6 +55,8 @@ return $overrides + [
     'ipAddress'             => 'IP',
     'statusCode'            => 'Statuscode',
     'artCode'               => 'EC',
+    'datetime'              => 'Tijd',
+    'requestUrl'            => 'Aanvraag-URL',
     'statusMessage'         => 'Statusbericht',
     'attributeName'         => 'Attribuutnaam',
     'attributeValue'        => 'Attribuutwaarde',

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -257,7 +257,11 @@ class EngineBlock_ApplicationSingleton
             $logRequestId = $logRequestId->get();
         }
 
+        $request = $this->getDiContainer()->getSymfonyRequest();
+
         $feedbackInfo = array();
+        $feedbackInfo['datetime'] = (new DateTime())->format(DateTimeInterface::ATOM);
+        $feedbackInfo['requestUrl'] = sprintf('%s%s', $request->getSchemeAndHttpHost(), $request->getPathInfo());
         $feedbackInfo['requestId'] = $logRequestId;
         $feedbackInfo['ipAddress'] = $this->getClientIpAddress();
         $feedbackInfo['artCode'] = Art::forException($exception);

--- a/theme/base/stylesheets/components/old-not-converted/error-page/error-details.scss
+++ b/theme/base/stylesheets/components/old-not-converted/error-page/error-details.scss
@@ -22,7 +22,7 @@
             display: grid;
             grid-auto-flow: row dense;
             grid-gap: 0.5em;
-            grid-template-columns: repeat(3, 1fr);
+            grid-template-columns: repeat(2, 1fr);
 
             // For IE 10 and 11, we can not use grid-auto-flow, and getting good results otherwise is not feasible
             @media all and (-ms-high-contrast: none) {

--- a/theme/base/stylesheets/components/old-not-converted/error-page/feedback-info.scss
+++ b/theme/base/stylesheets/components/old-not-converted/error-page/feedback-info.scss
@@ -25,24 +25,25 @@
         font-weight: bold;
     }
 
-    &--identityprovider,
-    &--idp-hash,
-    &--serviceprovider,
-    &--serviceprovidername,
-    &--proxyserviceprovider {
-        @include breakpoints.screen('tabletAndBigger') {
-            grid-column-end: span 2;
-            order: -1;
-        }
-    }
+    @include breakpoints.screen('tabletAndBigger') {
+        &--identityprovider    { order: 1; }
+        &--artcode             { order: 2; }
+        &--serviceprovider     { order: 3; }
+        &--ipaddress           { order: 4; }
+        &--serviceprovidername { order: 5; }
+        &--requestid           { order: 6; }
+        &--requesturl          { order: 7; }
+        &--datetime            { order: 8; }
 
-    &--destination,
-    &--entityid,
-    &--statuscode,
-    &--statusmessage {
-        @include breakpoints.screen('tabletAndBigger') {
-            grid-column-end: span 3;
-            order: -1;
+        &--identityprovidername,
+        &--idp-hash,
+        &--proxyserviceprovider,
+        &--destination,
+        &--entityid,
+        &--statuscode,
+        &--statusmessage {
+            grid-column-end: span 2;
+            order: 9;
         }
     }
 }


### PR DESCRIPTION
Its hard to find errors in the logs without a timestamp as we dont know when the error occured. This is something we want to help the support department. Therefore, the time the screen appeard should have a iso timestamp.

<img width="1200" height="1121" alt="page-2026-03-06T10-07-33-508Z" src="https://github.com/user-attachments/assets/0a459dd6-71fc-4f47-b01b-f45a6cbc2744" />

