### PR TITLE
Add logging when old SAML requests are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes:
   * The `0000-00-00 00:00:00` is added for clarity/consistency, as this is probably the default behaviour of your database already.
 * Removed unused index `consent.deleted_at`. Delete this from your production database if it's there.
 * Added a specific error page for unsolicited SAML responses (IdP-initiated SSO without a prior AuthnRequest).
+* Added `max_issue_instant_age` to parameters.yaml to configure the logging mechanism. EB will write log entries if it receives requests that are older than this value.
 
 * Stabilized consent checks
   * In order to make the consent hashes more robust, a more consistent way of hashing the user attributes has been introduced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes:
   * The `0000-00-00 00:00:00` is added for clarity/consistency, as this is probably the default behaviour of your database already.
 * Removed unused index `consent.deleted_at`. Delete this from your production database if it's there.
 * Added a specific error page for unsolicited SAML responses (IdP-initiated SSO without a prior AuthnRequest).
+* Added `max_issue_instant_age` to parameters.yml to configure the logging mechanism. EB will write log entries if it receives requests that are older than this value.
 
 * Stabilized consent checks
   * In order to make the consent hashes more robust, a more consistent way of hashing the user attributes has been introduced

--- a/config/packages/parameters.yml.dist
+++ b/config/packages/parameters.yml.dist
@@ -57,6 +57,9 @@ parameters:
     metadata_add_requested_attributes: all
     ## The number of seconds a Metadata document is deemed valid (default 24h). Must be a positive integer.
     metadata_expiration_time: 86400
+    ## The maximum age (in seconds) of the IssueInstant in incoming SAMLRequests before a warning is logged.
+    ## Default is 24h (86400)
+    max_issue_instant_age: 86400
 
     ##########################################################################################
     ## PHP SETTINGS

--- a/config/reference.php
+++ b/config/reference.php
@@ -1466,8 +1466,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     monolog?: MonologConfig,
  *     doctrine?: DoctrineConfig,
  *     doctrine_migrations?: DoctrineMigrationsConfig,
- *     debug?: DebugConfig,
- *     web_profiler?: WebProfilerConfig,
  *     "when@ci"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1493,6 +1491,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         doctrine_migrations?: DoctrineMigrationsConfig,
  *         debug?: DebugConfig,
  *         web_profiler?: WebProfilerConfig,
+ *     },
+ *     "when@prod"?: array{
+ *         imports?: ImportsConfig,
+ *         parameters?: ParametersConfig,
+ *         services?: ServicesConfig,
+ *         framework?: FrameworkConfig,
+ *         security?: SecurityConfig,
+ *         twig?: TwigConfig,
+ *         monolog?: MonologConfig,
+ *         doctrine?: DoctrineConfig,
+ *         doctrine_migrations?: DoctrineMigrationsConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1592,6 +1601,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  * @psalm-type RoutesConfig = array{
  *     "when@ci"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     "when@dev"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
+ *     "when@prod"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     "when@test"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     ...<string, RouteConfig|ImportConfig|AliasConfig>
  * }

--- a/library/EngineBlock/Application/DiContainer.php
+++ b/library/EngineBlock/Application/DiContainer.php
@@ -437,6 +437,11 @@ class EngineBlock_Application_DiContainer extends \Pimple\Container
         return (array) $this->container->getParameter('forbidden_signature_methods');
     }
 
+    public function getMaxIssueInstantAge(): int
+    {
+        return (int) $this->container->getParameter('max_issue_instant_age');
+    }
+
     /**
      * @return AllowedSchemeValidator
      */

--- a/library/EngineBlock/Corto/Adapter.php
+++ b/library/EngineBlock/Corto/Adapter.php
@@ -374,7 +374,8 @@ class EngineBlock_Corto_Adapter
         $proxyServer->setConfigs(array(
             'ConsentStoreValues' => $settings->isConsentStoreValuesActive(),
             'metadataValidUntilSeconds' => 86400, // This sets the time (in seconds) the entity metadata is valid.
-            'forbiddenSignatureMethods' => $settings->getForbiddenSignatureMethods()
+            'forbiddenSignatureMethods' => $settings->getForbiddenSignatureMethods(),
+            'maxIssueInstantAge' => $settings->getMaxIssueInstantAge(),
         ));
 
         $this->configureProxyCertificates($proxyServer);

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -587,7 +587,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
     }
 
     /**
-     * Check if the IssueInstant of the message is too far out of sync
+     * Check if the IssueInstant of the message is too far out of sync or too old
      * @param integer $issueInstant
      * @param string $type
      * @param string $entityid
@@ -606,6 +606,20 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
                     $entityid,
                     abs($timeDelta),
                     $timeDelta>0 ? "past" : "future"
+                )
+            );
+        }
+
+        $maxAge = $this->_server->getConfig('maxIssueInstantAge', 86400);
+        if ($timeDelta > $maxAge) {
+            $this->_logger->warning(
+                sprintf(
+                    'IssueInstant of SAML message from %s "%s" is %d seconds old (threshold: %d seconds); '
+                    . 'request may originate from a bookmarked or replayed URL',
+                    $type,
+                    $entityid,
+                    $timeDelta,
+                    $maxAge
                 )
             );
         }

--- a/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
@@ -21,6 +21,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlockBundle\Bridge\DiContainerRuntime;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use SAML2\Assertion;
 use SAML2\Assertion\Validation\ConstraintValidator\NotBefore;
 use SAML2\Assertion\Validation\ConstraintValidator\NotOnOrAfter;
@@ -107,6 +108,72 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends TestCase
             'Received an assertion that has expired. Check clock synchronization on IdP and SP.',
             $result->getErrors()[1]
         );
+    }
+
+    public function test_checkIssueInstant_logs_warning_when_request_exceeds_max_age(): void
+    {
+        $maxAge = 86400;
+        $issueInstant = time() - $maxAge - 1;
+
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('notice')->once(); // clock-drift notice still fires (delta > 30 s)
+        $logger->shouldReceive('warning')->once()->withArgs(function (string $message) use ($maxAge): bool {
+            return str_contains($message, 'bookmarked or replayed URL')
+                && str_contains($message, (string)$maxAge);
+        });
+
+        $proxyServer = Phake::mock('EngineBlock_Corto_ProxyServer');
+        Phake::when($proxyServer)->getConfig('maxIssueInstantAge', 86400)->thenReturn($maxAge);
+
+        $bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
+        $this->injectLogger($bindings, $logger);
+
+        $method = new ReflectionMethod(EngineBlock_Corto_Module_Bindings::class, '_checkIssueInstant');
+        $method->invoke($bindings, $issueInstant, 'SP', 'https://sp.example.edu');
+    }
+
+    public function test_checkIssueInstant_does_not_warn_when_request_is_within_max_age(): void
+    {
+        $maxAge = 86400;
+        $issueInstant = time() - $maxAge + 5;
+
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('notice')->once(); // clock-drift notice fires (delta > 30 s)
+        $logger->shouldNotReceive('warning');
+
+        $proxyServer = Phake::mock('EngineBlock_Corto_ProxyServer');
+        Phake::when($proxyServer)->getConfig('maxIssueInstantAge', 86400)->thenReturn($maxAge);
+
+        $bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
+        $this->injectLogger($bindings, $logger);
+
+        $method = new ReflectionMethod(EngineBlock_Corto_Module_Bindings::class, '_checkIssueInstant');
+        $method->invoke($bindings, $issueInstant, 'SP', 'https://sp.example.edu');
+    }
+
+    public function test_checkIssueInstant_does_not_warn_when_request_is_in_the_future(): void
+    {
+        $maxAge = 86400;
+        $issueInstant = time() + 100;
+
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('notice')->once(); // clock-drift notice fires (delta > 30 s)
+        $logger->shouldNotReceive('warning');
+
+        $proxyServer = Phake::mock('EngineBlock_Corto_ProxyServer');
+        Phake::when($proxyServer)->getConfig('maxIssueInstantAge', 86400)->thenReturn($maxAge);
+
+        $bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
+        $this->injectLogger($bindings, $logger);
+
+        $method = new ReflectionMethod(EngineBlock_Corto_Module_Bindings::class, '_checkIssueInstant');
+        $method->invoke($bindings, $issueInstant, 'SP', 'https://sp.example.edu');
+    }
+
+    private function injectLogger(EngineBlock_Corto_Module_Bindings $bindings, LoggerInterface $logger): void
+    {
+        $property = new ReflectionProperty(EngineBlock_Corto_Module_Bindings::class, '_logger');
+        $property->setValue($bindings, $logger);
     }
 
     /**

--- a/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
@@ -21,6 +21,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlockBundle\Bridge\DiContainerRuntime;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use SAML2\Assertion;
 use SAML2\Assertion\Validation\ConstraintValidator\NotBefore;
 use SAML2\Assertion\Validation\ConstraintValidator\NotOnOrAfter;
@@ -107,6 +108,72 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends TestCase
             'Received an assertion that has expired. Check clock synchronization on IdP and SP.',
             $result->getErrors()[1]
         );
+    }
+
+    public function test_checkIssueInstant_logs_warning_when_request_exceeds_max_age(): void
+    {
+        $maxAge = 86400;
+        $issueInstant = time() - $maxAge - 1;
+
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('notice')->once(); // clock-drift notice still fires (delta > 30 s)
+        $logger->shouldReceive('warning')->once()->withArgs(function (string $message) use ($maxAge): bool {
+            return str_contains($message, 'bookmarked or replayed URL')
+                && str_contains($message, (string)$maxAge);
+        });
+
+        $proxyServer = Phake::mock('EngineBlock_Corto_ProxyServer');
+        Phake::when($proxyServer)->getConfig('maxIssueInstantAge', 86400)->thenReturn($maxAge);
+
+        $bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
+        $this->injectLogger($bindings, $logger);
+
+        $method = new ReflectionMethod(EngineBlock_Corto_Module_Bindings::class, '_checkIssueInstant');
+        $method->invoke($bindings, $issueInstant, 'SP', 'https://sp.example.edu');
+    }
+
+    public function test_checkIssueInstant_does_not_warn_when_request_is_within_max_age(): void
+    {
+        $maxAge = 86400;
+        $issueInstant = time() - $maxAge + 1;
+
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('notice')->once(); // clock-drift notice fires (delta > 30 s)
+        $logger->shouldNotReceive('warning');
+
+        $proxyServer = Phake::mock('EngineBlock_Corto_ProxyServer');
+        Phake::when($proxyServer)->getConfig('maxIssueInstantAge', 86400)->thenReturn($maxAge);
+
+        $bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
+        $this->injectLogger($bindings, $logger);
+
+        $method = new ReflectionMethod(EngineBlock_Corto_Module_Bindings::class, '_checkIssueInstant');
+        $method->invoke($bindings, $issueInstant, 'SP', 'https://sp.example.edu');
+    }
+
+    public function test_checkIssueInstant_does_not_warn_when_request_is_in_the_future(): void
+    {
+        $maxAge = 86400;
+        $issueInstant = time() + 100;
+
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('notice')->once(); // clock-drift notice fires (delta > 30 s)
+        $logger->shouldNotReceive('warning');
+
+        $proxyServer = Phake::mock('EngineBlock_Corto_ProxyServer');
+        Phake::when($proxyServer)->getConfig('maxIssueInstantAge', 86400)->thenReturn($maxAge);
+
+        $bindings = new EngineBlock_Corto_Module_Bindings($proxyServer);
+        $this->injectLogger($bindings, $logger);
+
+        $method = new ReflectionMethod(EngineBlock_Corto_Module_Bindings::class, '_checkIssueInstant');
+        $method->invoke($bindings, $issueInstant, 'SP', 'https://sp.example.edu');
+    }
+
+    private function injectLogger(EngineBlock_Corto_Module_Bindings $bindings, LoggerInterface $logger): void
+    {
+        $property = new ReflectionProperty(EngineBlock_Corto_Module_Bindings::class, '_logger');
+        $property->setValue($bindings, $logger);
     }
 
     /**


### PR DESCRIPTION
Prior to this change, EB would not make note of the fact that old SAML requests are used. Engine does make a log notice about possible clock drift, but does so if if the time is off by 30 seconds.

This change adds a warning if a request is received that is X seconds old. With the default being 1 day.

Functionally, EB does proces these requests as usual, but SPs might reject the requests.

Resolves #1792