### PR TITLE
Add missing help-discover template to base theme

### DIFF
--- a/theme/base/templates/modules/Authentication/View/IdentityProvider/help-discover.html.twig
+++ b/theme/base/templates/modules/Authentication/View/IdentityProvider/help-discover.html.twig
@@ -1,0 +1,12 @@
+{% extends '@themeLayouts/scripts/default.html.twig' %}
+
+{% block title %}{{ parent() }} - {{ 'help_header'|trans }}{% endblock %}
+
+{% block content %}
+<main class="box">
+    <div class="mod-content">
+        <h1>{{ 'help_header'|trans }}</h1>
+        {{ 'help_page_content'|trans|raw }}
+    </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
The /authentication/idp/help-discover route was throwing a generic exception for any theme other than openconext because the template only existed in theme/openconext/ but not in theme/base/ as a fallback.

The Twig @theme namespace resolves active theme first, then falls back to base — adding the template there fixes the broken help button on the WAYF screen for all non-openconext themes.

Fixes #1881