### PR TITLE
Translation for 'login via'

### DIFF
--- a/theme/base/templates/modules/Default/Partials/LoginBar.html.twig
+++ b/theme/base/templates/modules/Default/Partials/LoginBar.html.twig
@@ -1,3 +1,3 @@
 <header>
-    <p class="loginBar">Login via {{ loginName }}</p>
+    <p class="loginBar">{{ 'wayf_title'|trans }} {{ loginName }}</p>
 </header>

--- a/theme/base/templates/modules/Default/Partials/header.html.twig
+++ b/theme/base/templates/modules/Default/Partials/header.html.twig
@@ -1,4 +1,4 @@
 <header>
-    <p>Login via {{ login }}</p>
+    <p>{{ 'wayf_title'|trans }} {{ login }}</p>
     <h1>{{ pageTitle }}</h1>
 </header>

--- a/theme/openconext/translations/messages.en.php
+++ b/theme/openconext/translations/messages.en.php
@@ -8,6 +8,7 @@ if (file_exists($overridesFile)) {
 
 return $overrides + [
     // General
+    'wayf_title'                => 'Log in with',
     'search'                    => 'Search for an %organisationNoun%...',
     'search_screenreader'       => 'Search',
     'log_in_to'                 => 'Select an %organisationNoun% to login to the service',

--- a/theme/openconext/translations/messages.nl.php
+++ b/theme/openconext/translations/messages.nl.php
@@ -8,6 +8,7 @@ if (file_exists($overridesFile)) {
 
 return $overrides + [
     // General
+    'wayf_title'                => 'Log in met',
     'search'                    => 'Zoek een %organisationNoun%...',
     'search_screenreader'       => 'Zoeken',
     'log_in_to'                 => 'Selecteer een %organisationNoun% en login bij',

--- a/theme/openconext/translations/messages.pt.php
+++ b/theme/openconext/translations/messages.pt.php
@@ -8,6 +8,7 @@ if (file_exists($overridesFile)) {
 
 return $overrides + [
     // General
+    'wayf_title'                => 'Entrar com a',
     'search'                    => 'Procure por uma %organisationNoun%...',
     'search_screenreader'       => 'Procurar',
     'log_in_to'                 => 'Seleccione uma %organisationNoun% para se autenticar no serviço:',


### PR DESCRIPTION
The current text on top of the IdP discovery GUI (WAYF) is not translated and contains a spelling error (login should be log in as a verb).