### PR TITLE
Clear, manage and rework feedback data storage in session

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -82,6 +82,10 @@ jobs:
                 if: always()
                 run: |
                     cd docker && docker compose exec -T --user www-data engine.dev.openconext.local bash -c '
+                        echo -e "\nContainer lint\n"  && \
+                        bin/console lint:container --env=ci && \
+                        echo -e "\nYAML lint\n"  && \
+                        bin/console lint:yaml config/ && \
                         echo -e "\nTwig lint\n"  && \
                         bin/console lint:twig theme/ && \
                         cd theme && \

--- a/ci/qa/lint.sh
+++ b/ci/qa/lint.sh
@@ -3,6 +3,12 @@ set -e
 
 cd $(dirname $0)/../../
 
+echo -e "\nContainer lint\n"
+bin/console lint:container --env=ci
+
+echo -e "\nYAML lint\n"
+bin/console lint:yaml config/
+
 echo -e "\nTwig lint\n"
 bin/console lint:twig theme/
 

--- a/config/services/bridge.yml
+++ b/config/services/bridge.yml
@@ -7,6 +7,8 @@ services:
             - '@engineblock.compat.application'
             - '@logger'
             - '@request_stack'
+            - '@OpenConext\EngineBlock\Service\FeedbackStateHelper'
+            - '@OpenConext\EngineBlock\Service\FeedbackInfoCollector'
 
     OpenConext\EngineBlockBridge\Logger\AuthenticationLoggerAdapter:
         arguments:

--- a/config/services/ci/controllers.yml
+++ b/config/services/ci/controllers.yml
@@ -27,6 +27,7 @@ services:
             - '@translator'
             - '@twig'
             - '@engineblock.compat.logger'
+            - '@OpenConext\EngineBlock\Service\FeedbackStateHelper'
 
     engineblock.functional_test.controller.consent:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Controllers\ConsentController

--- a/config/services/ci/controllers.yml
+++ b/config/services/ci/controllers.yml
@@ -24,9 +24,7 @@ services:
     engineblock.functional_test.controller.feedback:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Controllers\FeedbackController
         arguments:
-            - '@translator'
             - '@twig'
-            - '@engineblock.compat.logger'
             - '@OpenConext\EngineBlock\Service\FeedbackStateHelper'
 
     engineblock.functional_test.controller.consent:

--- a/config/services/controllers/authentication.yml
+++ b/config/services/controllers/authentication.yml
@@ -32,7 +32,7 @@ services:
         arguments:
             - '@translator'
             - '@twig'
-            - '@engineblock.compat.logger'
+            - '@OpenConext\EngineBlock\Service\FeedbackStateHelper'
 
     OpenConext\EngineBlockBundle\Controller\MetadataController:
         arguments:

--- a/config/services/services.yml
+++ b/config/services/services.yml
@@ -80,6 +80,24 @@ services:
         arguments:
             - '@request_stack'
 
+    OpenConext\EngineBlock\Service\FeedbackStateHelper:
+        arguments:
+            - '@request_stack'
+
+    OpenConext\EngineBlock\Service\FeedbackStateHelperInterface:
+        alias: OpenConext\EngineBlock\Service\FeedbackStateHelper
+
+    OpenConext\EngineBlock\Service\FeedbackInfoCollector:
+        arguments:
+            - '@request_stack'
+            - '@OpenConext\EngineBlock\Request\RequestId'
+            - '@OpenConext\EngineBlock\Metadata\MetadataRepository\CachedDoctrineMetadataRepository'
+            - '@OpenConext\EngineBlockBundle\Localization\LocaleProvider'
+            - '@OpenConext\EngineBlock\Service\FeedbackStateHelper'
+
+    OpenConext\EngineBlock\Service\FeedbackInfoCollectorInterface:
+        alias: OpenConext\EngineBlock\Service\FeedbackInfoCollector
+
     OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper:
         arguments:
             - '@OpenConext\EngineBlock\Stepup\StepupGatewayLoaMapping'
@@ -330,6 +348,7 @@ services:
             - '@OpenConext\EngineBlockBundle\Configuration\ErrorFeedbackConfiguration'
             - '@engineblock.compat.repository.metadata'
             - '@OpenConext\EngineBlockBundle\Authentication\Service\SamlResponseHelper'
+            - '@OpenConext\EngineBlock\Service\FeedbackStateHelper'
 
     OpenConext\EngineBlockBundle\Twig\Extensions\Extension\GlobalSiteNotice:
         autoconfigure: true

--- a/library/EngineBlock/ApplicationSingleton.php
+++ b/library/EngineBlock/ApplicationSingleton.php
@@ -17,10 +17,8 @@
  */
 
 use OpenConext\EngineBlock\Logger\Handler\FingersCrossed\ManualOrDecoratedActivationStrategy;
-use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
 use OpenConext\EngineBlock\Request\RequestId;
 use OpenConext\EngineBlockBundle\Bridge\DiContainerRuntime;
-use OpenConext\EngineBlockBundle\Exception\Art;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
@@ -238,58 +236,16 @@ class EngineBlock_ApplicationSingleton
         // Store some valuable debug info in session so it can be displayed on feedback pages
         if($this->hasSession()) {
             // In CLI context, the session is not available
-            $this->getSession()->set('feedbackInfo', $this->collectFeedbackInfo($exception));
+            $feedbackHelper = $this->getDiContainerRuntime()->feedbackStateHelper;
+            $feedbackHelper->storeFeedbackInfo(
+                $this->getDiContainerRuntime()->feedbackInfoCollector->collect($exception)
+            );
         }
 
         // flush all messages in queue, something went wrong!
         $this->flushLog('An error was caught');
 
         return true;
-    }
-
-    /**
-     * @param Exception $exception
-     * @return array
-     */
-    public function collectFeedbackInfo(Throwable $exception)
-    {
-        $logRequestId = $this->getLogRequestId();
-        if ($logRequestId === null) {
-            $logRequestId = 'N/A - application not yet bootstrapped';
-        } else {
-            $logRequestId = $logRequestId->get();
-        }
-
-        $request = $this->getDiContainer()->getSymfonyRequest();
-
-        $feedbackInfo = array();
-        $feedbackInfo['datetime'] = (new DateTime())->format(DateTimeInterface::ATOM);
-        $feedbackInfo['requestUrl'] = sprintf('%s%s', $request->getSchemeAndHttpHost(), $request->getPathInfo());
-        $feedbackInfo['requestId'] = $logRequestId;
-        $feedbackInfo['ipAddress'] = $this->getClientIpAddress();
-        $feedbackInfo['artCode'] = Art::forException($exception);
-
-        // @todo  reset this when login is succesful
-        // Find the current identity provider
-        $spEntityId = $_SESSION['originalServiceProvider'] ?? $_SESSION['currentServiceProvider'] ?? null;
-        if ($spEntityId !== null) {
-            $feedbackInfo['serviceProvider'] = $spEntityId;
-            $feedbackInfo['serviceProviderName'] = $this->getServiceProviderName($spEntityId);
-        }
-
-        if (isset($_SESSION['proxyServiceProvider'])) {
-            $feedbackInfo['proxyServiceProvider'] = $_SESSION['proxyServiceProvider'];
-        }
-
-        // @todo  reset this when login is succesful
-        // Find the current identity provider
-        if (isset($_SESSION['currentIdentityProvider'])) {
-            $idpEntityId = $_SESSION['currentIdentityProvider'];
-            $feedbackInfo['identityProvider'] = $idpEntityId;
-            $feedbackInfo['identityProviderName'] = $this->getidentityProviderName($idpEntityId);
-        }
-
-        return $feedbackInfo;
     }
 
     /**
@@ -441,26 +397,4 @@ class EngineBlock_ApplicationSingleton
         return $this->_diContainer;
     }
 
-    /**
-     * @param string $serviceProviderId
-     * @return string
-     */
-    private function getServiceProviderName(string $serviceProviderId){
-        try {
-            $serviceProvider = $this->getDiContainer()->getMetadataRepository()->fetchServiceProviderByEntityId($serviceProviderId);
-            return $serviceProvider->getDisplayName($this->getDiContainer()->getLocaleProvider()->getLocale());
-        } catch (EntityNotFoundException $e) {}
-
-        return '';
-    }
-
-    private function getIdentityProviderName(string $identityProviderId): string
-    {
-        try {
-            $identityProvider = $this->getDiContainer()->getMetadataRepository()->fetchIdentityProviderByEntityId($identityProviderId);
-            return $identityProvider->getDisplayName($this->getDiContainer()->getLocaleProvider()->getLocale());
-        } catch (EntityNotFoundException $e) {}
-
-        return '';
-    }
 }

--- a/library/EngineBlock/Corto/Module/Bindings.php
+++ b/library/EngineBlock/Corto/Module/Bindings.php
@@ -180,8 +180,11 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
                 'Missing <saml:Issuer> in message delivered to AssertionConsumerService.'
             );
         }
-        // Remember sp for debugging
-        $_SESSION['currentServiceProvider'] = $ebRequest->getIssuer()->getValue();
+
+        EngineBlock_ApplicationSingleton::getInstance()->getDiContainerRuntime()->feedbackStateHelper->startNewFlow(
+            $ebRequest->getId(),
+            $ebRequest->getIssuer()->getValue()
+        );
 
         // Verify that we know this SP and have metadata for it.
         $serviceProvider = $this->_verifyKnownSP($spEntityId->getValue());
@@ -324,7 +327,7 @@ class EngineBlock_Corto_Module_Bindings extends EngineBlock_Corto_Module_Abstrac
         }
 
         // Remember idp for debugging
-        $_SESSION['currentIdentityProvider'] = $idpEntityId;
+        EngineBlock_ApplicationSingleton::getInstance()->getDiContainerRuntime()->feedbackStateHelper->setCurrentIdentityProvider($idpEntityId->getValue());
 
         // Verify that we know this IdP and have metadata for it.
         $cortoIdpMetadata = $this->_verifyKnownIdP(

--- a/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/AssertionConsumer.php
@@ -19,6 +19,7 @@
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactory;
 use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
 use OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper;
 use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
@@ -31,33 +32,19 @@ use Symfony\Component\HttpFoundation\Session\Session;
 
 class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_Corto_Module_Service_ServiceInterface
 {
-    /**
-     * @var EngineBlock_Corto_ProxyServer
-     */
-    private $_server;
+    private EngineBlock_Corto_ProxyServer $_server;
 
-    /**
-     * @var EngineBlock_Corto_XmlToArray
-     */
-    private $_xmlConverter;
+    private EngineBlock_Corto_XmlToArray $_xmlConverter;
 
-    /**
-     * @var Session
-     */
-    private $_session;
+    private Session $_session;
 
-    /**
-     * @var ProcessingStateHelperInterface
-     */
-    private $_processingStateHelper;
-    /**
-     * @var StepupGatewayCallOutHelper
-     */
-    private $_stepupGatewayCallOutHelper;
-    /**
-     * @var ServiceProviderFactory
-     */
-    private $_serviceProviderFactory;
+    private ProcessingStateHelperInterface $_processingStateHelper;
+
+    private StepupGatewayCallOutHelper $_stepupGatewayCallOutHelper;
+
+    private ServiceProviderFactory $_serviceProviderFactory;
+
+    private FeedbackStateHelperInterface $_feedbackStateHelper;
 
     public function __construct(
         EngineBlock_Corto_ProxyServer $server,
@@ -65,7 +52,8 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         Session $session,
         ProcessingStateHelperInterface $processingStateHelper,
         StepupGatewayCallOutHelper $stepupGatewayCallOutHelper,
-        ServiceProviderFactory $serviceProviderFactory
+        ServiceProviderFactory $serviceProviderFactory,
+        FeedbackStateHelperInterface $feedbackStateHelper
     )
     {
         $this->_server = $server;
@@ -74,6 +62,7 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         $this->_processingStateHelper = $processingStateHelper;
         $this->_stepupGatewayCallOutHelper = $stepupGatewayCallOutHelper;
         $this->_serviceProviderFactory = $serviceProviderFactory;
+        $this->_feedbackStateHelper = $feedbackStateHelper;
     }
 
     /**
@@ -126,8 +115,7 @@ class EngineBlock_Corto_Module_Service_AssertionConsumer implements EngineBlock_
         if ($sp->getCoins()->isTrustedProxy()) {
             $proxySp = $sp;
             $sp = $this->_server->findOriginalServiceProvider($receivedRequest, $log);
-            $_SESSION['originalServiceProvider'] = $sp->entityId;
-            $_SESSION['proxyServiceProvider'] = $proxySp->entityId;
+            $this->_feedbackStateHelper->setProxyContext($sp->entityId, $proxySp->entityId);
         }
 
         // Verify the SP requester chain.

--- a/library/EngineBlock/Corto/Module/Service/ProcessedAssertionConsumer.php
+++ b/library/EngineBlock/Corto/Module/Service/ProcessedAssertionConsumer.php
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -31,12 +32,19 @@ class EngineBlock_Corto_Module_Service_ProcessedAssertionConsumer implements Eng
      */
     private $_processingStateHelper;
 
+    /**
+     * @var FeedbackStateHelperInterface
+     */
+    private $_feedbackStateHelper;
+
     public function __construct(
         EngineBlock_Corto_ProxyServer $server,
-        ProcessingStateHelperInterface $processingStateHelper
+        ProcessingStateHelperInterface $processingStateHelper,
+        FeedbackStateHelperInterface $feedbackStateHelper
     ) {
         $this->_server = $server;
         $this->_processingStateHelper = $processingStateHelper;
+        $this->_feedbackStateHelper = $feedbackStateHelper;
     }
 
     /**
@@ -84,6 +92,8 @@ class EngineBlock_Corto_Module_Service_ProcessedAssertionConsumer implements Eng
 
         $sentResponse = $this->_server->createEnhancedResponse($receivedRequest, $response);
         $this->_server->sendResponseToRequestIssuer($receivedRequest, $sentResponse);
+
+        $this->_feedbackStateHelper->clearFlowContext();
         return;
     }
 }

--- a/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
+++ b/library/EngineBlock/Corto/Module/Service/SingleSignOn.php
@@ -186,8 +186,7 @@ class EngineBlock_Corto_Module_Service_SingleSignOn implements EngineBlock_Corto
             // When a trusted proxy is used, the originalServiceProvider is set to the entityId of the original issuing
             // SP. This prevents the display of the Proxy in the feedback information.
             if (isset($proxySp) && $proxySp->getCoins()->isTrustedProxy()) {
-                $_SESSION['originalServiceProvider'] = $sp->entityId;
-                $_SESSION['proxyServiceProvider'] = $proxySp->entityId;
+                EngineBlock_ApplicationSingleton::getInstance()->getDiContainerRuntime()->feedbackStateHelper->setProxyContext($sp->entityId, $proxySp->entityId);
             }
             throw new EngineBlock_Corto_Module_Service_SingleSignOn_NoIdpsException('No candidate IdPs found');
         }

--- a/library/EngineBlock/Corto/Module/Services.php
+++ b/library/EngineBlock/Corto/Module/Services.php
@@ -110,12 +110,14 @@ class EngineBlock_Corto_Module_Services extends EngineBlock_Corto_Module_Abstrac
                     $diContainer->getSession(),
                     $diContainer->getProcessingStateHelper(),
                     $diContainer->getStepupGatewayCallOutHelper(),
-                    $diContainer->getServiceProviderFactory()
+                    $diContainer->getServiceProviderFactory(),
+                    $diContainerRuntime->feedbackStateHelper
                 );
             case EngineBlock_Corto_Module_Service_ProcessedAssertionConsumer::class :
                 return new EngineBlock_Corto_Module_Service_ProcessedAssertionConsumer(
                     $server,
-                    $diContainer->getProcessingStateHelper()
+                    $diContainer->getProcessingStateHelper(),
+                    $diContainerRuntime->feedbackStateHelper
                 );
             case EngineBlock_Corto_Module_Service_StepupAssertionConsumer::class :
                 return new EngineBlock_Corto_Module_Service_StepupAssertionConsumer(

--- a/library/EngineBlock/SamlHelper.php
+++ b/library/EngineBlock/SamlHelper.php
@@ -120,8 +120,7 @@ class EngineBlock_SamlHelper
         // The filters will log any additional information that is available.
         $lastRequesterEntity = $repository->findServiceProviderByEntityId($lastRequesterEntityId, $logger);
         if (!$lastRequesterEntity) {
-            $_SESSION['originalServiceProvider'] = $lastRequesterEntityId;
-            $_SESSION['proxyServiceProvider'] = $serviceProvider->entityId;
+            EngineBlock_ApplicationSingleton::getInstance()->getDiContainerRuntime()->feedbackStateHelper->setProxyContext($lastRequesterEntityId, $serviceProvider->entityId);
             throw new EngineBlock_Exception_UnknownServiceProvider(
                 'Invalid RequesterID specified',
                 $lastRequesterEntityId,

--- a/src/OpenConext/EngineBlock/Service/FeedbackInfoCollector.php
+++ b/src/OpenConext/EngineBlock/Service/FeedbackInfoCollector.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use DateTime;
+use DateTimeInterface;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Request\RequestId;
+use OpenConext\EngineBlockBundle\Exception\Art;
+use OpenConext\EngineBlockBundle\Localization\LocaleProvider;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Throwable;
+
+/**
+ * If trouble occurs, this class gathers the details from the session.
+ */
+class FeedbackInfoCollector implements FeedbackInfoCollectorInterface
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly RequestId $requestId,
+        private readonly MetadataRepositoryInterface $metadataRepository,
+        private readonly LocaleProvider $localeProvider,
+        private readonly FeedbackStateHelperInterface $feedbackStateHelper,
+    ) {
+    }
+
+    public function collect(Throwable $exception): array
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        $feedbackInfo = [
+            'datetime'   => (new DateTime())->format(DateTimeInterface::ATOM),
+            'requestUrl' => $request !== null
+                ? sprintf('%s%s', $request->getSchemeAndHttpHost(), $request->getPathInfo())
+                : 'N/A',
+            'requestId'  => $this->requestId->get(),
+            'ipAddress'  => $request?->getClientIp() ?? 'N/A',
+            'artCode'    => Art::forException($exception),
+        ];
+
+        $bucket = $this->feedbackStateHelper->getActiveFlowContext();
+
+        $spEntityId = $bucket['originalServiceProvider'] ?? $bucket['serviceProvider'] ?? null;
+        if ($spEntityId !== null) {
+            $feedbackInfo['serviceProvider']     = $spEntityId;
+            $feedbackInfo['serviceProviderName'] = $this->getEntityDisplayName('sp', $spEntityId);
+        }
+
+        if (isset($bucket['proxyServiceProvider'])) {
+            $feedbackInfo['proxyServiceProvider'] = $bucket['proxyServiceProvider'];
+        }
+
+        if (isset($bucket['identityProvider'])) {
+            $idpEntityId = $bucket['identityProvider'];
+            $feedbackInfo['identityProvider']     = $idpEntityId;
+            $feedbackInfo['identityProviderName'] = $this->getEntityDisplayName('idp', $idpEntityId);
+        }
+
+        return $feedbackInfo;
+    }
+
+    private function getEntityDisplayName(string $type, string $entityId): string
+    {
+        $locale = $this->localeProvider->getLocale();
+        try {
+            $entity = $type === 'sp'
+                ? $this->metadataRepository->fetchServiceProviderByEntityId($entityId)
+                : $this->metadataRepository->fetchIdentityProviderByEntityId($entityId);
+            return $entity->getDisplayName($locale);
+        } catch (EntityNotFoundException) {
+            return '';
+        }
+    }
+}

--- a/src/OpenConext/EngineBlock/Service/FeedbackInfoCollectorInterface.php
+++ b/src/OpenConext/EngineBlock/Service/FeedbackInfoCollectorInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use Throwable;
+
+interface FeedbackInfoCollectorInterface
+{
+    /**
+     * Returns a feedback-info array populated from the current request, session state,
+     * ART code, and SP/IdP display names.
+     */
+    public function collect(Throwable $exception): array;
+}

--- a/src/OpenConext/EngineBlock/Service/FeedbackStateHelper.php
+++ b/src/OpenConext/EngineBlock/Service/FeedbackStateHelper.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * Tracks details about the various operations a user performs throughout the SAML flows
+ */
+class FeedbackStateHelper implements FeedbackStateHelperInterface
+{
+    private const EARLY_FEEDBACK_KEY = '_early';
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    private function session(): SessionInterface
+    {
+        return $this->requestStack->getSession();
+    }
+
+    public function storeFeedbackInfo(array $feedback): void
+    {
+        $requestKey = $this->session()->get('currentSamlRequestId') ?? self::EARLY_FEEDBACK_KEY;
+        $all = $this->session()->get('feedbackInfo') ?: [];
+        $all[$requestKey] = $feedback;
+        $this->session()->set('feedbackInfo', $all);
+        $this->session()->set('currentFeedbackKey', $requestKey);
+    }
+
+    public function getFeedbackInfo(): array
+    {
+        $feedbackKey = $this->session()->get('currentFeedbackKey');
+        if ($feedbackKey === null) {
+            return [];
+        }
+        return ($this->session()->get('feedbackInfo') ?: [])[$feedbackKey] ?? [];
+    }
+
+    public function getActiveFlowContext(): array
+    {
+        $currentRequestId = $this->session()->get('currentSamlRequestId');
+        if ($currentRequestId === null) {
+            return [];
+        }
+        return ($this->session()->get('feedbackInfo') ?: [])[$currentRequestId] ?? [];
+    }
+
+    public function mergeFeedbackInfo(array $defaults): void
+    {
+        $feedbackKey = $this->session()->get('currentFeedbackKey') ?? self::EARLY_FEEDBACK_KEY;
+        $all = $this->session()->get('feedbackInfo') ?: [];
+        $all[$feedbackKey] = array_merge($defaults, $all[$feedbackKey] ?? []);
+        $this->session()->set('feedbackInfo', $all);
+    }
+
+    public function clearFeedbackInfo(): void
+    {
+        $currentRequestId = $this->session()->get('currentSamlRequestId');
+        if ($currentRequestId !== null) {
+            $all = $this->session()->get('feedbackInfo') ?: [];
+            unset($all[$currentRequestId]);
+            if (empty($all)) {
+                $this->session()->remove('feedbackInfo');
+            } else {
+                $this->session()->set('feedbackInfo', $all);
+            }
+        }
+        $this->session()->remove('currentSamlRequestId');
+        // currentFeedbackKey is intentionally preserved so error pages remain accessible after a subsequent successful login.
+    }
+
+    public function startNewFlow(string $samlRequestId, string $serviceProviderId): void
+    {
+        $this->session()->set('currentSamlRequestId', $samlRequestId);
+        $all = $this->session()->get('feedbackInfo') ?: [];
+        $all[$samlRequestId] = ['serviceProvider' => $serviceProviderId];
+        $this->session()->set('feedbackInfo', $all);
+    }
+
+    public function setCurrentIdentityProvider(string $idpEntityId): void
+    {
+        $currentRequestId = $this->session()->get('currentSamlRequestId');
+        if ($currentRequestId === null) {
+            return;
+        }
+        $all = $this->session()->get('feedbackInfo') ?: [];
+        $all[$currentRequestId]['identityProvider'] = $idpEntityId;
+        $this->session()->set('feedbackInfo', $all);
+    }
+
+    public function setProxyContext(string $originalSpId, string $proxySpId): void
+    {
+        $currentRequestId = $this->session()->get('currentSamlRequestId');
+        if ($currentRequestId === null) {
+            return;
+        }
+        $all = $this->session()->get('feedbackInfo') ?: [];
+        $all[$currentRequestId]['originalServiceProvider'] = $originalSpId;
+        $all[$currentRequestId]['proxyServiceProvider'] = $proxySpId;
+        $this->session()->set('feedbackInfo', $all);
+    }
+
+    public function clearFlowContext(): void
+    {
+        $this->clearFeedbackInfo();
+    }
+}

--- a/src/OpenConext/EngineBlock/Service/FeedbackStateHelperInterface.php
+++ b/src/OpenConext/EngineBlock/Service/FeedbackStateHelperInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+/**
+ * Manages the feedback (error context) state for an authentication flow.
+ *
+ * Feedback info is keyed by SAML request ID so that concurrent or sequential
+ * flows do not bleed their error context into each other.
+ */
+interface FeedbackStateHelperInterface
+{
+    public function storeFeedbackInfo(array $feedback): void;
+
+    public function getFeedbackInfo(): array;
+
+    /**
+     * Returns the feedback bucket for the actively running SAML flow (keyed by
+     * currentSamlRequestId). Use this when you need the SP/IdP context that was
+     * accumulated during the current flow (e.g. during error collection), before
+     * storeFeedbackInfo() has been called for this flow.
+     */
+    public function getActiveFlowContext(): array;
+
+    public function mergeFeedbackInfo(array $defaults): void;
+
+    public function clearFeedbackInfo(): void;
+
+    public function startNewFlow(string $samlRequestId, string $serviceProviderId): void;
+
+    public function setCurrentIdentityProvider(string $idpEntityId): void;
+
+    public function setProxyContext(string $originalSpId, string $proxySpId): void;
+
+    public function clearFlowContext(): void;
+}

--- a/src/OpenConext/EngineBlockBridge/ErrorReporter.php
+++ b/src/OpenConext/EngineBlockBridge/ErrorReporter.php
@@ -23,32 +23,31 @@ use EngineBlock_Corto_Exception_HasFeedbackInfoInterface;
 use EngineBlock_Corto_Exception_PEPNoAccess;
 use EngineBlock_Exception;
 use Exception;
+use OpenConext\EngineBlock\Service\FeedbackInfoCollectorInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class ErrorReporter
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-    /**
-     * @var EngineBlock_ApplicationSingleton
-     */
-    private $engineBlockApplicationSingleton;
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
+    private LoggerInterface $logger;
+    private EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton;
+    private RequestStack $requestStack;
+    private FeedbackStateHelperInterface $feedbackStateHelper;
+    private FeedbackInfoCollectorInterface $feedbackInfoCollector;
 
     public function __construct(
         EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton,
         LoggerInterface $logger,
         RequestStack $requestStack,
+        FeedbackStateHelperInterface $feedbackStateHelper,
+        FeedbackInfoCollectorInterface $feedbackInfoCollector,
     ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
         $this->logger = $logger;
         $this->requestStack = $requestStack;
+        $this->feedbackStateHelper = $feedbackStateHelper;
+        $this->feedbackInfoCollector = $feedbackInfoCollector;
     }
 
     public function reportError(Exception $exception, string $messageSuffix): void
@@ -94,18 +93,18 @@ class ErrorReporter
             return;
         }
 
-        $session  = $this->requestStack->getSession();
-        $feedback = $session->get('feedbackInfo') ?: [];
+        $session = $this->requestStack->getSession();
 
-        if ($exception instanceof EngineBlock_Corto_Exception_HasFeedbackInfoInterface) {
-            $feedback = array_merge($feedback, $exception->getFeedbackInfo());
-        } elseif ($exception instanceof EngineBlock_Corto_Exception_PEPNoAccess) {
+        if ($exception instanceof EngineBlock_Corto_Exception_PEPNoAccess) {
             $session->set('error_authorization_policy_decision', $exception->getPolicyDecision());
         }
 
-        $session->set('feedbackInfo', array_merge(
-            $feedback,
-            $this->engineBlockApplicationSingleton->collectFeedbackInfo($exception)
-        ));
+        $feedback = $this->feedbackInfoCollector->collect($exception);
+
+        if ($exception instanceof EngineBlock_Corto_Exception_HasFeedbackInfoInterface) {
+            $feedback = array_merge($feedback, $exception->getFeedbackInfo());
+        }
+
+        $this->feedbackStateHelper->storeFeedbackInfo($feedback);
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Bridge/DiContainerRuntime.php
+++ b/src/OpenConext/EngineBlockBundle/Bridge/DiContainerRuntime.php
@@ -18,6 +18,8 @@
 
 namespace OpenConext\EngineBlockBundle\Bridge;
 
+use OpenConext\EngineBlock\Service\FeedbackInfoCollectorInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlockBundle\Service\WayfRenderer;
 use Twig\Environment;
 
@@ -33,6 +35,8 @@ final readonly class DiContainerRuntime
     public function __construct(
         public Environment $twig,
         public WayfRenderer $wayfRenderer,
+        public FeedbackStateHelperInterface $feedbackStateHelper,
+        public FeedbackInfoCollectorInterface $feedbackInfoCollector,
         private array $preferredIdpEntityIds = [],
     ) {
     }

--- a/src/OpenConext/EngineBlockBundle/Bridge/EngineBlockBootstrapper.php
+++ b/src/OpenConext/EngineBlockBundle/Bridge/EngineBlockBootstrapper.php
@@ -19,6 +19,8 @@
 namespace OpenConext\EngineBlockBundle\Bridge;
 
 use EngineBlock_ApplicationSingleton;
+use OpenConext\EngineBlock\Service\FeedbackInfoCollectorInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlockBundle\Service\WayfRenderer;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -31,9 +33,17 @@ class EngineBlockBootstrapper implements EventSubscriberInterface
     public function __construct(
         Environment $twig,
         WayfRenderer $wayfRenderer,
+        FeedbackStateHelperInterface $feedbackStateHelper,
+        FeedbackInfoCollectorInterface $feedbackInfoCollector,
         array $preferredIdpEntityIds = [],
     ) {
-        $this->diContainerRuntime = new DiContainerRuntime($twig, $wayfRenderer, $preferredIdpEntityIds);
+        $this->diContainerRuntime = new DiContainerRuntime(
+            $twig,
+            $wayfRenderer,
+            $feedbackStateHelper,
+            $feedbackInfoCollector,
+            $preferredIdpEntityIds,
+        );
     }
 
     public function onKernelRequest(): void

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -18,12 +18,10 @@
 
 namespace OpenConext\EngineBlockBundle\Controller;
 
-use EngineBlock_Corto_ProxyServer;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlockBundle\Pdp\PolicyDecision;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
@@ -35,33 +33,20 @@ use Twig\Environment;
  */
 class FeedbackController
 {
-    /**
-     * @var \Symfony\Contracts\Translation\TranslatorInterface
-     */
-    private $translator;
+    private TranslatorInterface $translator;
 
-    /**
-     * @var Environment
-     */
-    private $twig;
+    private Environment $twig;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private FeedbackStateHelperInterface $feedbackStateHelper;
 
     public function __construct(
         TranslatorInterface $translator,
         Environment $twig,
-        LoggerInterface $logger
+        FeedbackStateHelperInterface $feedbackStateHelper
     ) {
         $this->translator = $translator;
         $this->twig = $twig;
-        $this->logger = $logger;
-
-        // we have to start the old session in order to be able to retrieve the feedback info
-        $server = new EngineBlock_Corto_ProxyServer($twig);
-        $server->startSession();
+        $this->feedbackStateHelper = $feedbackStateHelper;
     }
 
     #[Route(
@@ -173,7 +158,7 @@ class FeedbackController
 
         // Add feedback info from url
         $customFeedbackInfo = ['EntityID' => $entityId];
-        $this->setFeedbackInformationOnSession($request->getSession(), $customFeedbackInfo);
+        $this->setFeedbackInformationOnSession($customFeedbackInfo);
 
         $body = $this->twig->render(
             '@theme/Authentication/View/Feedback/unknown-service-provider.html.twig',
@@ -194,7 +179,7 @@ class FeedbackController
             'Destination' => $request->query->get('destination'),
         ];
 
-        $this->setFeedbackInformationOnSession($request->getSession(), $customFeedbackInfo);
+        $this->setFeedbackInformationOnSession($customFeedbackInfo);
 
         $body = $this->twig->render('@theme/Authentication/View/Feedback/unknown-identity-provider.html.twig');
 
@@ -250,12 +235,12 @@ class FeedbackController
 
 
     #[Route(path: '/authentication/feedback/invalid-attribute-value', name: 'authentication_feedback_invalid_attribute_value', methods: ['GET'])]
-    public function invalidAttributeValueAction(Request $request)
+    public function invalidAttributeValueAction()
     {
-        $feedbackInfo = $request->getSession()->get('feedbackInfo');
+        $feedbackInfo = $this->feedbackStateHelper->getFeedbackInfo();
 
-        $attributeName = $feedbackInfo['attributeName'];
-        $attributeValue = $feedbackInfo['attributeValue'];
+        $attributeName  = $feedbackInfo['attributeName'] ?? '';
+        $attributeValue = $feedbackInfo['attributeValue'] ?? '';
 
         return new Response(
             $this->twig->render(
@@ -421,7 +406,7 @@ class FeedbackController
         $customFeedbackInfo = [
             'Idp Hash' => $request->query->get('idp-hash'),
         ];
-        $this->setFeedbackInformationOnSession($request->getSession(), $customFeedbackInfo);
+        $this->setFeedbackInformationOnSession($customFeedbackInfo);
 
         return new Response(
             $this->twig->render('@theme/Authentication/View/Feedback/unknown-preselected-idp.html.twig'),
@@ -436,7 +421,7 @@ class FeedbackController
         $customFeedbackInfo = [
             'Key ID' => $request->query->get('keyid'),
         ];
-        $this->setFeedbackInformationOnSession($request->getSession(), $customFeedbackInfo);
+        $this->setFeedbackInformationOnSession($customFeedbackInfo);
 
         return new Response(
             $this->twig->render('@theme/Authentication/View/Feedback/unknown-keyid.html.twig'),
@@ -539,13 +524,8 @@ class FeedbackController
         );
     }
 
-    /**
-     * @param SessionInterface $session
-     * @param array $customFeedbackInfo
-     */
-    private function setFeedbackInformationOnSession(SessionInterface $session, array $customFeedbackInfo)
+    private function setFeedbackInformationOnSession(array $customFeedbackInfo): void
     {
-        $feedbackInfo = $session->get('feedbackInfo', []);
-        $session->set('feedbackInfo', array_merge($customFeedbackInfo, $feedbackInfo));
+        $this->feedbackStateHelper->mergeFeedbackInfo($customFeedbackInfo);
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
+++ b/src/OpenConext/EngineBlockBundle/Twig/Extensions/Extension/Feedback.php
@@ -21,6 +21,7 @@ namespace OpenConext\EngineBlockBundle\Twig\Extensions\Extension;
 use EngineBlock_ApplicationSingleton;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlockBundle\Authentication\Service\SamlResponseHelper;
 use OpenConext\EngineBlockBundle\Configuration\ErrorFeedbackConfigurationInterface;
 use OpenConext\EngineBlockBundle\Value\FeedbackInformation;
@@ -50,16 +51,23 @@ class Feedback
      */
     private $samlResponseHelper;
 
+    /**
+     * @var FeedbackStateHelperInterface
+     */
+    private $feedbackStateHelper;
+
     public function __construct(
         EngineBlock_ApplicationSingleton $application,
         ErrorFeedbackConfigurationInterface $errorFeedbackConfiguration,
         MetadataRepositoryInterface $metadataRepository,
-        SamlResponseHelper $samlResponseHelper
+        SamlResponseHelper $samlResponseHelper,
+        FeedbackStateHelperInterface $feedbackStateHelper
     ) {
         $this->application = $application;
         $this->errorFeedbackConfiguration = $errorFeedbackConfiguration;
         $this->metadataRepository = $metadataRepository;
         $this->samlResponseHelper = $samlResponseHelper;
+        $this->feedbackStateHelper = $feedbackStateHelper;
     }
 
     #[AsTwigFunction(name: 'flushLog')]
@@ -171,8 +179,7 @@ class Feedback
     #[AsTwigFunction(name: 'getSamlFailedResponse')]
     public function getSamlFailedResponse(): string
     {
-        $session = $this->application->getSession();
-        $feedbackInfo = $session->get('feedbackInfo');
+        $feedbackInfo = $this->feedbackStateHelper->getFeedbackInfo();
         // If AuthnFailedResponse is not set, we are unable to render a createAuthnFailedResponse
         $sspResponse = $feedbackInfo['AuthnFailedResponse'] ?? null;
         $value = '';
@@ -196,8 +203,7 @@ class Feedback
      */
     private function retrieveFeedbackInfo()
     {
-        $session = $this->application->getSession();
-        $feedbackInfo = $session->get('feedbackInfo');
+        $feedbackInfo = $this->feedbackStateHelper->getFeedbackInfo();
         $feedbackInfoMap = new FeedbackInformationMap();
 
         // Remove the empty valued feedback info entries.

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/FeedbackController.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Controllers/FeedbackController.php
@@ -18,12 +18,10 @@
 
 namespace OpenConext\EngineBlockFunctionalTestingBundle\Controllers;
 
-use EngineBlock_Corto_ProxyServer;
-use Psr\Log\LoggerInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
 /**
@@ -32,33 +30,17 @@ use Twig\Environment;
  */
 class FeedbackController extends AbstractController
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
 
-    /**
-     * @var Environment
-     */
-    private $twig;
+    private Environment $twig;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private FeedbackStateHelperInterface $feedbackStateHelper;
 
     public function __construct(
-        TranslatorInterface $translator,
         Environment $twig,
-        LoggerInterface $logger
+        FeedbackStateHelperInterface $feedbackStateHelper
     ) {
-        $this->translator = $translator;
         $this->twig = $twig;
-        $this->logger = $logger;
-
-        // we have to start the old session in order to be able to retrieve the feedback info
-        $server = new EngineBlock_Corto_ProxyServer($twig);
-        $server->startSession();
+        $this->feedbackStateHelper = $feedbackStateHelper;
     }
 
     /**
@@ -74,14 +56,12 @@ class FeedbackController extends AbstractController
         $feedbackInfo = $this->getFeedbackInfo($request);
         $parameters = $this->getTemplateParameters($request);
 
-        $session = $request->getSession();
-
         $template = sprintf(
             '@theme/Authentication/View/Feedback/%s.html.twig',
             $key
         );
 
-        $session->set('feedbackInfo', $feedbackInfo);
+        $this->feedbackStateHelper->storeFeedbackInfo($feedbackInfo);
 
         return new Response($this->twig->render($template, $parameters), 200);
     }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -214,7 +214,7 @@ Feature:
     And I pass through the IdP
     And I give my consent
   Then I should see "Attribute value not allowed"
-    And I should see "Your organisation sends a value for attribute schacHomeOrganization (\"out-of-scope\") which is not allowed for this organisation. Therefore you cannot log in."
+    And I should see "Dummy Idp sends a value for attribute schacHomeOrganization (\"out-of-scope\") which is not allowed for this organisation. Therefore you cannot log in."
     And I should see "UR ID:"
     And I should see "IP:"
     And I should see "EC:"
@@ -243,7 +243,7 @@ Feature:
       And I pass through the IdP
       And I give my consent
     Then I should see "Attribute value not allowed"
-      And I should see "Your organisation sends a value for attribute eduPersonPrincipalName (\"out-of-scope\") which is not allowed for this organisation. Therefore you cannot log in."
+      And I should see "Dummy Idp sends a value for attribute eduPersonPrincipalName (\"out-of-scope\") which is not allowed for this organisation. Therefore you cannot log in."
       And I should see "UR ID:"
       And I should see "IP:"
       And I should see "EC:"
@@ -273,7 +273,7 @@ Feature:
       And I pass through the IdP
       And I give my consent
     Then I should see "Attribute value not allowed"
-      And I should see "Your organisation sends a value for attribute subject-id (\"out-of-scope\") which is not allowed for this organisation. Therefore you cannot log in."
+      And I should see "Dummy Idp sends a value for attribute subject-id (\"out-of-scope\") which is not allowed for this organisation. Therefore you cannot log in."
       And I should see "UR ID:"
       And I should see "IP:"
       And I should see "EC:"
@@ -289,7 +289,7 @@ Feature:
       And I pass through the IdP
       And I give my consent
     Then I should see "Attribute value not allowed"
-      And I should see "Your organisation sends a value for attribute subject-id (\"not exactly one value\") which is not allowed for this organisation. Therefore you cannot log in."
+      And I should see "Dummy Idp sends a value for attribute subject-id (\"not exactly one value\") which is not allowed for this organisation. Therefore you cannot log in."
 
   Scenario: I log in at my Identity Provider, and have a subject-id attribute without a scope.
     Given the IdP "Dummy Idp" sends attribute "urn:mace:terena.org:attribute-def:schacHomeOrganization" with value "test"
@@ -300,7 +300,7 @@ Feature:
       And I pass through the IdP
       And I give my consent
     Then I should see "Attribute value not allowed"
-      And I should see "Your organisation sends a value for attribute subject-id (\"missing @ in value\") which is not allowed for this organisation. Therefore you cannot log in."
+      And I should see "Dummy Idp sends a value for attribute subject-id (\"missing @ in value\") which is not allowed for this organisation. Therefore you cannot log in."
 
   Scenario: I log in at my Identity Provider, that has the 'block_user_on_violation' feature activated, and has a valid subject-id attribute.
     Given feature "eb.block_user_on_violation" is enabled

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/ClearErrorMessages.feature
@@ -419,6 +419,49 @@ Feature:
     Then I should see "Unknown key id"
      And I should see "Key ID: does-not-exist"
 
+  Scenario: feedbackInfo from a previous failed authentication should not bleed into a subsequent unrelated error
+    # First auth: causes an error that writes IdP info into feedbackInfo in the session.
+    Given the IdP is configured to always return Responses with StatusCode Responder/RequestDenied
+     When I log in at "Dummy SP"
+      And I pass through EngineBlock
+      And I pass through the IdP
+     Then I should see "Identity Provider error"
+      And I should see "IdP:"
+    # Second auth: causes an error that has no IdP context.
+    # The stale IdP info from the previous error must NOT appear on this error page.
+     When I log in at "Unconnected SP"
+     Then I should see "No organisations found"
+      And I should not see "IdP:"
+
+  Scenario: Global session context from a completed login should not appear in a subsequent unrelated error
+    When I log in at "Dummy SP"
+     And I pass through EngineBlock
+     And I pass through the IdP
+     And I give my consent
+     And I pass through EngineBlock
+    # Auth is now complete. An early error (before any SAML request is parsed) must not show
+    # SP/IdP context that leaked from the completed auth into the session.
+    When I post data "{}" to Engineblock URL "/authentication/idp/single-sign-on"
+    Then I should see "The parameter \"SAMLRequest\" is missing on the SAML SSO request"
+     And I should not see "IdP:"
+     And I should not see "SP:"
+
+  Scenario: A previous failed auth's feedback context survives a subsequent successful login
+    # Flow A: an error that has SP context but no IdP context.
+    When I log in at "Unconnected SP"
+    Then I should see "No organisations found"
+     And I should see "SP:"
+    # Flow B: a completely different, successful auth.
+    When I log in at "Dummy SP"
+     And I pass through EngineBlock
+     And I pass through the IdP
+     And I give my consent
+     And I pass through EngineBlock
+    # Navigate back to flow A's error page (as if via back button or bookmarked URL).
+    # Flow A's SP context must still be readable from the session.
+    When I go to Engineblock URL "/authentication/feedback/no-idps"
+    Then I should see "SP:"
+
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a location
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying a binding
 #  Scenario: I try an unsolicited login (at EB) but mess up by not specifying an invalid index

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/FeedbackFooters.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/FeedbackFooters.feature
@@ -44,6 +44,11 @@ Feature:
       And I should see "support@openconext.org"
 
 
+
+  Scenario: The functional-testing feedback page renders correctly with feedback-info
+    When I go to Engineblock URL "/functional-testing/feedback?template=session-lost&feedback-info=%7B%22requestId%22%3A%22test-abc%22%2C%22ipAddress%22%3A%221.2.3.4%22%2C%22artCode%22%3A%2231914%22%7D"
+    Then I should see "your session was lost"
+
   Scenario: When a IdP specific error page is shown and a translation is not configured the support emailaddress of the IdP should be hidden
     Given The clock on the IdP "Dummy Idp" is ahead
     And I have configured the following translations:

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/PolicyEnforcement.feature
@@ -19,7 +19,7 @@ Feature:
     And I pass through EngineBlock
     And I pass through the IdP
     And I should see "Error - Access denied"
-    And I should see "Message from your organisation:"
+    And I should see "Message from Dummy IdP:"
     And I should see "Students of MyIdP do not have access to this resource"
     And the response should contain "idp-logo.jpg"
 
@@ -30,7 +30,7 @@ Feature:
     And I pass through EngineBlock
     And I pass through the IdP
     And I should see "Error - Access denied"
-    And I should see "Message from your organisation:"
+    And I should see "Message from Dummy IdP:"
     And I should see "Students of MyIdP do not have access to this resource"
     And the response should contain "idp-logo.jpg"
 
@@ -41,7 +41,7 @@ Feature:
       And I pass through EngineBlock
       And I pass through the IdP
       And I should see "Error - Access denied"
-      And I should see "Message from your organisation:"
+      And I should see "Message from Dummy IdP:"
 
   Scenario: Access is denied because of an Indeterminate policy
     Given SP "Dummy SP" requires a policy enforcement decision
@@ -50,7 +50,7 @@ Feature:
       And I pass through EngineBlock
       And I pass through the IdP
       And I should see "Error - Access denied"
-      And I should see "Message from your organisation:"
+      And I should see "Message from Dummy IdP:"
 
   Scenario: Access is permitted because of a Permit policy
     Given SP "Dummy SP" requires a policy enforcement decision
@@ -78,7 +78,7 @@ Feature:
     And I pass through EngineBlock
     And I pass through the IdP
     And I should see "Error - Access denied"
-    And I should see "Message from your organisation:"
+    And I should see "Message from Dummy IdP:"
 
   Scenario: Error page shows the end-SP name, not the trusted proxy name
     Given SP "Stepup SelfService" requires a policy enforcement decision
@@ -103,7 +103,7 @@ Feature:
     And I pass through EngineBlock
     And I pass through the IdP
     And I should see "Error - Access denied"
-    And I should see "Message from your organisation:"
+    And I should see "Message from Dummy IdP:"
 
   Scenario: Access is permitted because of a Permit policy, End-SP behind Trusted Proxy
     Given SP "Stepup SelfService" requires a policy enforcement decision

--- a/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/BindingsTest.php
@@ -20,6 +20,8 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Service\FeedbackInfoCollectorInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlockBundle\Bridge\DiContainerRuntime;
 use OpenConext\EngineBlockBundle\Service\WayfRenderer;
 use PHPUnit\Framework\TestCase;
@@ -60,7 +62,12 @@ class EngineBlock_Test_Corto_Module_BindingsTest extends TestCase
         Phake::when($this->proxyServer)->getConfig('WantsAuthnRequestsSigned')->thenReturn(false);
 
         $engineBlock = \EngineBlock_ApplicationSingleton::getInstance();
-        $engineBlock->setDiContainerRuntime(new DiContainerRuntime(Phake::mock(Twig\Environment::class), Phake::mock(WayfRenderer::class)));
+        $engineBlock->setDiContainerRuntime(new DiContainerRuntime(
+            $this->createStub(Twig\Environment::class),
+            $this->createStub(WayfRenderer::class),
+            $this->createStub(FeedbackStateHelperInterface::class),
+            $this->createStub(FeedbackInfoCollectorInterface::class),
+        ));
 
         $this->bindings = new EngineBlock_Corto_Module_Bindings($this->proxyServer);
     }

--- a/tests/library/EngineBlock/Test/Corto/Module/Service/AssertionConsumerTest.php
+++ b/tests/library/EngineBlock/Test/Corto/Module/Service/AssertionConsumerTest.php
@@ -21,8 +21,8 @@ use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
 use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
 use OpenConext\EngineBlock\Metadata\Factory\Factory\ServiceProviderFactory;
 use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlock\Service\ProcessingStateHelperInterface;
-use OpenConext\EngineBlock\Stepup\StepupGatewayCallOutHelper;
 use PHPUnit\Framework\TestCase;
 use SAML2\Assertion;
 use SAML2\Constants;
@@ -51,9 +51,15 @@ class EngineBlock_Test_Corto_Module_Service_AssertionConsumerTest extends TestCa
     /** @var EngineBlock_Saml2_AuthnRequestAnnotationDecorator */
     private $requestMock;
 
+    /** @var Session */
+    private Session $session;
+
+    private FeedbackStateHelperInterface $feedbackStateHelperMock;
+
     public function setUp(): void
     {
-        $_SERVER['HTTP_HOST'] = 'engine.example.com';
+        $this->session = new Session(new MockArraySessionStorage());
+        $this->feedbackStateHelperMock = Phake::mock(FeedbackStateHelperInterface::class);
 
         $this->bindingsModuleMock = Phake::mock('EngineBlock_Corto_Module_Bindings');
         $this->proxyServerMock    = $this->mockProxyServer();
@@ -101,15 +107,9 @@ class EngineBlock_Test_Corto_Module_Service_AssertionConsumerTest extends TestCa
 
         $this->runServe();
 
-        $this->assertSame(
+        Phake::verify($this->feedbackStateHelperMock)->setProxyContext(
             self::REAL_SP_ENTITY_ID,
-            $_SESSION['originalServiceProvider'],
-            'originalServiceProvider must be set to the real SP entity ID behind the trusted proxy'
-        );
-        $this->assertSame(
-            self::PROXY_SP_ENTITY_ID,
-            $_SESSION['proxyServiceProvider'],
-            'proxyServiceProvider must be set to the trusted proxy SP entity ID'
+            self::PROXY_SP_ENTITY_ID
         );
     }
 
@@ -127,15 +127,8 @@ class EngineBlock_Test_Corto_Module_Service_AssertionConsumerTest extends TestCa
 
         $this->runServe();
 
-        $this->assertArrayNotHasKey(
-            'originalServiceProvider',
-            $_SESSION,
-            'originalServiceProvider must NOT be written when the SP is not a trusted proxy'
-        );
-        $this->assertArrayNotHasKey(
-            'proxyServiceProvider',
-            $_SESSION,
-            'proxyServiceProvider must NOT be written when the SP is not a trusted proxy'
+        Phake::verify($this->feedbackStateHelperMock, Phake::never())->setProxyContext(
+            Phake::anyParameters()
         );
     }
 
@@ -148,12 +141,13 @@ class EngineBlock_Test_Corto_Module_Service_AssertionConsumerTest extends TestCa
         $service = new EngineBlock_Corto_Module_Service_AssertionConsumer(
             $this->proxyServerMock,
             Phake::mock('EngineBlock_Corto_XmlToArray'),
-            new Session(new MockArraySessionStorage()),
+            $this->session,
             Phake::mock(ProcessingStateHelperInterface::class),
             // StepupGatewayCallOutHelper is declared final and cannot be Phake-mocked;
             // use the real instance from the DI container (never called in this code path).
             EngineBlock_ApplicationSingleton::getInstance()->getDiContainer()->getStepupGatewayCallOutHelper(),
-            Phake::mock(ServiceProviderFactory::class)
+            Phake::mock(ServiceProviderFactory::class),
+            $this->feedbackStateHelperMock
         );
 
         try {

--- a/tests/unit/OpenConext/EngineBlock/Service/FeedbackInfoCollectorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/FeedbackInfoCollectorTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use Exception;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Entity\IdentityProvider;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\EntityNotFoundException;
+use OpenConext\EngineBlock\Metadata\MetadataRepository\MetadataRepositoryInterface;
+use OpenConext\EngineBlock\Request\RequestId;
+use OpenConext\EngineBlock\Request\RequestIdGenerator;
+use OpenConext\EngineBlockBundle\Localization\LanguageSupportProvider;
+use OpenConext\EngineBlockBundle\Localization\LocaleProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class FeedbackInfoCollectorTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private FeedbackInfoCollector $collector;
+    private MetadataRepositoryInterface $metadataRepository;
+    private FeedbackStateHelperInterface $feedbackStateHelper;
+
+    protected function setUp(): void
+    {
+        $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $requestId = new RequestId(new class implements RequestIdGenerator {
+            public function generateRequestId(): string
+            {
+                return 'test-request-id';
+            }
+        });
+
+        $this->metadataRepository = m::mock(MetadataRepositoryInterface::class);
+        $this->metadataRepository->shouldReceive('fetchServiceProviderByEntityId')
+            ->andThrow(new EntityNotFoundException(''))->byDefault();
+        $this->metadataRepository->shouldReceive('fetchIdentityProviderByEntityId')
+            ->andThrow(new EntityNotFoundException(''))->byDefault();
+
+        $localeProvider = new LocaleProvider(
+            new LanguageSupportProvider(['en', 'nl'], ['en', 'nl']),
+            'en',
+        );
+
+        $this->feedbackStateHelper = m::mock(FeedbackStateHelperInterface::class);
+        $this->feedbackStateHelper->shouldReceive('getActiveFlowContext')->andReturn([])->byDefault();
+
+        $this->collector = new FeedbackInfoCollector(
+            $requestStack,
+            $requestId,
+            $this->metadataRepository,
+            $localeProvider,
+            $this->feedbackStateHelper,
+        );
+    }
+
+    #[Test]
+    public function collect_includes_standard_request_fields(): void
+    {
+        $this->metadataRepository->shouldIgnoreMissing();
+
+        $info = $this->collector->collect(new Exception('oops'));
+
+        self::assertArrayHasKey('datetime', $info);
+        self::assertArrayHasKey('requestUrl', $info);
+        self::assertArrayHasKey('requestId', $info);
+        self::assertArrayHasKey('ipAddress', $info);
+        self::assertArrayHasKey('artCode', $info);
+        self::assertSame('test-request-id', $info['requestId']);
+    }
+
+    #[Test]
+    public function collect_includes_sp_and_idp_names_from_session(): void
+    {
+        $this->feedbackStateHelper->shouldReceive('getActiveFlowContext')->andReturn([
+            'serviceProvider'  => 'https://sp.example.com',
+            'identityProvider' => 'https://idp.example.com',
+        ]);
+
+        $sp = m::mock(ServiceProvider::class);
+        $sp->shouldReceive('getDisplayName')->andReturn('My SP');
+
+        $idp = m::mock(IdentityProvider::class);
+        $idp->shouldReceive('getDisplayName')->andReturn('My IdP');
+
+        $this->metadataRepository
+            ->shouldReceive('fetchServiceProviderByEntityId')
+            ->with('https://sp.example.com')
+            ->andReturn($sp);
+
+        $this->metadataRepository
+            ->shouldReceive('fetchIdentityProviderByEntityId')
+            ->with('https://idp.example.com')
+            ->andReturn($idp);
+
+        $info = $this->collector->collect(new Exception('oops'));
+
+        self::assertSame('https://sp.example.com', $info['serviceProvider']);
+        self::assertSame('My SP', $info['serviceProviderName']);
+        self::assertSame('https://idp.example.com', $info['identityProvider']);
+        self::assertSame('My IdP', $info['identityProviderName']);
+    }
+
+    #[Test]
+    public function collect_uses_original_sp_when_proxy_context_is_set(): void
+    {
+        $this->feedbackStateHelper->shouldReceive('getActiveFlowContext')->andReturn([
+            'serviceProvider'         => 'https://proxy.example.com',
+            'originalServiceProvider' => 'https://realsp.example.com',
+            'proxyServiceProvider'    => 'https://proxy.example.com',
+        ]);
+
+        $sp = m::mock(ServiceProvider::class);
+        $sp->shouldReceive('getDisplayName')->andReturn('Real SP');
+
+        $this->metadataRepository
+            ->shouldReceive('fetchServiceProviderByEntityId')
+            ->with('https://realsp.example.com')
+            ->andReturn($sp);
+
+        $info = $this->collector->collect(new Exception('oops'));
+
+        self::assertSame('https://realsp.example.com', $info['serviceProvider']);
+        self::assertSame('Real SP', $info['serviceProviderName']);
+        self::assertSame('https://proxy.example.com', $info['proxyServiceProvider']);
+    }
+
+    #[Test]
+    public function collect_returns_empty_name_when_entity_not_found(): void
+    {
+        $this->feedbackStateHelper->shouldReceive('getActiveFlowContext')->andReturn([
+            'serviceProvider' => 'https://unknown.example.com',
+        ]);
+
+        $this->metadataRepository
+            ->shouldReceive('fetchServiceProviderByEntityId')
+            ->andThrow(new EntityNotFoundException('not found'));
+
+        $info = $this->collector->collect(new Exception('oops'));
+
+        self::assertSame('https://unknown.example.com', $info['serviceProvider']);
+        self::assertSame('', $info['serviceProviderName']);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Service/FeedbackStateHelperTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/FeedbackStateHelperTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class FeedbackStateHelperTest extends TestCase
+{
+    private Session $session;
+    private FeedbackStateHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->session = new Session(new MockArraySessionStorage());
+
+        $request = new Request();
+        $request->setSession($this->session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $this->helper = new FeedbackStateHelper($requestStack);
+    }
+
+    #[Test]
+    public function it_removes_only_the_current_flows_feedback_entry(): void
+    {
+        $this->session->set('feedbackInfo', ['req-1' => ['serviceProvider' => 'https://sp.example.com']]);
+        $this->session->set('currentFeedbackKey', 'req-1');
+        $this->session->set('currentSamlRequestId', 'req-1');
+
+        $this->helper->clearFeedbackInfo();
+
+        // The one entry was removed so feedbackInfo is now empty/gone
+        self::assertNull($this->session->get('feedbackInfo'));
+        // currentSamlRequestId is removed (the flow is done)
+        self::assertNull($this->session->get('currentSamlRequestId'));
+        // currentFeedbackKey is preserved so the error page URL still resolves
+        self::assertSame('req-1', $this->session->get('currentFeedbackKey'));
+    }
+
+    #[Test]
+    public function it_preserves_other_flows_feedback_info_when_clearing_current_flow(): void
+    {
+        $this->session->set('feedbackInfo', [
+            'req-1' => ['serviceProvider' => 'https://failed-sp.example.com'],
+            'req-2' => ['serviceProvider' => 'https://current-sp.example.com'],
+        ]);
+        $this->session->set('currentFeedbackKey', 'req-1');
+        $this->session->set('currentSamlRequestId', 'req-2');
+
+        $this->helper->clearFeedbackInfo();
+
+        $remaining = $this->session->get('feedbackInfo');
+        self::assertArrayHasKey('req-1', $remaining);
+        self::assertArrayNotHasKey('req-2', $remaining);
+        self::assertSame('req-1', $this->session->get('currentFeedbackKey'));
+        self::assertNull($this->session->get('currentSamlRequestId'));
+    }
+
+    #[Test]
+    public function it_is_a_no_op_when_no_feedback_info_is_in_the_session(): void
+    {
+        // Should not throw when keys are absent
+        $this->helper->clearFeedbackInfo();
+
+        self::assertNull($this->session->get('feedbackInfo'));
+        self::assertNull($this->session->get('currentFeedbackKey'));
+        self::assertNull($this->session->get('currentSamlRequestId'));
+    }
+
+    #[Test]
+    public function it_stores_feedback_info_keyed_by_saml_request_id(): void
+    {
+        $this->session->set('currentSamlRequestId', 'req-xyz');
+
+        $this->helper->storeFeedbackInfo(['serviceProvider' => 'https://sp.example.com']);
+
+        $all = $this->session->get('feedbackInfo');
+        self::assertArrayHasKey('req-xyz', $all);
+        self::assertSame('https://sp.example.com', $all['req-xyz']['serviceProvider']);
+        self::assertSame('req-xyz', $this->session->get('currentFeedbackKey'));
+    }
+
+    #[Test]
+    public function it_stores_feedback_info_under_a_fallback_key_when_no_saml_request_id(): void
+    {
+        $feedback = ['serviceProvider' => 'https://sp.example.com'];
+        $this->helper->storeFeedbackInfo($feedback);
+
+        self::assertSame($feedback, $this->helper->getFeedbackInfo());
+    }
+
+    #[Test]
+    public function it_returns_the_current_keyed_feedback_info(): void
+    {
+        $this->session->set('feedbackInfo', [
+            'req-1' => ['serviceProvider' => 'https://sp.example.com'],
+            'req-2' => ['serviceProvider' => 'https://other.example.com'],
+        ]);
+        $this->session->set('currentFeedbackKey', 'req-1');
+
+        $result = $this->helper->getFeedbackInfo();
+
+        self::assertSame(['serviceProvider' => 'https://sp.example.com'], $result);
+    }
+
+    #[Test]
+    public function it_returns_empty_array_when_no_current_feedback_key(): void
+    {
+        $result = $this->helper->getFeedbackInfo();
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function it_returns_active_flow_context_by_saml_request_id(): void
+    {
+        $this->session->set('currentSamlRequestId', 'req-1');
+        $this->session->set('feedbackInfo', [
+            'req-1' => ['serviceProvider' => 'https://sp.example.com', 'identityProvider' => 'https://idp.example.com'],
+            'req-2' => ['serviceProvider' => 'https://other.example.com'],
+        ]);
+
+        $result = $this->helper->getActiveFlowContext();
+
+        self::assertSame('https://sp.example.com', $result['serviceProvider']);
+        self::assertSame('https://idp.example.com', $result['identityProvider']);
+    }
+
+    #[Test]
+    public function it_returns_empty_active_flow_context_when_no_saml_request_id(): void
+    {
+        self::assertSame([], $this->helper->getActiveFlowContext());
+    }
+
+    #[Test]
+    public function it_starts_a_new_flow_setting_request_id_and_initialising_the_feedback_bucket(): void
+    {
+        $this->helper->startNewFlow('req-new', 'https://sp.example.com');
+
+        self::assertSame('req-new', $this->session->get('currentSamlRequestId'));
+        $bucket = ($this->session->get('feedbackInfo') ?: [])['req-new'] ?? null;
+        self::assertSame('https://sp.example.com', $bucket['serviceProvider']);
+        // No loose currentServiceProvider key is written
+        self::assertNull($this->session->get('currentServiceProvider'));
+    }
+
+    #[Test]
+    public function it_sets_the_current_identity_provider(): void
+    {
+        $this->session->set('currentSamlRequestId', 'req-1');
+        $this->session->set('feedbackInfo', ['req-1' => ['serviceProvider' => 'https://sp.example.com']]);
+
+        $this->helper->setCurrentIdentityProvider('https://idp.example.com');
+
+        $bucket = ($this->session->get('feedbackInfo') ?: [])['req-1'] ?? [];
+        self::assertSame('https://idp.example.com', $bucket['identityProvider']);
+        // No loose currentIdentityProvider key is written
+        self::assertNull($this->session->get('currentIdentityProvider'));
+    }
+
+    #[Test]
+    public function it_sets_the_proxy_context_for_trusted_proxy_flows(): void
+    {
+        $this->session->set('currentSamlRequestId', 'req-1');
+        $this->session->set('feedbackInfo', ['req-1' => ['serviceProvider' => 'https://sp.example.com']]);
+
+        $this->helper->setProxyContext('https://realsp.example.com', 'https://proxy.example.com');
+
+        $bucket = ($this->session->get('feedbackInfo') ?: [])['req-1'] ?? [];
+        self::assertSame('https://realsp.example.com', $bucket['originalServiceProvider']);
+        self::assertSame('https://proxy.example.com', $bucket['proxyServiceProvider']);
+        // No loose session keys written
+        self::assertNull($this->session->get('originalServiceProvider'));
+        self::assertNull($this->session->get('proxyServiceProvider'));
+    }
+
+    #[Test]
+    public function it_clears_flow_context_including_feedback_and_session_vars(): void
+    {
+        $this->session->set('feedbackInfo', ['req-1' => [
+            'serviceProvider' => 'https://sp.example.com',
+            'identityProvider' => 'https://idp.example.com',
+            'originalServiceProvider' => 'https://orig-sp.example.com',
+            'proxyServiceProvider' => 'https://proxy-sp.example.com',
+        ]]);
+        $this->session->set('currentFeedbackKey', 'req-1');
+        $this->session->set('currentSamlRequestId', 'req-1');
+
+        $this->helper->clearFlowContext();
+
+        // feedbackInfo entry for the completed flow is removed (was the only entry)
+        self::assertNull($this->session->get('feedbackInfo'));
+        // currentFeedbackKey is preserved so error page URLs keep working
+        self::assertSame('req-1', $this->session->get('currentFeedbackKey'));
+        self::assertNull($this->session->get('currentSamlRequestId'));
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Service/ProcessingStateHelperTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Service/ProcessingStateHelperTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlock\Service;
+
+use EngineBlock_Corto_Module_Services_SessionLostException;
+use EngineBlock_Saml2_ResponseAnnotationDecorator;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Metadata\Entity\AbstractRole;
+use OpenConext\EngineBlock\Service\Dto\ProcessingStateStep;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class ProcessingStateHelperTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private Session $session;
+    private ProcessingStateHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->session = new Session(new MockArraySessionStorage());
+
+        $request = new Request();
+        $request->setSession($this->session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $this->helper = new ProcessingStateHelper($requestStack);
+    }
+
+    #[Test]
+    public function it_stores_and_retrieves_a_processing_step(): void
+    {
+        $role = m::mock(AbstractRole::class);
+        $response = m::mock(EngineBlock_Saml2_ResponseAnnotationDecorator::class);
+
+        $step = $this->helper->addStep('req-1', ProcessingStateHelperInterface::STEP_CONSENT, $role, $response);
+
+        self::assertInstanceOf(ProcessingStateStep::class, $step);
+        self::assertSame($step, $this->helper->getStepByRequestId('req-1', ProcessingStateHelperInterface::STEP_CONSENT));
+    }
+
+    #[Test]
+    public function it_throws_when_step_not_found(): void
+    {
+        $this->expectException(EngineBlock_Corto_Module_Services_SessionLostException::class);
+
+        $this->helper->getStepByRequestId('nonexistent', ProcessingStateHelperInterface::STEP_CONSENT);
+    }
+
+    #[Test]
+    public function it_clears_a_step_by_request_id(): void
+    {
+        $role = m::mock(AbstractRole::class);
+        $response = m::mock(EngineBlock_Saml2_ResponseAnnotationDecorator::class);
+
+        $this->helper->addStep('req-1', ProcessingStateHelperInterface::STEP_CONSENT, $role, $response);
+        $this->helper->clearStepByRequestId('req-1');
+
+        $this->expectException(EngineBlock_Corto_Module_Services_SessionLostException::class);
+        $this->helper->getStepByRequestId('req-1', ProcessingStateHelperInterface::STEP_CONSENT);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBridge/ErrorReporterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/ErrorReporterTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBridge;
+
+use EngineBlock_ApplicationSingleton;
+use EngineBlock_Corto_Exception_HasFeedbackInfoInterface;
+use EngineBlock_Corto_Exception_PEPNoAccess;
+use Exception;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\EngineBlock\Service\FeedbackInfoCollectorInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use stdClass;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class ErrorReporterTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private Session $session;
+    private RequestStack $requestStack;
+    private EngineBlock_ApplicationSingleton $applicationSingleton;
+    private LoggerInterface $logger;
+    private FeedbackStateHelperInterface $feedbackStateHelper;
+    private FeedbackInfoCollectorInterface $feedbackInfoCollector;
+    private ErrorReporter $reporter;
+
+    protected function setUp(): void
+    {
+        $this->session = new Session(new MockArraySessionStorage());
+
+        $request = new Request();
+        $request->setSession($this->session);
+
+        $this->requestStack = new RequestStack();
+        $this->requestStack->push($request);
+
+        $this->applicationSingleton = m::mock(EngineBlock_ApplicationSingleton::class);
+        $this->applicationSingleton->shouldReceive('flushLog')->byDefault();
+
+        $this->logger = m::mock(LoggerInterface::class);
+        $this->logger->shouldIgnoreMissing();
+
+        $this->feedbackStateHelper = m::mock(FeedbackStateHelperInterface::class);
+        $this->feedbackStateHelper->shouldReceive('storeFeedbackInfo')->byDefault();
+
+        $this->feedbackInfoCollector = m::mock(FeedbackInfoCollectorInterface::class);
+        $this->feedbackInfoCollector->shouldReceive('collect')->andReturn([])->byDefault();
+
+        $this->reporter = new ErrorReporter(
+            $this->applicationSingleton,
+            $this->logger,
+            $this->requestStack,
+            $this->feedbackStateHelper,
+            $this->feedbackInfoCollector,
+        );
+    }
+
+    #[Test]
+    public function it_collects_and_stores_feedback_via_the_dedicated_services(): void
+    {
+        $exception = new Exception('test');
+        $feedback = ['artCode' => 'art:0:0:0:0'];
+
+        $this->feedbackInfoCollector->shouldReceive('collect')->with($exception)->once()->andReturn($feedback);
+        $this->feedbackStateHelper->shouldReceive('storeFeedbackInfo')->with($feedback)->once();
+
+        $this->reporter->reportError($exception, '');
+    }
+
+    #[Test]
+    public function it_skips_feedback_storage_when_there_is_no_active_request(): void
+    {
+        $reporter = new ErrorReporter(
+            $this->applicationSingleton,
+            $this->logger,
+            new RequestStack(),
+            $this->feedbackStateHelper,
+            $this->feedbackInfoCollector,
+        );
+
+        $this->feedbackInfoCollector->shouldNotReceive('collect');
+        $this->feedbackStateHelper->shouldNotReceive('storeFeedbackInfo');
+
+        $reporter->reportError(new Exception('test'), '');
+    }
+
+    #[Test]
+    public function it_merges_exception_feedback_info_when_exception_implements_has_feedback_info_interface(): void
+    {
+        $exception = new class('test') extends Exception implements EngineBlock_Corto_Exception_HasFeedbackInfoInterface {
+            public function getFeedbackInfo(): array
+            {
+                return ['customKey' => 'customValue', 'artCode' => 'overridden-art-code'];
+            }
+        };
+
+        $this->feedbackInfoCollector
+            ->shouldReceive('collect')
+            ->andReturn(['artCode' => 'original-art-code', 'datetime' => '2026-01-01']);
+
+        $this->feedbackStateHelper
+            ->shouldReceive('storeFeedbackInfo')
+            ->once()
+            ->with([
+                'artCode'   => 'overridden-art-code',
+                'datetime'  => '2026-01-01',
+                'customKey' => 'customValue',
+            ]);
+
+        $this->reporter->reportError($exception, '');
+    }
+
+    #[Test]
+    public function it_stores_the_pep_policy_decision_in_the_session(): void
+    {
+        $decision = new stdClass();
+        $exception = EngineBlock_Corto_Exception_PEPNoAccess::basedOn($decision);
+
+        $this->reporter->reportError($exception, '');
+
+        self::assertSame($decision, $this->session->get('error_authorization_policy_decision'));
+    }
+}

--- a/tests/unit/OpenConext/EngineBlockBundle/DiContainerRuntimeTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/DiContainerRuntimeTest.php
@@ -18,6 +18,8 @@
 
 namespace Tests\OpenConext\EngineBlockBundle;
 
+use OpenConext\EngineBlock\Service\FeedbackInfoCollectorInterface;
+use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use OpenConext\EngineBlockBundle\Bridge\DiContainerRuntime;
 use OpenConext\EngineBlockBundle\Service\WayfRenderer;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +32,8 @@ class DiContainerRuntimeTest extends TestCase
         $runtime = new DiContainerRuntime(
             $this->createStub(Environment::class),
             $this->createStub(WayfRenderer::class),
+            $this->createStub(FeedbackStateHelperInterface::class),
+            $this->createStub(FeedbackInfoCollectorInterface::class),
         );
 
         $this->assertSame([], $runtime->getPreferredIdpEntityIds());
@@ -42,6 +46,8 @@ class DiContainerRuntimeTest extends TestCase
         $runtime = new DiContainerRuntime(
             $this->createStub(Environment::class),
             $this->createStub(WayfRenderer::class),
+            $this->createStub(FeedbackStateHelperInterface::class),
+            $this->createStub(FeedbackInfoCollectorInterface::class),
             $entityIds,
         );
 


### PR DESCRIPTION
Prior to this change, there were two issues: 
 * Feedback info was not cleared on successful login. This caused the debug info from previous successful requests to appear in new requests. For example, the IdP or SP from the previous request would be shown, implying it belonged to the current request.
 * The feedback info was stored at the top level of the session. This means, when having two active requests, data from the first would be merged into the second and/or vice versa. 

This change clears the feedback data on successful auth and stores the data separate per request, if possible. 

In order to make these changes, the code needed to be refactored. The main issues were: 
* Direct access to $_SESSION. This should be done via the Symfony Session, no longer via the Corto session, which is being phased out. 
* Because of this direct access, there was no central place to manage and encapsulate the feedback info state management. The writes were scattered, making it difficult to trace back how it works. This is now refactored to be the responsibility of the [FeedbackStateHelper](https://github.com/OpenConext/OpenConext-engineblock/compare/feature/EB-1795_clear-sessino?expand=1#diff-1ee213868cf761152d1481e298c752defbcaac60a770ace86f5b9b921f12abf3R24)

Resolves #1795 