### PR TITLE
fix: return HTTP 503 on bootstrap error for /health endpoint

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -6,16 +6,29 @@ use Symfony\Component\HttpFoundation\Request;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-// Validate required envs
-if (!isset($_ENV['APP_ENV'])) {
-    throw new RuntimeException('APP_ENV environment variable is not defined.');
+try {
+    // Validate required envs
+    if (!isset($_ENV['APP_ENV'])) {
+        throw new RuntimeException('APP_ENV environment variable is not defined.');
+    }
+    if (!isset($_ENV['APP_SECRET']) || trim($_ENV['APP_SECRET']) === '') {
+        throw new \RuntimeException('APP_SECRET is missing or empty. Set it in your environment configuration.');
+    }
+    if ($_ENV['APP_ENV'] === 'prod' && strlen($_ENV['APP_SECRET']) < 32) {
+        throw new \RuntimeException('APP_SECRET must be at least 32 characters long in production.');
+    }
+} catch (\Throwable $e) {
+    http_response_code(503);
+    header('Content-Type: application/json');
+    $body = ['status' => 'DOWN'];
+    if (trim($e->getMessage()) !== '') {
+        $body['message'] = $e->getMessage();
+    }
+    error_log($e->getMessage());
+    echo json_encode($body) ?: '{"status":"DOWN"}';
+    exit;
 }
-if (!isset($_ENV['APP_SECRET']) || trim($_ENV['APP_SECRET']) === '') {
-    throw new \RuntimeException('APP_SECRET is missing or empty. Set it in your environment configuration.');
-}
-if ($_ENV['APP_ENV'] === 'prod' && strlen($_ENV['APP_SECRET']) < 32) {
-    throw new \RuntimeException('APP_SECRET must be at least 32 characters long in production.');
-}
+
 $debug = filter_var($_ENV['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN);
 
 if ($debug) {

--- a/public/index.php
+++ b/public/index.php
@@ -17,6 +17,25 @@ try {
     if ($_ENV['APP_ENV'] === 'prod' && strlen($_ENV['APP_SECRET']) < 32) {
         throw new \RuntimeException('APP_SECRET must be at least 32 characters long in production.');
     }
+
+    $debug = filter_var($_ENV['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN);
+
+    if ($debug) {
+        umask(0000);
+
+        Debug::enable();
+    }
+
+    if ($trustedProxies = $_ENV['TRUSTED_PROXIES'] ?? false) {
+        Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
+    }
+
+    if ($trustedHosts = $_ENV['TRUSTED_HOSTS'] ?? false) {
+        Request::setTrustedHosts(explode(',', $trustedHosts));
+    }
+
+    $kernel = new Kernel($_ENV['APP_ENV'], $debug);
+    $request = Request::createFromGlobals();
 } catch (\Throwable $e) {
     http_response_code(503);
     header('Content-Type: application/json');
@@ -28,25 +47,6 @@ try {
     echo json_encode($body) ?: '{"status":"DOWN"}';
     exit;
 }
-
-$debug = filter_var($_ENV['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN);
-
-if ($debug) {
-    umask(0000);
-
-    Debug::enable();
-}
-
-if ($trustedProxies = $_ENV['TRUSTED_PROXIES'] ?? false) {
-    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
-}
-
-if ($trustedHosts = $_ENV['TRUSTED_HOSTS'] ?? false) {
-    Request::setTrustedHosts(explode(',', $trustedHosts));
-}
-
-$kernel = new Kernel($_ENV['APP_ENV'], $debug);
-$request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/src/OpenConext/EngineBlockBundle/EventListener/FallbackExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/FallbackExceptionListener.php
@@ -80,7 +80,7 @@ class FallbackExceptionListener
         $path = $event->getRequest()->getPathInfo();
         if (in_array($path, ['/health', '/internal/health', '/info', '/internal/info'], true)) {
             $event->setResponse(new JsonResponse(
-                ['status' => 'DOWN', 'message' => $exception->getMessage()],
+                ['status' => 'DOWN'],
                 JsonResponse::HTTP_SERVICE_UNAVAILABLE
             ));
             return;

--- a/src/OpenConext/EngineBlockBundle/EventListener/FallbackExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/FallbackExceptionListener.php
@@ -21,6 +21,7 @@ namespace OpenConext\EngineBlockBundle\EventListener;
 use EngineBlock_Exception;
 use OpenConext\EngineBlockBridge\ErrorReporter;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -75,6 +76,15 @@ class FallbackExceptionListener
             get_class($exception),
             $exception->getMessage()
         ));
+
+        $path = $event->getRequest()->getPathInfo();
+        if (in_array($path, ['/health', '/internal/health', '/info', '/internal/info'], true)) {
+            $event->setResponse(new JsonResponse(
+                ['status' => 'DOWN', 'message' => $exception->getMessage()],
+                JsonResponse::HTTP_SERVICE_UNAVAILABLE
+            ));
+            return;
+        }
 
         if ($exception instanceof EngineBlock_Exception) {
             $this->errorReporter->reportError($exception, 'Caught Unhandled EngineBlock_Exception');

--- a/tests/functional/OpenConext/EngineBlockBundle/Controller/MonitorControllerTest.php
+++ b/tests/functional/OpenConext/EngineBlockBundle/Controller/MonitorControllerTest.php
@@ -50,4 +50,19 @@ final class MonitorControllerTest extends FunctionalWebTestCase
         $json = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
         $this->assertSame(['status' => 'UP'], $json);
     }
+
+    #[Test]
+    #[Group('Monitor')]
+    public function health_returns_json(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', 'https://engine.dev.openconext.local/health');
+
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJson($response->getContent());
+
+        $json = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(['status' => 'UP'], $json);
+    }
 }


### PR DESCRIPTION
## Summary

- Wraps the env validation block in `public/index.php` in a `try-catch(\Throwable)` so misconfiguration errors (e.g. missing/short `APP_SECRET`) return HTTP 503 instead of a PHP fatal error page with HTTP 200
- Response format matches the `openconext/monitor-bundle` DOWN convention: `{"status":"DOWN","message":"..."}` 
- Adds `error_log()` so bootstrap failures still appear in server logs
- Adds functional test coverage for the public `/health` route

## Test Plan

- [ ] Set `APP_ENV=prod` and `APP_SECRET=short` in devconf `.env`, restart engine container, hit `GET https://engine.dev.openconext.local/health` — expect HTTP 503 with `{"status":"DOWN","message":"APP_SECRET must be at least 32 characters long in production."}`
- [ ] Revert `.env`, restart, hit `/health` again — expect HTTP 200 `{"status":"UP"}`
- [ ] Run `./vendor/bin/phpunit --configuration=./tests/phpunit.xml --testsuite=functional --filter=MonitorControllerTest` — expect 3 tests passing

Closes #1936