### PR TITLE
fix: remove HTTP Redirect binding support from AcsRequestValidator

### DIFF
--- a/src/OpenConext/EngineBlock/Validator/AcsRequestValidator.php
+++ b/src/OpenConext/EngineBlock/Validator/AcsRequestValidator.php
@@ -25,30 +25,27 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * The AcsRequestValidator verifies valid saml binding
  *
- * Valid requests method / binding combinations for SSO are:
+ * Valid requests method / binding combinations for ACS are:
  *
  *  | Request method | Parameter name  |
  *  | -------------- | --------------- |
- *  | GET            | SAMLResponse    |
  *  | POST           | SAMLResponse    |
  */
 class AcsRequestValidator implements RequestValidator
 {
-    private $supportedRequestMethods = [Request::METHOD_GET, Request::METHOD_POST];
+    private $supportedRequestMethods = [Request::METHOD_POST];
 
     public function isValid(Request $request)
     {
         $requestMethod = $request->getMethod();
-        // Defense in depth; anything other than POST and GET are probably already rejected at routing time.
+        // Defense in depth; anything other than POST is already rejected at routing time.
         if (!in_array($requestMethod, $this->supportedRequestMethods)) {
-            // Only Redirect binding is supported for Single Sign On
             throw new InvalidRequestMethodException(
                 sprintf('The HTTP request method "%s" is not supported on this SAML ACS endpoint', $requestMethod)
             );
         }
 
-        if (($requestMethod ===  Request::METHOD_POST && !$request->request->has('SAMLResponse')) ||
-            ($requestMethod ===  Request::METHOD_GET && !$request->query->has('SAMLResponse'))) {
+        if ($requestMethod === Request::METHOD_POST && !$request->request->has('SAMLResponse')) {
             throw new MissingParameterException(
                 sprintf('The parameter "SAMLResponse" is missing on the SAML ACS request')
             );

--- a/tests/unit/OpenConext/EngineBlock/Validator/AcsRequestValidatorTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Validator/AcsRequestValidatorTest.php
@@ -45,18 +45,6 @@ class AcsRequestValidatorTest extends TestCase
     }
 
     #[BackupGlobals(true)]
-    public function test_happy_flow_get()
-    {
-        // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
-        $_SERVER['REQUEST_METHOD'] = 'GET';
-        $_GET['SAMLResponse'] = 'loremipsum';
-
-        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
-
-        $this->assertTrue($this->validator->isValid($request));
-    }
-
-    #[BackupGlobals(true)]
     public function test_happy_flow_post()
     {
         // Under the hood, the Binding::getCurrentBinding method is used, which directly reads from the super globals
@@ -66,6 +54,19 @@ class AcsRequestValidatorTest extends TestCase
         $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
 
         $this->assertTrue($this->validator->isValid($request));
+    }
+
+    #[BackupGlobals(true)]
+    public function test_get_method_is_not_supported()
+    {
+        $this->expectException(InvalidRequestMethodException::class);
+        $this->expectExceptionMessage('The HTTP request method "GET" is not supported on this SAML ACS endpoint');
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
+
+        $this->validator->isValid($request);
     }
 
     #[BackupGlobals(true)]
@@ -88,19 +89,6 @@ class AcsRequestValidatorTest extends TestCase
         $this->expectExceptionMessage('The parameter "SAMLResponse" is missing on the SAML ACS request');
 
         $_SERVER['REQUEST_METHOD'] = 'POST';
-
-        $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
-
-        $this->validator->isValid($request);
-    }
-
-    #[BackupGlobals(true)]
-    public function test_missing_saml_argument_on_get()
-    {
-        $this->expectException(MissingParameterException::class);
-        $this->expectExceptionMessage('The parameter "SAMLResponse" is missing on the SAML ACS request');
-
-        $_SERVER['REQUEST_METHOD'] = 'GET';
 
         $request = new Request($_GET, $_POST, [], [], [], $_SERVER);
 


### PR DESCRIPTION
EB only supports HTTP POST binding on the ACS endpoint. The route already restricts to POST, so the GET branch was dead code. GET now throws InvalidRequestMethodException like any other unsupported method.

Closes #1750