### PR TITLE
Remove verify peer flag from HttpClient and related configurations

### DIFF
--- a/config/packages/parameters.yml.dist
+++ b/config/packages/parameters.yml.dist
@@ -323,7 +323,6 @@ parameters:
     sram.authz_location: authz
     sram.attributes_location: attributes
     sram.interrupt_location: interrupt
-    sram.verify_peer: false
     sram.allowed_attributes:
         - 'urn:mace:dir:attribute-def:eduPersonEntitlement'
         - 'urn:mace:dir:attribute-def:eduPersonPrincipalName'

--- a/config/services/services.yml
+++ b/config/services/services.yml
@@ -358,7 +358,6 @@ services:
             - "%sram.attributes_location%"
             - "%sram.interrupt_location%"
             - "%sram.api_token%"
-            - "%sram.verify_peer%"
 
     engineblock.sbs.http_client:
         class: OpenConext\EngineBlock\Http\HttpClient

--- a/src/OpenConext/EngineBlock/Http/HttpClient.php
+++ b/src/OpenConext/EngineBlock/Http/HttpClient.php
@@ -89,14 +89,13 @@ class HttpClient
      * @param array $headers
      * @return mixed
      */
-    public function post($data, $path, $parameters = [], array $headers = [], bool $verify = true)
+    public function post($data, $path, $parameters = [], array $headers = [])
     {
         $resource = ResourcePathFormatter::format($path, $parameters);
         $response = $this->httpClient->request('POST', $resource, [
             'http_errors' => false,
             'body' => $data,
             'headers' => $headers,
-            'verify' => $verify,
         ]);
         $statusCode = $response->getStatusCode();
 

--- a/src/OpenConext/EngineBlockBundle/Sbs/SbsClient.php
+++ b/src/OpenConext/EngineBlockBundle/Sbs/SbsClient.php
@@ -33,7 +33,6 @@ final class SbsClient implements SbsClientInterface
         private readonly string $attributesLocation,
         private readonly string $interruptLocation,
         private readonly string $apiToken,
-        private readonly bool $verifyPeer
     ) {
     }
 
@@ -44,7 +43,6 @@ final class SbsClient implements SbsClientInterface
             $this->buildUrl($this->authzLocation),
             [],
             $this->requestHeaders(),
-            $this->verifyPeer
         );
 
         if (!is_array($jsonData)) {
@@ -61,7 +59,6 @@ final class SbsClient implements SbsClientInterface
             $this->buildUrl($this->attributesLocation),
             [],
             $this->requestHeaders(),
-            $this->verifyPeer
         );
 
         if (!is_array($jsonData)) {

--- a/tests/unit/OpenConext/EngineBlockBundle/Sbs/SbsClientTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Sbs/SbsClientTest.php
@@ -45,7 +45,6 @@ class SbsClientTest extends TestCase
             '/authz',
             '/interrupt',
             'Bearer test_token',
-            true
         );
     }
 


### PR DESCRIPTION
This was a leftover from SBS integration development and is no longer needed.