### PR TITLE
feat(db): add unique constraint on user.uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,10 +56,11 @@ The following feedback pages previously returned HTTP **200 OK** and now return 
 
 Maintenance:
 * Removed the `openconext` theme. The `skeune` theme is now the only supported theme and the default. (#1980)
-* The non-unique index `idx_user_uuid` on the `user` table has been replaced by a unique index `uq_user_uuid`. Run the following on your production database (#1974):
+* The non-unique index `idx_user_uuid` on the `user` table has been replaced by a unique index `uq_user_uuid`, and the `uuid` column is now enforced as `NOT NULL`. Before running the migration, ensure no rows have a `NULL` uuid (there should be none in a healthy database). Run the following on your production database (#1974):
   ```sql
   SET SESSION innodb_sort_buffer_size = 268435456;
   ALTER TABLE `user`
+      CHANGE `uuid` `uuid` CHAR(36) NOT NULL COMMENT '(DC2Type:engineblock_collab_person_uuid)',
       ADD UNIQUE INDEX `uq_user_uuid` (`uuid`),
       DROP INDEX `idx_user_uuid`,
       ALGORITHM=INPLACE,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Maintenance:
   ```sql
   SET SESSION innodb_sort_buffer_size = 268435456;
   ALTER TABLE `user`
-      CHANGE `uuid` `uuid` CHAR(36) NOT NULL COMMENT '(DC2Type:engineblock_collab_person_uuid)',
+      CHANGE `uuid` `uuid` CHAR(36) NOT NULL,
       ADD UNIQUE INDEX `uq_user_uuid` (`uuid`),
       DROP INDEX `idx_user_uuid`,
       ALGORITHM=INPLACE,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ The following feedback pages previously returned HTTP **200 OK** and now return 
 
 Maintenance:
 * Removed the `openconext` theme. The `skeune` theme is now the only supported theme and the default. (#1980)
+* The non-unique index `idx_user_uuid` on the `user` table has been replaced by a unique index `uq_user_uuid`. Run the following on your production database (#1974):
+  ```sql
+  SET SESSION innodb_sort_buffer_size = 268435456;
+  ALTER TABLE `user`
+      ADD UNIQUE INDEX `uq_user_uuid` (`uuid`),
+      DROP INDEX `idx_user_uuid`,
+      ALGORITHM=INPLACE,
+      LOCK=NONE;
+  ```
 
 ## UNRELEASED 7.2.0
 Upgrade to Symfony 7.4

--- a/migrations/DoctrineMigrations/Version20260602000000.php
+++ b/migrations/DoctrineMigrations/Version20260602000000.php
@@ -31,11 +31,11 @@ final class Version20260602000000 extends AbstractEngineBlockMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `user` CHANGE `uuid` `uuid` CHAR(36) NOT NULL COMMENT \'(DC2Type:engineblock_collab_person_uuid)\', ADD UNIQUE INDEX `uq_user_uuid` (`uuid`), DROP INDEX `idx_user_uuid`');
+        $this->addSql('ALTER TABLE `user` CHANGE `uuid` `uuid` CHAR(36) NOT NULL, ADD UNIQUE INDEX `uq_user_uuid` (`uuid`), DROP INDEX `idx_user_uuid`');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `user` CHANGE `uuid` `uuid` CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:engineblock_collab_person_uuid)\', ADD INDEX `idx_user_uuid` (`uuid`), DROP INDEX `uq_user_uuid`');
+        $this->addSql('ALTER TABLE `user` CHANGE `uuid` `uuid` CHAR(36) DEFAULT NULL, ADD INDEX `idx_user_uuid` (`uuid`), DROP INDEX `uq_user_uuid`');
     }
 }

--- a/migrations/DoctrineMigrations/Version20260602000000.php
+++ b/migrations/DoctrineMigrations/Version20260602000000.php
@@ -31,21 +31,11 @@ final class Version20260602000000 extends AbstractEngineBlockMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('SET SESSION innodb_sort_buffer_size = 268435456');
-        $this->addSql(
-            'ALTER TABLE `user` ADD UNIQUE INDEX `uq_user_uuid` (`uuid`), DROP INDEX `idx_user_uuid`, ALGORITHM=INPLACE, LOCK=NONE'
-        );
+        $this->addSql('ALTER TABLE `user` ADD UNIQUE INDEX `uq_user_uuid` (`uuid`), DROP INDEX `idx_user_uuid`');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql(
-            'ALTER TABLE `user` ADD INDEX `idx_user_uuid` (`uuid`), DROP INDEX `uq_user_uuid`'
-        );
-    }
-
-    public function isTransactional(): bool
-    {
-        return false;
+        $this->addSql('ALTER TABLE `user` ADD INDEX `idx_user_uuid` (`uuid`), DROP INDEX `uq_user_uuid`');
     }
 }

--- a/migrations/DoctrineMigrations/Version20260602000000.php
+++ b/migrations/DoctrineMigrations/Version20260602000000.php
@@ -26,16 +26,16 @@ final class Version20260602000000 extends AbstractEngineBlockMigration
 {
     public function getDescription(): string
     {
-        return 'Replace non-unique idx_user_uuid with unique index uq_user_uuid on user.uuid';
+        return 'Replace non-unique idx_user_uuid with unique index uq_user_uuid on user.uuid and enforce NOT NULL';
     }
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `user` ADD UNIQUE INDEX `uq_user_uuid` (`uuid`), DROP INDEX `idx_user_uuid`');
+        $this->addSql('ALTER TABLE `user` CHANGE `uuid` `uuid` CHAR(36) NOT NULL COMMENT \'(DC2Type:engineblock_collab_person_uuid)\', ADD UNIQUE INDEX `uq_user_uuid` (`uuid`), DROP INDEX `idx_user_uuid`');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `user` ADD INDEX `idx_user_uuid` (`uuid`), DROP INDEX `uq_user_uuid`');
+        $this->addSql('ALTER TABLE `user` CHANGE `uuid` `uuid` CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:engineblock_collab_person_uuid)\', ADD INDEX `idx_user_uuid` (`uuid`), DROP INDEX `uq_user_uuid`');
     }
 }

--- a/migrations/DoctrineMigrations/Version20260602000000.php
+++ b/migrations/DoctrineMigrations/Version20260602000000.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace OpenConext\EngineBlock\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20260602000000 extends AbstractEngineBlockMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace non-unique idx_user_uuid with unique index uq_user_uuid on user.uuid';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('SET SESSION innodb_sort_buffer_size = 268435456');
+        $this->addSql(
+            'ALTER TABLE `user` ADD UNIQUE INDEX `uq_user_uuid` (`uuid`), DROP INDEX `idx_user_uuid`, ALGORITHM=INPLACE, LOCK=NONE'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(
+            'ALTER TABLE `user` ADD INDEX `idx_user_uuid` (`uuid`), DROP INDEX `uq_user_uuid`'
+        );
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/src/OpenConext/EngineBlockBundle/Authentication/Entity/User.php
+++ b/src/OpenConext/EngineBlockBundle/Authentication/Entity/User.php
@@ -23,7 +23,7 @@ use OpenConext\EngineBlock\Authentication\Value\CollabPersonUuid;
 use OpenConext\EngineBlockBundle\Authentication\Repository\UserRepository;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
-#[ORM\Index(name: 'idx_user_uuid', columns: ['uuid'])]
+#[ORM\UniqueConstraint(name: 'uq_user_uuid', columns: ['uuid'])]
 class User
 {
     /**


### PR DESCRIPTION
The uuid column stores collabPersonUuid, which must be unique per user. The existing non-unique idx_user_uuid provided no enforcement.

Migration uses ALGORITHM=INPLACE, LOCK=NONE for zero-downtime on large tables. Skips if idx_user_uuid is absent (already migrated manually).

DONT release before the dbal 4 update

Closes #1974