### PR TITLE
Reject metadata push when IdP discovery entry is missing English name

### DIFF
--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssembler.php
@@ -42,16 +42,21 @@ class DiscoveryAssembler
             return [];
         }
 
+        $entityId = $connection->name ?? 'unknown';
         $discoveries = [];
-        foreach ($connection->metadata->discoveries as $discovery) {
+        foreach ($connection->metadata->discoveries as $index => $discovery) {
             $names = $this->extractLocalizedFields($discovery, 'name');
             $keywords = $this->extractLocalizedFields($discovery, 'keywords');
             $logo = $this->assembleLogo($discovery);
 
             if (!isset($names['en'])) {
                 throw new InvalidDiscoveryException(
-                    'A discovery entry is missing a required English name (name_en). ' .
-                    'Refusing to process metadata push.'
+                    sprintf(
+                        'Discovery entry #%d for entity "%s" is missing a required English name (name_en). ' .
+                        'Refusing to process metadata push.',
+                        $index,
+                        $entityId
+                    )
                 );
             }
             $discoveries[] = Discovery::create($names, $keywords, $logo);

--- a/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssembler.php
+++ b/src/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssembler.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlock\Metadata\Entity\Assembler;
 
+use OpenConext\EngineBlock\Exception\InvalidDiscoveryException;
 use OpenConext\EngineBlock\Metadata\Discovery;
 use OpenConext\EngineBlock\Metadata\Logo;
 use OpenConext\EngineBlockBundle\Localization\LanguageSupportProvider;
@@ -47,9 +48,13 @@ class DiscoveryAssembler
             $keywords = $this->extractLocalizedFields($discovery, 'keywords');
             $logo = $this->assembleLogo($discovery);
 
-            if (isset($names['en'])) {
-                $discoveries[] = Discovery::create($names, $keywords, $logo);
+            if (!isset($names['en'])) {
+                throw new InvalidDiscoveryException(
+                    'A discovery entry is missing a required English name (name_en). ' .
+                    'Refusing to process metadata push.'
+                );
             }
+            $discoveries[] = Discovery::create($names, $keywords, $logo);
         }
 
         return empty($discoveries) ? [] : ['discoveries' => $discoveries];

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/Api/ConnectionsControllerTest.php
@@ -396,6 +396,39 @@ class ConnectionsControllerTest extends FunctionalWebTestCase
         $this->assertStatusCode(Response::HTTP_OK, $client);
     }
 
+    #[Group('Api')]
+    #[Group('Connections')]
+    #[Group('MetadataPush')]
+    #[Test]
+    public function pushing_idp_with_discovery_missing_english_name_returns_bad_request(): void
+    {
+        $client = $this->createAuthorizedClient();
+
+        $payload = '{"connections":{"idp1":{
+            "allow_all_entities":true,
+            "allowed_connections":[],
+            "metadata":{
+                "name":{"en":"Test IdP","nl":"Test IdP nl"},
+                "discoveries":[{"name_nl":"Ontbrekend Engels"}],
+                "SingleSignOnService":[{
+                    "Binding":"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "Location":"https://idp.example.com/sso"
+                }]
+            },
+            "name":"https://idp.example.com",
+            "state":"prodaccepted",
+            "type":"saml20-idp"
+        }}}';
+
+        $client->request('POST', 'https://engine-api.dev.openconext.local/api/connections', [], [], [], $payload);
+
+        $this->assertStatusCode(Response::HTTP_BAD_REQUEST, $client);
+        $this->assertJson($client->getResponse()->getContent());
+        $isContentTypeJson = $client->getResponse()->headers->contains('Content-Type', 'application/json');
+        $this->assertTrue($isContentTypeJson, 'Response should have Content-Type: application/json header');
+        $this->assertStringContainsString('name_en', $client->getResponse()->getContent());
+    }
+
     public static function invalidHttpMethodProvider()
     {
         return [

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/DiscoveryAssemblerTest.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\EngineBlock\Tests;
 
+use OpenConext\EngineBlock\Exception\InvalidDiscoveryException;
 use OpenConext\EngineBlock\Metadata\Discovery;
 use OpenConext\EngineBlock\Metadata\Entity\Assembler\DiscoveryAssembler;
 use OpenConext\EngineBlock\Metadata\Logo;
@@ -84,8 +85,11 @@ class DiscoveryAssemblerTest extends TestCase
         $this->assertEquals(100, $discovery->getLogo()->height);
     }
 
-    public function testAssembleDiscoveriesSkipsDiscoveryWithoutEnglishName(): void
+    public function testAssembleDiscoveriesThrowsWhenDiscoveryMissingEnglishName(): void
     {
+        $this->expectException(InvalidDiscoveryException::class);
+        $this->expectExceptionMessage('missing a required English name');
+
         $connection = new stdClass();
         $connection->metadata = new stdClass();
         $connection->metadata->discoveries = [
@@ -95,9 +99,7 @@ class DiscoveryAssemblerTest extends TestCase
             ])
         ];
 
-        $result = $this->discoveryAssembler->assembleDiscoveries($connection);
-
-        $this->assertEquals([], $result);
+        $this->discoveryAssembler->assembleDiscoveries($connection);
     }
 
     public function testAssembleDiscoveriesWithTrimmedValues(): void

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/PushMetadataAssemblerTest.php
@@ -20,6 +20,7 @@ namespace OpenConext\EngineBlock\Tests;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Exception\InvalidDiscoveryException;
 use OpenConext\EngineBlock\Metadata\AttributeReleasePolicy;
 use OpenConext\EngineBlock\Metadata\Discovery;
 use OpenConext\EngineBlock\Metadata\Entity\Assembler\PushMetadataAssembler;
@@ -567,6 +568,15 @@ class PushMetadataAssemblerTest extends TestCase
         $this->assertSame('Dummy IdP', $idp->nameEn);
         $this->assertSame('idp keywords', $idp->getMdui()->getKeywords('en'));
         $this->assertSame('https://engine.dev.openconext.local/images/logo.png?v=dev', $idp->logo->url);
+    }
+
+    public function test_it_rejects_idp_with_discovery_missing_english_name(): void
+    {
+        $this->expectException(InvalidDiscoveryException::class);
+        $this->expectExceptionMessage('missing a required English name');
+
+        $input = $this->readFixture('metadata_idp_discovery_missing_english.json');
+        $this->assembler->assemble($input);
     }
 
     private function readFixture(string $file): object

--- a/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/fixtures/metadata_idp_discovery_missing_english.json
+++ b/tests/integration/OpenConext/EngineBlock/Metadata/Entity/Assembler/fixtures/metadata_idp_discovery_missing_english.json
@@ -1,0 +1,24 @@
+{
+    "2d96e27a-76cf-4ca2-ac70-ece5d4c49525": {
+        "name": "https:\/\/serviceregistry.dev.openconext.local\/simplesaml\/module.php\/saml\/sp\/metadata.php\/default-idp",
+        "state": "prodaccepted",
+        "type": "saml20-idp",
+        "metadata": {
+            "discoveries": [
+                {
+                    "name_nl": "Ontbrekend Engels"
+                }
+            ],
+            "SingleSignOnService": [
+                {
+                    "Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "Location": "https:\/\/mujina-idp.dev.openConext.local\/SingleSignOnService"
+                }
+            ],
+            "name": {
+                "en": "Dummy IdP",
+                "nl": "Dummy IdP nl"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #1865: when Manage pushes IdP metadata with a `discoveries` entry that has no English name (`name_en`), EngineBlock now rejects the push with HTTP 400 instead of silently dropping the entry
- Changed `DiscoveryAssembler::assembleDiscoveries()` to throw `InvalidDiscoveryException` instead of silently skipping; the existing `ConnectionsController` catch-all propagates this as HTTP 400
- Added tests at three levels: unit (`DiscoveryAssemblerTest`), assembler integration (`PushMetadataAssemblerTest`), and HTTP functional (`ConnectionsControllerTest`)

## Test plan

- [ ] Run unit and integration tests: `./vendor/bin/phpunit --configuration=./tests/phpunit.xml --testsuite=unit,integration`
- [ ] Verify `POST /api/connections` with an IdP discovery missing `name_en` returns HTTP 400 with an error message containing `name_en`
- [ ] Verify a normal metadata push with a valid discovery (including `name_en`) still succeeds