### PR TITLE
Fix wayf_title translation key not resolving for non-openconext themes

### DIFF
--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -35,6 +35,7 @@ return $overrides + [
     'name_id_support_url' => 'https://example.org',
 
     // General
+    'wayf_title'            => 'Log in with',
     'value'                 => 'Value',
     'post_data'             => 'POST Data',
     'processing'            => 'Connecting to the service',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -35,6 +35,7 @@ return $overrides + [
     'name_id_support_url' => 'https://example.org',
 
     // General
+    'wayf_title'            => 'Log in met',
     'value'                 => 'Waarde',
     'post_data'             => 'POST Data',
     'processing'            => 'Verbinden met de dienst',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -35,6 +35,7 @@ return $overrides + [
     'name_id_support_url' => 'https://example.org',
 
     // General
+    'wayf_title'            => 'Entrar com a',
     'value'                 => 'Valor',
     'post_data'             => 'POST Data',
     'processing'            => 'A estabelecer ligação ao serviço',


### PR DESCRIPTION
The wayf_title key was added only to the openconext theme translations, but the base partials (LoginBar.html.twig, header.html.twig) that use it are shared across all themes. Add the key to the base languages/ catalogue so it resolves regardless of the active theme.


Repairs https://github.com/OpenConext/OpenConext-engineblock/pull/1937