### PR TITLE
remove dead eb.encrypted_assertions_require_outer_signature feature flag

### DIFF
--- a/config/packages/engineblock_features.yaml
+++ b/config/packages/engineblock_features.yaml
@@ -7,7 +7,6 @@ parameters:
         api.deprovision:     "%feature_api_deprovision%"
         api.users_nameid_lookup: "%feature_api_users_nameid_lookup%"
         eb.encrypted_assertions: "%feature_eb_encrypted_assertions%"
-        eb.encrypted_assertions_require_outer_signature: "%feature_eb_encrypted_assertions_require_outer_signature%"
         eb.run_all_manipulations_prior_to_consent: "%feature_run_all_manipulations_prior_to_consent%"
         eb.block_user_on_violation: "%feature_block_user_on_violation%"
         eb.enable_sso_notification: "%feature_enable_sso_notification%"

--- a/config/packages/parameters.yml.dist
+++ b/config/packages/parameters.yml.dist
@@ -223,7 +223,6 @@ parameters:
     ## FEATURE SETTINGS
     ##########################################################################################
     feature_eb_encrypted_assertions: true
-    feature_eb_encrypted_assertions_require_outer_signature: true
     feature_api_metadata_push: true
     feature_api_consent_listing: true
     feature_api_consent_remove: true

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -41,7 +41,6 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.run_all_manipulations_prior_to_consent', false));
         $this->setFeature(new Feature('eb.block_user_on_violation', true));
         $this->setFeature(new Feature('eb.encrypted_assertions', true));
-        $this->setFeature(new Feature('eb.encrypted_assertions_require_outer_signature', true));
         $this->setFeature(new Feature('eb.enable_sso_notification', false));
         $this->setFeature(new Feature('eb.feature_enable_consent', true));
         $this->setFeature(new Feature('eb.enable_sso_session_cookie', true));

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Encryption.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Encryption.feature
@@ -25,7 +25,6 @@ Feature:
   Scenario: EngineBlock rejects invalid RSA Encrypted Responses
     Given the SP uses the HTTP POST Binding
       And feature "eb.encrypted_assertions" is enabled
-      And feature "eb.encrypted_assertions_require_outer_signature" is enabled
       And the IdP encrypts its assertions with the public key in "src/OpenConext/EngineBlockFunctionalTestingBundle/Resources/keys/rolled-over.crt"
      When I log in at "Dummy SP"
       And I pass through the SP
@@ -54,10 +53,9 @@ Feature:
      Then the url should match "authentication/feedback/received-invalid-response"
       And I should see "Invalid organisation SAML response"
 
-  Scenario: EngineBlock rejects encrypted responses without outer signature if the feature "eb.encrypted_assertions_require_outer_signatures" is enabled
+  Scenario: EngineBlock rejects encrypted responses without outer signature
     Given the SP uses the HTTP POST Binding
       And feature "eb.encrypted_assertions" is enabled
-      And feature "eb.encrypted_assertions_require_outer_signature" is enabled
       And the IdP encrypts its assertions with the public key in "tests/resources/key/engineblock.crt"
       And the IdP does not sign its responses
      When I log in at "Dummy SP"
@@ -66,23 +64,6 @@ Feature:
       And I pass through the IdP
      Then the url should match "authentication/feedback/received-invalid-response"
       And I should see "Invalid organisation SAML response"
-
-  # This scenario is currently not supported by EngineBlock,
-  # see https://www.pivotaltracker.com/story/show/155703943
-  @SKIP
-  Scenario: EngineBlock accepts encrypted responses without an outer signature if the feature "eb.encrypted_assertions_require_outer_signatures" is disabled
-    Given the SP uses the HTTP POST Binding
-      And feature "eb.encrypted_assertions" is enabled
-      And feature "eb.encrypted_assertions_require_outer_signature" is disabled
-     When I log in at "Dummy SP"
-      And the IdP encrypts its assertions with the public key in "tests/resources/key/engineblock.crt"
-      And the IdP does not sign its responses
-      And I pass through the SP
-      And I pass through EngineBlock
-      And I pass through the IdP
-      And I give my consent
-      And I pass through EngineBlock
-     Then the response should contain "urn:mace:terena.org:attribute-def:schacHomeOrganization"
 
   Scenario: EngineBlock supports not signed responses
     Given the SP uses the HTTP POST Binding


### PR DESCRIPTION
The flag has been inoperative since 2018: Bindings.php unconditionally rejects encrypted assertions without an outer signature regardless of the flag value. Wiring it up is not viable because the SAML2 library checks wasSignedAtConstruction() on the original EncryptedAssertion objects (before decryption), which always returns false, so the library itself would reject such responses too.

Removes the flag from engineblock_features.yaml, parameters.yml.dist, TestFeatureConfiguration, and cleans up the Behat scenarios that referenced it (removing the @SKIP scenario that tested the broken path).

Closes #2002