### PR TITLE
Remove SAML request from URL in wayf

### DIFF
--- a/config/packages/ci/parameters.yml
+++ b/config/packages/ci/parameters.yml
@@ -2,6 +2,7 @@ parameters:
     api.users.nameidlookup.username: nameid
     api.users.nameidlookup.password: secret
     feature_api_users_nameid_lookup: true
+    feature_hide_bookmarkable_url: true
     auth.log.attributes:
         uid: 'urn:mace:dir:attribute-def:uid'
     encryption_keys:

--- a/config/packages/engineblock_features.yaml
+++ b/config/packages/engineblock_features.yaml
@@ -16,3 +16,4 @@ parameters:
         eb.stepup.sfo.override_engine_entityid: "%feature_stepup_sfo_override_engine_entityid%"
         eb.stepup.send_user_attributes: "%feature_stepup_send_user_attributes%"
         eb.feature_enable_sram_interrupt: "%feature_enable_sram_interrupt%"
+        eb.hide_bookmarkable_url: "%feature_hide_bookmarkable_url%"

--- a/config/packages/parameters.yml.dist
+++ b/config/packages/parameters.yml.dist
@@ -236,6 +236,7 @@ parameters:
     feature_stepup_sfo_override_engine_entityid: false
     feature_stepup_send_user_attributes: false
     feature_enable_sram_interrupt: false
+    feature_hide_bookmarkable_url: false
 
     ##########################################################################################
     ## PROFILE SETTINGS

--- a/config/reference.php
+++ b/config/reference.php
@@ -1466,8 +1466,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     monolog?: MonologConfig,
  *     doctrine?: DoctrineConfig,
  *     doctrine_migrations?: DoctrineMigrationsConfig,
- *     debug?: DebugConfig,
- *     web_profiler?: WebProfilerConfig,
  *     "when@ci"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1493,6 +1491,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         doctrine_migrations?: DoctrineMigrationsConfig,
  *         debug?: DebugConfig,
  *         web_profiler?: WebProfilerConfig,
+ *     },
+ *     "when@prod"?: array{
+ *         imports?: ImportsConfig,
+ *         parameters?: ParametersConfig,
+ *         services?: ServicesConfig,
+ *         framework?: FrameworkConfig,
+ *         security?: SecurityConfig,
+ *         twig?: TwigConfig,
+ *         monolog?: MonologConfig,
+ *         doctrine?: DoctrineConfig,
+ *         doctrine_migrations?: DoctrineMigrationsConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1592,6 +1601,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  * @psalm-type RoutesConfig = array{
  *     "when@ci"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     "when@dev"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
+ *     "when@prod"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     "when@test"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     ...<string, RouteConfig|ImportConfig|AliasConfig>
  * }

--- a/config/services/services.yml
+++ b/config/services/services.yml
@@ -400,6 +400,7 @@ services:
         arguments:
             - '@request_stack'
             - '@translator'
+            - '@OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration'
 
     OpenConext\EngineBlockBundle\Service\DiscoverySelectionService:
 

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -48,6 +48,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.feature_enable_idp_initiated_flow', true));
         $this->setFeature(new Feature('eb.stepup.send_user_attributes', true));
         $this->setFeature(new Feature('eb.feature_enable_sram_interrupt', true));
+        $this->setFeature(new Feature('eb.hide_bookmarkable_url', false));
     }
 
     public function setFeature(Feature $feature): void

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -26,6 +26,7 @@ use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -122,8 +123,15 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
     #[Route(path: '/authentication/idp/single-sign-on/{idpHash}', name: 'authentication_idp_sso_idphash', methods: ['GET', 'POST'])]
     public function singleSignOnAction(Request $request, ?string $keyId = null, ?string $idpHash = null)
     {
+        $storedRequest = $this->getStoredSessionRequest($request);
+        if ($storedRequest !== null) {
+            return new RedirectResponse($storedRequest);
+        }
+
         $this->requestValidator->isValid($request);
         $this->bindingValidator->isValid($request);
+
+        $this->storeRequestToSession($request);
 
         $cortoAdapter = new EngineBlock_Corto_Adapter();
 
@@ -134,6 +142,20 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
         $cortoAdapter->singleSignOn($idpHash);
 
         return ResponseFactory::fromEngineBlockResponse($this->engineBlockApplicationSingleton->getHttpResponse());
+    }
+
+    private function storeRequestToSession(Request $request): void
+    {
+        $request->getSession()->set('eb_last_sso_request_url', $request->getUri());
+    }
+
+    private function getStoredSessionRequest(Request $request): ?string
+    {
+        if (!$request->isMethod('GET') || $request->query->has('SAMLRequest')) {
+            return null;
+        }
+
+        return $request->getSession()->remove('eb_last_sso_request_url');
     }
 
     /**

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -26,7 +26,6 @@ use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -123,15 +122,8 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
     #[Route(path: '/authentication/idp/single-sign-on/{idpHash}', name: 'authentication_idp_sso_idphash', methods: ['GET', 'POST'])]
     public function singleSignOnAction(Request $request, ?string $keyId = null, ?string $idpHash = null)
     {
-        $storedRequest = $this->getStoredSessionRequest($request);
-        if ($storedRequest !== null) {
-            return new RedirectResponse($storedRequest);
-        }
-
         $this->requestValidator->isValid($request);
         $this->bindingValidator->isValid($request);
-
-        $this->storeRequestToSession($request);
 
         $cortoAdapter = new EngineBlock_Corto_Adapter();
 
@@ -142,20 +134,6 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
         $cortoAdapter->singleSignOn($idpHash);
 
         return ResponseFactory::fromEngineBlockResponse($this->engineBlockApplicationSingleton->getHttpResponse());
-    }
-
-    private function storeRequestToSession(Request $request): void
-    {
-        $request->getSession()->set('eb_last_sso_request_url', $request->getUri());
-    }
-
-    private function getStoredSessionRequest(Request $request): ?string
-    {
-        if (!$request->isMethod('GET') || $request->query->has('SAMLRequest')) {
-            return null;
-        }
-
-        return $request->getSession()->remove('eb_last_sso_request_url');
     }
 
     /**

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Wayf.php
@@ -20,6 +20,7 @@ namespace OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
 
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Service\Wayf\WayfIdp;
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use OpenConext\EngineBlockBundle\Service\IdpHistoryService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -40,10 +41,16 @@ class Wayf
      */
     private $previousSelection;
 
-    public function __construct(RequestStack $requestStack, TranslatorInterface $translator)
-    {
+    private FeatureConfigurationInterface $featureConfiguration;
+
+    public function __construct(
+        RequestStack $requestStack,
+        TranslatorInterface $translator,
+        FeatureConfigurationInterface $featureConfiguration
+    ) {
         $this->previousSelection = $this->loadPreviousSelectionFromCookie($requestStack);
         $this->translator = $translator;
+        $this->featureConfiguration = $featureConfiguration;
     }
 
     /**
@@ -166,6 +173,7 @@ class Wayf
                 'cutoffPointForShowingUnfilteredIdps' => $cutoffPointForShowingUnfilteredIdps,
                 'rememberChoiceCookieName' => self::REMEMBER_CHOICE_COOKIE_NAME,
                 'rememberChoiceFeature' => $rememberChoiceFeature,
+                'hideBookmarkableUrl' => $this->featureConfiguration->isEnabled('eb.hide_bookmarkable_url'),
                 'messages' => [
                     'moreIdpResults' => $this->translator->trans('more_idp_results'),
                     'requestAccess' => $this->translator->trans('request_access'),

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/HideBookmarkableUrl.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/HideBookmarkableUrl.feature
@@ -1,0 +1,24 @@
+Feature:
+  In order to prevent users from saving a broken SAML URL as a bookmark
+  As EngineBlock
+  I want to hide the SAMLRequest from the browser's address bar
+  while still recovering gracefully when the user presses the Back button
+
+  Background:
+    Given an EngineBlock instance on "dev.openconext.local"
+      And no registered SPs
+      And no registered Idps
+      And an Identity Provider named "Dummy Idp"
+      And an Identity Provider named "Second Idp"
+      And a Service Provider named "Dummy SP"
+
+  Scenario: Pressing Back after visiting the WAYF restores the SAML request from the session
+    When I log in at "Dummy SP"
+     And I go to Engineblock URL "/authentication/idp/single-sign-on"
+    Then I should see "Dummy Idp"
+
+  Scenario: A GET to the SSO endpoint without an active session shows an error
+    When I log in at "Dummy SP"
+     And I lose my session
+     And I go to Engineblock URL "/authentication/idp/single-sign-on"
+    Then I should see "The parameter \"SAMLRequest\" is missing on the SAML SSO request"

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/HideBookmarkableUrl.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/HideBookmarkableUrl.feature
@@ -2,23 +2,15 @@ Feature:
   In order to prevent users from saving a broken SAML URL as a bookmark
   As EngineBlock
   I want to hide the SAMLRequest from the browser's address bar
-  while still recovering gracefully when the user presses the Back button
 
   Background:
     Given an EngineBlock instance on "dev.openconext.local"
       And no registered SPs
       And no registered Idps
       And an Identity Provider named "Dummy Idp"
-      And an Identity Provider named "Second Idp"
       And a Service Provider named "Dummy SP"
 
-  Scenario: Pressing Back after visiting the WAYF restores the SAML request from the session
+  Scenario: A GET to the SSO endpoint without a SAMLRequest shows an error
     When I log in at "Dummy SP"
-     And I go to Engineblock URL "/authentication/idp/single-sign-on"
-    Then I should see "Dummy Idp"
-
-  Scenario: A GET to the SSO endpoint without an active session shows an error
-    When I log in at "Dummy SP"
-     And I lose my session
      And I go to Engineblock URL "/authentication/idp/single-sign-on"
     Then I should see "The parameter \"SAMLRequest\" is missing on the SAML SSO request"

--- a/tests/e2e/cypress/integration/skeune/wayf/wayf.bookmarkableUrl.spec.js
+++ b/tests/e2e/cypress/integration/skeune/wayf/wayf.bookmarkableUrl.spec.js
@@ -1,0 +1,22 @@
+context('hideBookmarkableUrl', () => {
+  describe('When the URL contains a SAMLRequest parameter', () => {
+    it('replaces the URL with ?feedback=bookmark', () => {
+      cy.visit('https://engine.dev.openconext.local/functional-testing/wayf?SAMLRequest=somevalue');
+      cy.url().should('not.include', 'SAMLRequest');
+      cy.url().should('include', 'feedback=bookmark');
+    });
+  });
+
+  describe('When the URL does not contain a SAMLRequest parameter', () => {
+    it('leaves the URL unchanged', () => {
+      cy.visit('https://engine.dev.openconext.local/functional-testing/wayf');
+      cy.url().should('not.include', 'feedback=bookmark');
+    });
+
+    it('leaves other query parameters intact', () => {
+      cy.visit('https://engine.dev.openconext.local/functional-testing/wayf?connectedIdps=5');
+      cy.url().should('not.include', 'feedback=bookmark');
+      cy.url().should('include', 'connectedIdps=5');
+    });
+  });
+});

--- a/tests/unit/OpenConext/EngineBlockBundle/Controller/IdentityProviderControllerTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Controller/IdentityProviderControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Tests;
+
+use EngineBlock_ApplicationSingleton;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Exception\MissingParameterException;
+use OpenConext\EngineBlock\Service\AuthenticationStateHelperInterface;
+use OpenConext\EngineBlock\Service\RequestAccessMailer;
+use OpenConext\EngineBlock\Validator\RequestValidator;
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
+use OpenConext\EngineBlockBundle\Controller\IdentityProviderController;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Twig\Environment;
+
+class IdentityProviderControllerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private IdentityProviderController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = new IdentityProviderController(
+            Mockery::mock(EngineBlock_ApplicationSingleton::class),
+            Mockery::mock(Environment::class),
+            Mockery::mock(\Psr\Log\LoggerInterface::class),
+            Mockery::mock(RequestAccessMailer::class),
+            Mockery::mock(RequestValidator::class),
+            Mockery::mock(RequestValidator::class),
+            Mockery::mock(RequestValidator::class),
+            Mockery::mock(AuthenticationStateHelperInterface::class),
+            Mockery::mock(FeatureConfigurationInterface::class)
+        );
+    }
+
+    #[Test]
+    public function a_get_without_saml_request_redirects_to_the_stored_session_url(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('eb_last_sso_request_url', 'https://engine.example.com/authentication/idp/single-sign-on?SAMLRequest=abc');
+
+        $request = Request::create('https://engine.example.com/authentication/idp/single-sign-on');
+        $request->setSession($session);
+
+        $response = $this->controller->singleSignOnAction($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(
+            'https://engine.example.com/authentication/idp/single-sign-on?SAMLRequest=abc',
+            $response->getTargetUrl()
+        );
+    }
+
+    #[Test]
+    public function the_stored_session_url_is_consumed_on_redirect_so_it_cannot_be_reused(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('eb_last_sso_request_url', 'https://engine.example.com/authentication/idp/single-sign-on?SAMLRequest=abc');
+
+        $request = Request::create('https://engine.example.com/authentication/idp/single-sign-on');
+        $request->setSession($session);
+
+        $this->controller->singleSignOnAction($request);
+
+        $this->assertNull($session->get('eb_last_sso_request_url'));
+    }
+
+    #[Test]
+    public function a_get_without_saml_request_and_no_stored_session_url_throws_missing_parameter_exception(): void
+    {
+        $this->expectException(MissingParameterException::class);
+
+        $requestValidator = Mockery::mock(RequestValidator::class);
+        $requestValidator->shouldReceive('isValid')->andThrow(new MissingParameterException('The parameter "SAMLRequest" is missing'));
+
+        $controller = new IdentityProviderController(
+            Mockery::mock(EngineBlock_ApplicationSingleton::class),
+            Mockery::mock(Environment::class),
+            Mockery::mock(\Psr\Log\LoggerInterface::class),
+            Mockery::mock(RequestAccessMailer::class),
+            $requestValidator,
+            Mockery::mock(RequestValidator::class),
+            Mockery::mock(RequestValidator::class),
+            Mockery::mock(AuthenticationStateHelperInterface::class),
+            Mockery::mock(FeatureConfigurationInterface::class)
+        );
+
+        $session = new Session(new MockArraySessionStorage());
+        $request = Request::create('https://engine.example.com/authentication/idp/single-sign-on');
+        $request->setSession($session);
+
+        $controller->singleSignOnAction($request);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/Controller/IdentityProviderControllerTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Controller/IdentityProviderControllerTest.php
@@ -29,7 +29,7 @@ use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use OpenConext\EngineBlockBundle\Controller\IdentityProviderController;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -39,16 +39,14 @@ class IdentityProviderControllerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private IdentityProviderController $controller;
-
-    protected function setUp(): void
+    private function buildController(?RequestValidator $requestValidator = null): IdentityProviderController
     {
-        $this->controller = new IdentityProviderController(
+        return new IdentityProviderController(
             Mockery::mock(EngineBlock_ApplicationSingleton::class),
             Mockery::mock(Environment::class),
-            Mockery::mock(\Psr\Log\LoggerInterface::class),
+            Mockery::mock(LoggerInterface::class),
             Mockery::mock(RequestAccessMailer::class),
-            Mockery::mock(RequestValidator::class),
+            $requestValidator ?? Mockery::mock(RequestValidator::class),
             Mockery::mock(RequestValidator::class),
             Mockery::mock(RequestValidator::class),
             Mockery::mock(AuthenticationStateHelperInterface::class),
@@ -57,61 +55,17 @@ class IdentityProviderControllerTest extends TestCase
     }
 
     #[Test]
-    public function a_get_without_saml_request_redirects_to_the_stored_session_url(): void
-    {
-        $session = new Session(new MockArraySessionStorage());
-        $session->set('eb_last_sso_request_url', 'https://engine.example.com/authentication/idp/single-sign-on?SAMLRequest=abc');
-
-        $request = Request::create('https://engine.example.com/authentication/idp/single-sign-on');
-        $request->setSession($session);
-
-        $response = $this->controller->singleSignOnAction($request);
-
-        $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(
-            'https://engine.example.com/authentication/idp/single-sign-on?SAMLRequest=abc',
-            $response->getTargetUrl()
-        );
-    }
-
-    #[Test]
-    public function the_stored_session_url_is_consumed_on_redirect_so_it_cannot_be_reused(): void
-    {
-        $session = new Session(new MockArraySessionStorage());
-        $session->set('eb_last_sso_request_url', 'https://engine.example.com/authentication/idp/single-sign-on?SAMLRequest=abc');
-
-        $request = Request::create('https://engine.example.com/authentication/idp/single-sign-on');
-        $request->setSession($session);
-
-        $this->controller->singleSignOnAction($request);
-
-        $this->assertNull($session->get('eb_last_sso_request_url'));
-    }
-
-    #[Test]
-    public function a_get_without_saml_request_and_no_stored_session_url_throws_missing_parameter_exception(): void
+    public function a_get_without_saml_request_throws_missing_parameter_exception(): void
     {
         $this->expectException(MissingParameterException::class);
 
         $requestValidator = Mockery::mock(RequestValidator::class);
         $requestValidator->shouldReceive('isValid')->andThrow(new MissingParameterException('The parameter "SAMLRequest" is missing'));
 
-        $controller = new IdentityProviderController(
-            Mockery::mock(EngineBlock_ApplicationSingleton::class),
-            Mockery::mock(Environment::class),
-            Mockery::mock(\Psr\Log\LoggerInterface::class),
-            Mockery::mock(RequestAccessMailer::class),
-            $requestValidator,
-            Mockery::mock(RequestValidator::class),
-            Mockery::mock(RequestValidator::class),
-            Mockery::mock(AuthenticationStateHelperInterface::class),
-            Mockery::mock(FeatureConfigurationInterface::class)
-        );
-
         $session = new Session(new MockArraySessionStorage());
         $request = Request::create('https://engine.example.com/authentication/idp/single-sign-on');
         $request->setSession($session);
 
-        $controller->singleSignOnAction($request);
+        $this->buildController($requestValidator)->singleSignOnAction($request);
     }
 }

--- a/tests/unit/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/WayfTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/WayfTest.php
@@ -20,6 +20,7 @@ namespace Tests\OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
 
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Service\Wayf\WayfIdp;
+use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use OpenConext\EngineBlockBundle\Twig\Extensions\Extension\ConnectedIdps;
 use OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Wayf;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -33,12 +34,15 @@ class WayfTest extends TestCase
     private $requestStack;
     private $translator;
     private $wayf;
+    private FeatureConfigurationInterface $featureConfiguration;
 
     protected function setUp(): void
     {
         $this->requestStack = $this->createMock(RequestStack::class);
         $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->wayf = new Wayf($this->requestStack, $this->translator);
+        $this->featureConfiguration = $this->createMock(FeatureConfigurationInterface::class);
+        $this->featureConfiguration->method('isEnabled')->willReturn(false);
+        $this->wayf = new Wayf($this->requestStack, $this->translator, $this->featureConfiguration);
     }
 
     public function testGetConnectedIdpsWithEmptyPreviousSelection()
@@ -118,7 +122,7 @@ class WayfTest extends TestCase
             ->willReturn($request);
 
         // Create new wayf instance with the mocked request
-        $wayf = new Wayf($requestStack, $this->translator);
+        $wayf = new Wayf($requestStack, $this->translator, $this->featureConfiguration);
 
         $idpList = [
             new WayfIdp(
@@ -231,6 +235,7 @@ class WayfTest extends TestCase
         $this->assertEquals(5, $config['cutoffPointForShowingUnfilteredIdps']);
         $this->assertEquals(Wayf::REMEMBER_CHOICE_COOKIE_NAME, $config['rememberChoiceCookieName']);
         $this->assertTrue($config['rememberChoiceFeature']);
+        $this->assertFalse($config['hideBookmarkableUrl']);
         $this->assertEquals('More results', $config['messages']['moreIdpResults']);
         $this->assertEquals('Request Access', $config['messages']['requestAccess']);
         $this->assertStringContainsString('/authentication/idp/requestAccess', $config['requestAccessUrl']);
@@ -247,5 +252,30 @@ class WayfTest extends TestCase
 
         $config = json_decode($jsonConfig, true);
         $this->assertEmpty($config['unconnectedIdps']);
+    }
+
+    public function testGetWayfJsonConfigIncludesHideBookmarkableUrlWhenFlagEnabled()
+    {
+        $featureConfiguration = $this->createMock(FeatureConfigurationInterface::class);
+        $featureConfiguration->method('isEnabled')
+            ->with('eb.hide_bookmarkable_url')
+            ->willReturn(true);
+
+        $wayf = new Wayf($this->requestStack, $this->translator, $featureConfiguration);
+
+        $connectedIdps = $this->createMock(ConnectedIdps::class);
+        $connectedIdps->method('getFormattedPreviousSelectionList')->willReturn([]);
+        $connectedIdps->method('getConnectedIdps')->willReturn([]);
+        $connectedIdps->method('getFormattedIdpList')->willReturn([]);
+
+        $serviceProvider = $this->createMock(ServiceProvider::class);
+        $serviceProvider->entityId = 'https://sp.example.org';
+        $serviceProvider->method('getDisplayName')->willReturn('Test SP');
+
+        $this->translator->method('trans')->willReturn('');
+
+        $config = json_decode($wayf->getWayfJsonConfig($connectedIdps, $serviceProvider, 'en', false, false, 5), true);
+
+        $this->assertTrue($config['hideBookmarkableUrl']);
     }
 }

--- a/theme/base/javascripts/wayf.js
+++ b/theme/base/javascripts/wayf.js
@@ -1,7 +1,8 @@
 import {initializePage} from './page';
 import {wayfCallbackAfterLoad} from './handlers';
 import {wayfPageSelector} from './selectors';
+import {hideBookmarkableUrl} from './wayf/hideBookmarkableUrl';
 
 export function initializeWayf() {
-  initializePage(wayfPageSelector, wayfCallbackAfterLoad);
+  initializePage(wayfPageSelector, wayfCallbackAfterLoad, hideBookmarkableUrl);
 }

--- a/theme/base/javascripts/wayf/hideBookmarkableUrl.js
+++ b/theme/base/javascripts/wayf/hideBookmarkableUrl.js
@@ -1,0 +1,17 @@
+/**
+ * Replace SAML query parameters in the URL bar with ?feedback=bookmark to prevent broken bookmarks
+ */
+export const hideBookmarkableUrl = () => {
+  if (!window.history || !window.history.replaceState) {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has('SAMLRequest')) {
+    return;
+  }
+
+  const cleanUrl = new URL(window.location.pathname, window.location.origin);
+  cleanUrl.searchParams.set('feedback', 'bookmark');
+  window.history.replaceState(null, '', cleanUrl.toString());
+};

--- a/theme/base/javascripts/wayf/hideBookmarkableUrl.js
+++ b/theme/base/javascripts/wayf/hideBookmarkableUrl.js
@@ -1,7 +1,14 @@
-/**
- * Replace SAML query parameters in the URL bar with ?feedback=bookmark to prevent broken bookmarks
- */
 export const hideBookmarkableUrl = () => {
+  const configEl = document.getElementById('wayf-configuration');
+  if (!configEl) {
+    return;
+  }
+
+  const config = JSON.parse(configEl.innerHTML);
+  if (!config.hideBookmarkableUrl) {
+    return;
+  }
+
   if (!window.history || !window.history.replaceState) {
     return;
   }


### PR DESCRIPTION
Prior to this change, users would bookmark the wayf. This caused expired/old saml requests from being handled by EB. EB does not have issues with that, but the SP might.

This change prevents users from bookmarking SAML requests.

Resolves #1973 