### PR TITLE
Add key rollover test

### DIFF
--- a/library/EngineBlock/Application/FunctionalTestDiContainer.php
+++ b/library/EngineBlock/Application/FunctionalTestDiContainer.php
@@ -79,6 +79,10 @@ class EngineBlock_Application_FunctionalTestDiContainer extends EngineBlock_Appl
                 'publicFile' => '/config/engine/engineblock.crt',
                 'privateFile' => $basePath . '/ci/qa-config/files/engineblock.pem',
             ],
+            'rollover' => [
+                'publicFile' => $basePath . '/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/keys/rolled-over.crt',
+                'privateFile' => $basePath . '/src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/keys/rolled-over.key',
+            ],
         ];
     }
 }

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -47,6 +47,7 @@ use SAML2\DOMDocumentFactory;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Due to all integration specific features
  * @SuppressWarnings(PHPMD.ExcessivePublicCount) Both set up and tasks can be a lot...
  * @SuppressWarnings(PHPMD.TooManyFields) Both set up and tasks can be a lot...
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength) Both set up and tasks can be a lot...
  */
 class EngineBlockContext extends AbstractSubContext
 {
@@ -320,6 +321,20 @@ class EngineBlockContext extends AbstractSubContext
         $mink = $this->getMinkContext();
         $mink->visit(
             $this->engineBlock->unsolicitedLocation($mockIdP->entityId(), $mockSp->entityId(), 'does-not-exist')
+        );
+    }
+
+    /**
+     * @Given /^An IdP initiated Single Sign on for SP "([^"]*)" is triggered by IdP "([^"]*)" and specifies the "([^"]*)" signing key$/
+     */
+    public function anIdpInitiatedSingleSignOnForSpIsTriggeredByIdPWithNamedSigningKey($spName, $idpName, $keyId)
+    {
+        $mockSp = $this->mockSpRegistry->get($spName);
+        $mockIdP = $this->mockIdpRegistry->get($idpName);
+
+        $mink = $this->getMinkContext();
+        $mink->visit(
+            $this->engineBlock->unsolicitedLocation($mockIdP->entityId(), $mockSp->entityId(), $keyId)
         );
     }
 

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/MinkContext.php
@@ -70,6 +70,8 @@ class MinkContext extends BaseMinkContext
         $xpathObj->registerNamespace('md', 'urn:oasis:names:tc:SAML:2.0:metadata');
         $xpathObj->registerNamespace('mdui', Common::NS);
         $xpathObj->registerNamespace('shibmd', Scope::NS);
+        $xpathObj->registerNamespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
+        $xpathObj->registerNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
         $nodeList = $xpathObj->query($xpath);
 
         if (!$nodeList || $nodeList->length === 0) {
@@ -205,6 +207,8 @@ class MinkContext extends BaseMinkContext
         $xpathObj->registerNamespace('ds', XMLSecurityDSig::XMLDSIGNS);
         $xpathObj->registerNamespace('md', 'urn:oasis:names:tc:SAML:2.0:metadata');
         $xpathObj->registerNamespace('mdui', Common::NS);
+        $xpathObj->registerNamespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
+        $xpathObj->registerNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
         $nodeList = $xpathObj->query($xpath);
 
         if ($nodeList && $nodeList->length > 0) {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/UnsolicitedSingleSignOn.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/UnsolicitedSingleSignOn.feature
@@ -25,6 +25,17 @@ Feature:
     And I give my consent
     And I pass through EngineBlock
     Then the url should match "functional-testing/Dummy%20SP/acs"
+    And the response should match xpath '//ds:X509Certificate[starts-with(.,"MIIDuDCCAqCgAwIBAgIJAPdqJ9JQKN6vMA0GCSqGSIb3DQEBBQUAMEYxDzANBgNVBAMT")]'
+
+  Scenario: An IdP initiates a login with the rollover signing key
+    When An IdP initiated Single Sign on for SP "Dummy SP" is triggered by IdP "Dummy IdP" and specifies the "rollover" signing key
+    And I pass through EngineBlock
+    And I pass through the IdP
+    And I give my consent
+    And I pass through EngineBlock
+    Then the url should match "functional-testing/Dummy%20SP/acs"
+    # See src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/keys/rolled-over.crt
+    And the response should match xpath '//ds:X509Certificate[starts-with(.,"MIIDhTCCAm2gAwIBAgIJALJlbT5u9cXzMA0GCSqG")]'
 
   # Should result in a generic 500 error, the logs specify the problem in greater detail.
   Scenario: An IdP initiates a login with an SP identity id query parameter


### PR DESCRIPTION
Prior to this change, there was no specific test that asserted using the key:rollover URL results in a response that is signed with the rollover certificate.

This change asserts the response contains the rollover certificate.

Resolves #1759