### PR TITLE
Provide an enriched info actuator endpoint for monitoring purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ public/fonts
 public/images
 public/javascripts
 public/stylesheets
+public/version.json
 
 theme/node_modules
 vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,36 @@ The following feedback pages previously returned HTTP **200 OK** and now return 
 Maintenance:
 * Removed the `openconext` theme. The `skeune` theme is now the only supported theme and the default. (#1980)
 
+### Actuator
+There are now two additional endpoints available to retrieve information about the running software;
+`/version.json` and `/actuator/info`. Ensure that those endpoints are restricted for only administrator access.
+
+example /version.json:
+```json
+{
+    "name": "openconext/engineblock",
+    "description": "OpenConext SAML proxy",
+    "version": "7.0.0-dev",
+    "time": "2026-05-19T12:06:37.581Z"
+}
+```
+
+example /actuator/info:
+```json
+{
+  "build": {
+    "name": "openconext/engineblock",
+    "description": "OpenConext SAML proxy",
+    "version": "7.0.0-dev",
+    "time": "2026-05-18T11:59:07.992Z"
+  },
+  "days_since_release": 1
+}
+```
+
+The time is set during composer install and thus is latest build time of the software. Using this you can ensure that you are running
+the correct version of the software.
+
 ## UNRELEASED 7.2.0
 Upgrade to Symfony 7.4
 Upgrade to `doctrine/dbal` 4

--- a/bin/extractVersion.sh
+++ b/bin/extractVersion.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+if [ ! -f "composer.json" ]; then
+  echo "composer.json not found" >&2
+  exit 1
+fi
+
+# Extract simple fields (works for standard composer.json formatting)
+NAME=$(grep -m1 '"name"' composer.json | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+DESCRIPTION=$(grep -m1 '"description"' composer.json | sed -E 's/.*"description"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+VERSION=$(grep -m1 '"version"' composer.json | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+
+DATE=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+
+printf '{\n'
+printf '  "name": "%s",\n' "$NAME"
+printf '  "description": "%s",\n' "$DESCRIPTION"
+printf '  "version": "%s",\n' "$VERSION"
+printf '  "time": "%s"\n' "$DATE"
+printf '}\n'

--- a/composer.json
+++ b/composer.json
@@ -92,10 +92,12 @@
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "bin/extractVersion.sh > public/version.json"
         ],
         "post-update-cmd": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "bin/extractVersion.sh > public/version.json"
         ],
         "pre-archive-cmd": [
             "bash -c 'if [ -z \"${ASSET_TAG}\" ]; then export ASSET_TAG=$(head -c16 /dev/urandom | od --format=x1 --address-radix=none | tr -d \" \"); echo \"ASSET_TAG not set, using random value: ${ASSET_TAG}\"; fi; sed -i -e \"s,#ASSET_VERSION#,${ASSET_TAG},g\" ./config/packages/framework.yaml'"

--- a/config/services/controllers/authentication.yml
+++ b/config/services/controllers/authentication.yml
@@ -77,3 +77,8 @@ services:
         arguments:
             - '@symfony.mailer'
             - '%email_request_access_address%'
+
+    OpenConext\EngineBlockBundle\Controller\ActuatorController:
+        arguments:
+            - '@engineblock.compat.logger'
+            - '%kernel.project_dir%'

--- a/src/OpenConext/EngineBlockBundle/Controller/ActuatorController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/ActuatorController.php
@@ -39,9 +39,8 @@ class ActuatorController extends AbstractController
 
     public function __construct(
         LoggerInterface $logger,
-        string          $projectDir
-    )
-    {
+        string $projectDir
+    ) {
         $this->logger = $logger;
         $this->projectDir = $projectDir;
     }

--- a/src/OpenConext/EngineBlockBundle/Controller/ActuatorController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/ActuatorController.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockBundle\Controller;
+
+use DateTime;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Throwable;
+
+class ActuatorController extends AbstractController
+{
+    private const string PUBLIC_DIR = "public";
+
+    private const string VERSION_FILE = "version.json";
+
+    private const string BUILD_TIME_FORMAT = "Y-m-d\TH:i:s.v\Z";
+
+    private LoggerInterface $logger;
+
+    private string $projectDir;
+
+    public function __construct(
+        LoggerInterface $logger,
+        string          $projectDir
+    )
+    {
+        $this->logger = $logger;
+        $this->projectDir = $projectDir;
+    }
+
+    #[Route(
+        path: '/actuator/info',
+        name: 'actuator_info',
+        methods: ['GET']
+    )]
+    public function getBuildInfo(): JsonResponse
+    {
+        try {
+            $versionFile = $this->projectDir . DIRECTORY_SEPARATOR . self::PUBLIC_DIR .
+                DIRECTORY_SEPARATOR . self::VERSION_FILE;
+
+            $versionContent = json_decode(file_get_contents($versionFile), true);
+
+            // Calculate days since release
+            $buildTimeString = $versionContent["time"];
+            $buildTime = DateTime::createFromFormat(self::BUILD_TIME_FORMAT, $buildTimeString);
+            $daysSinceRelease = (new DateTime())->diff($buildTime)->days;
+
+            $buildInfo = [
+                'build' => $versionContent ?? [],
+                'days_since_release' => $daysSinceRelease
+            ];
+        } catch (Throwable $e) {
+            $this->logger->error("Failed to build actuator info: " . $e->getMessage(), $e->getTrace());
+            $buildInfo = [];
+        }
+
+        return $this->json($buildInfo);
+    }
+}


### PR DESCRIPTION
This PR proposes an actuator endpoint (/actuator/info). 

This endpoint is in line with the other actuator endpoints we that are introduced in the Openconext landscape:
- https://github.com/OpenConext/OpenConext-manage/pull/680
- https://github.com/OpenConext/OpenConext-attribute-aggregation/pull/148

With this PR, a version file will be created during build process in /public/version.json. This file will be used by the actuator endpoint (/actuator/info) to show information regarding when the application has been build, the current version, description and will show the amount of days passed since the release was build. This information can be used by application monitoring to determine whether a new release of the application and its middleware is required.

example /version.json:
```json
{
    "name": "openconext/engineblock",
    "description": "OpenConext SAML proxy",
    "version": "7.0.0-dev",
    "time": "2026-05-19T12:06:37.581Z"
}
```

example /actuator/info:
```json
{
  "build": {
    "name": "openconext/engineblock",
    "description": "OpenConext SAML proxy",
    "version": "7.0.0-dev",
    "time": "2026-05-18T11:59:07.992Z"
  },
  "days_since_release": 1
}
```

I also reviewed the implementation in the openconext/monitor-bundle, which exposes `https://engine.surfconext.nl/info`.
As I understand it, that implementation relies on environment variables for build metadata. Those variables are not persisted as part of the packaged application artifact, whereas this approach stores the metadata in a generated file during the build process