### PR TITLE
feat(feedback): show bookmark error page for saved WAYF URLs

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -128,7 +128,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * @psalm-type FrameworkConfig = array{
  *     secret?: scalar|Param|null,
  *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
- *     allowed_http_method_override?: null|list<string|Param>,
+ *     allowed_http_method_override?: list<string|Param>|null,
  *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
  *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
  *     test?: bool|Param,
@@ -136,9 +136,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
  *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
  *     enabled_locales?: list<scalar|Param|null>,
- *     trusted_hosts?: string|list<scalar|Param|null>,
+ *     trusted_hosts?: list<scalar|Param|null>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: string|list<scalar|Param|null>,
+ *     trusted_headers?: list<scalar|Param|null>,
  *     error_controller?: scalar|Param|null, // Default: "error_controller"
  *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
@@ -202,23 +202,23 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 property?: scalar|Param|null,
  *                 service?: scalar|Param|null,
  *             },
- *             supports?: string|list<scalar|Param|null>,
+ *             supports?: list<scalar|Param|null>,
  *             definition_validators?: list<scalar|Param|null>,
  *             support_strategy?: scalar|Param|null,
- *             initial_marking?: \BackedEnum|string|list<scalar|Param|null>,
- *             events_to_dispatch?: null|list<string|Param>,
- *             places?: string|list<array{ // Default: []
+ *             initial_marking?: list<scalar|Param|null>,
+ *             events_to_dispatch?: list<string|Param>|null,
+ *             places?: list<array{ // Default: []
  *                 name?: scalar|Param|null,
  *                 metadata?: array<string, mixed>,
  *             }>,
  *             transitions?: list<array{ // Default: []
  *                 name?: string|Param,
  *                 guard?: string|Param, // An expression to block the transition.
- *                 from?: \BackedEnum|string|list<array{ // Default: []
+ *                 from?: list<array{ // Default: []
  *                     place?: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
- *                 to?: \BackedEnum|string|list<array{ // Default: []
+ *                 to?: list<array{ // Default: []
  *                     place?: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
@@ -271,7 +271,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
  *         json_manifest_path?: scalar|Param|null, // Default: null
  *         base_path?: scalar|Param|null, // Default: ""
- *         base_urls?: string|list<scalar|Param|null>,
+ *         base_urls?: list<scalar|Param|null>,
  *         packages?: array<string, array{ // Default: []
  *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
  *             version_strategy?: scalar|Param|null, // Default: null
@@ -279,12 +279,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             version_format?: scalar|Param|null, // Default: null
  *             json_manifest_path?: scalar|Param|null, // Default: null
  *             base_path?: scalar|Param|null, // Default: ""
- *             base_urls?: string|list<scalar|Param|null>,
+ *             base_urls?: list<scalar|Param|null>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: false
- *         paths?: string|array<string, scalar|Param|null>,
+ *         paths?: array<string, scalar|Param|null>,
  *         excluded_patterns?: list<scalar|Param|null>,
  *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
  *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
@@ -303,7 +303,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     translator?: bool|array{ // Translator configuration
  *         enabled?: bool|Param, // Default: true
- *         fallbacks?: string|list<scalar|Param|null>,
+ *         fallbacks?: list<scalar|Param|null>,
  *         logging?: bool|Param, // Default: false
  *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
  *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
@@ -333,7 +333,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: true
  *         cache?: scalar|Param|null, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
  *         enable_attributes?: bool|Param, // Default: true
- *         static_method?: string|list<scalar|Param|null>,
+ *         static_method?: list<scalar|Param|null>,
  *         translation_domain?: scalar|Param|null, // Default: "validators"
  *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose"|Param, // Default: "html5"
  *         mapping?: array{
@@ -396,7 +396,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
  *         default_pdo_provider?: scalar|Param|null, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: string|list<scalar|Param|null>,
+ *             adapters?: list<scalar|Param|null>,
  *             tags?: scalar|Param|null, // Default: null
  *             public?: bool|Param, // Default: false
  *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
@@ -419,11 +419,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     lock?: bool|string|array{ // Lock configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: string|array<string, string|list<scalar|Param|null>>,
+ *         resources?: array<string, string|list<scalar|Param|null>>,
  *     },
  *     semaphore?: bool|string|array{ // Semaphore configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: string|array<string, scalar|Param|null>,
+ *         resources?: array<string, scalar|Param|null>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: false
@@ -453,7 +453,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
  *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: int|string|list<scalar|Param|null>,
+ *         stop_worker_on_signals?: list<scalar|Param|null>,
  *         default_bus?: scalar|Param|null, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
  *             default_middleware?: bool|string|array{
@@ -461,7 +461,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 allow_no_handlers?: bool|Param, // Default: false
  *                 allow_no_senders?: bool|Param, // Default: true
  *             },
- *             middleware?: string|list<string|array{ // Default: []
+ *             middleware?: list<string|array{ // Default: []
  *                 id?: scalar|Param|null,
  *                 arguments?: list<mixed>,
  *             }>,
@@ -510,9 +510,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
  *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: int|string|array<string, array{ // Default: []
+ *                 http_codes?: array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
+ *                     methods?: list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -563,9 +563,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
  *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: int|string|array<string, array{ // Default: []
+ *                 http_codes?: array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
+ *                     methods?: list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -582,8 +582,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         transports?: array<string, scalar|Param|null>,
  *         envelope?: array{ // Mailer Envelope configuration
  *             sender?: scalar|Param|null,
- *             recipients?: string|list<scalar|Param|null>,
- *             allowed_recipients?: string|list<scalar|Param|null>,
+ *             recipients?: list<scalar|Param|null>,
+ *             allowed_recipients?: list<scalar|Param|null>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
  *             value?: mixed,
@@ -635,7 +635,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
  *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
  *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: string|list<scalar|Param|null>,
+ *             limiters?: list<scalar|Param|null>,
  *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
  *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
@@ -658,20 +658,20 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
  *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
  *             allow_elements?: array<string, mixed>,
- *             block_elements?: string|list<string|Param>,
- *             drop_elements?: string|list<string|Param>,
+ *             block_elements?: list<string|Param>,
+ *             drop_elements?: list<string|Param>,
  *             allow_attributes?: array<string, mixed>,
  *             drop_attributes?: array<string, mixed>,
  *             force_attributes?: array<string, array<string, string|Param>>,
  *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: string|list<string|Param>,
- *             allowed_link_hosts?: null|string|list<string|Param>,
+ *             allowed_link_schemes?: list<string|Param>,
+ *             allowed_link_hosts?: list<string|Param>|null,
  *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: string|list<string|Param>,
- *             allowed_media_hosts?: null|string|list<string|Param>,
+ *             allowed_media_schemes?: list<string|Param>,
+ *             allowed_media_hosts?: list<string|Param>|null,
  *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: string|list<string|Param>,
- *             without_attribute_sanitizers?: string|list<string|Param>,
+ *             with_attribute_sanitizers?: list<string|Param>,
+ *             without_attribute_sanitizers?: list<string|Param>,
  *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
  *         }>,
  *     },
@@ -705,7 +705,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     password_hashers?: array<string, string|array{ // Default: []
  *         algorithm?: scalar|Param|null,
- *         migrate_from?: string|list<scalar|Param|null>,
+ *         migrate_from?: list<scalar|Param|null>,
  *         hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
  *         key_length?: scalar|Param|null, // Default: 40
  *         ignore_case?: bool|Param, // Default: false
@@ -719,12 +719,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     providers?: array<string, array{ // Default: []
  *         id?: scalar|Param|null,
  *         chain?: array{
- *             providers?: string|list<scalar|Param|null>,
+ *             providers?: list<scalar|Param|null>,
  *         },
  *         memory?: array{
  *             users?: array<string, array{ // Default: []
  *                 password?: scalar|Param|null, // Default: null
- *                 roles?: string|list<scalar|Param|null>,
+ *                 roles?: list<scalar|Param|null>,
  *             }>,
  *         },
  *         ldap?: array{
@@ -733,7 +733,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             search_dn?: scalar|Param|null, // Default: null
  *             search_password?: scalar|Param|null, // Default: null
  *             extra_fields?: list<scalar|Param|null>,
- *             default_roles?: string|list<scalar|Param|null>,
+ *             default_roles?: list<scalar|Param|null>,
  *             role_fetcher?: scalar|Param|null, // Default: null
  *             uid_key?: scalar|Param|null, // Default: "sAMAccountName"
  *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
@@ -748,7 +748,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     firewalls?: array<string, array{ // Default: []
  *         pattern?: scalar|Param|null,
  *         host?: scalar|Param|null,
- *         methods?: string|list<scalar|Param|null>,
+ *         methods?: list<scalar|Param|null>,
  *         security?: bool|Param, // Default: true
  *         user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
  *         request_matcher?: scalar|Param|null,
@@ -767,8 +767,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             path?: scalar|Param|null, // Default: "/logout"
  *             target?: scalar|Param|null, // Default: "/"
  *             invalidate_session?: bool|Param, // Default: true
- *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
- *             delete_cookies?: string|array<string, array{ // Default: []
+ *             clear_site_data?: list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
+ *             delete_cookies?: array<string, array{ // Default: []
  *                 path?: scalar|Param|null, // Default: null
  *                 domain?: scalar|Param|null, // Default: null
  *                 secure?: scalar|Param|null, // Default: false
@@ -906,7 +906,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             success_handler?: scalar|Param|null,
  *             failure_handler?: scalar|Param|null,
  *             realm?: scalar|Param|null, // Default: null
- *             token_extractors?: string|list<scalar|Param|null>,
+ *             token_extractors?: list<scalar|Param|null>,
  *             token_handler?: string|array{
  *                 id?: scalar|Param|null,
  *                 oidc_user_info?: string|array{
@@ -921,7 +921,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 },
  *                 oidc?: array{
  *                     discovery?: array{ // Enable the OIDC discovery.
- *                         base_uri?: string|list<scalar|Param|null>,
+ *                         base_uri?: list<scalar|Param|null>,
  *                         cache?: array{
  *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
@@ -964,7 +964,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         remember_me?: array{
  *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
  *             service?: scalar|Param|null,
- *             user_providers?: string|list<scalar|Param|null>,
+ *             user_providers?: list<scalar|Param|null>,
  *             catch_exceptions?: bool|Param, // Default: true
  *             signature_properties?: list<scalar|Param|null>,
  *             token_provider?: string|array{
@@ -992,12 +992,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         path?: scalar|Param|null, // Use the urldecoded format. // Default: null
  *         host?: scalar|Param|null, // Default: null
  *         port?: int|Param, // Default: null
- *         ips?: string|list<scalar|Param|null>,
+ *         ips?: list<scalar|Param|null>,
  *         attributes?: array<string, scalar|Param|null>,
  *         route?: scalar|Param|null, // Default: null
- *         methods?: string|list<scalar|Param|null>,
+ *         methods?: list<scalar|Param|null>,
  *         allow_if?: scalar|Param|null, // Default: null
- *         roles?: string|list<scalar|Param|null>,
+ *         roles?: list<scalar|Param|null>,
  *     }>,
  *     role_hierarchy?: array<string, string|list<scalar|Param|null>>,
  * }
@@ -1018,7 +1018,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     auto_reload?: scalar|Param|null,
  *     optimizations?: int|Param,
  *     default_path?: scalar|Param|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
- *     file_name_pattern?: string|list<scalar|Param|null>,
+ *     file_name_pattern?: list<scalar|Param|null>,
  *     paths?: array<string, mixed>,
  *     date?: array{ // The default format options used by the date filter.
  *         format?: scalar|Param|null, // Default: "F j, Y H:i"
@@ -1111,7 +1111,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         delay_between_messages?: bool|Param, // Default: false
  *         topic?: int|Param, // Default: null
  *         factor?: int|Param, // Default: 1
- *         tags?: string|list<scalar|Param|null>,
+ *         tags?: list<scalar|Param|null>,
  *         console_formatter_options?: mixed, // Default: []
  *         formatter?: scalar|Param|null,
  *         nested?: bool|Param, // Default: false
@@ -1155,7 +1155,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             host?: scalar|Param|null,
  *         },
  *         from_email?: scalar|Param|null,
- *         to_email?: string|list<scalar|Param|null>,
+ *         to_email?: list<scalar|Param|null>,
  *         subject?: scalar|Param|null,
  *         content_type?: scalar|Param|null, // Default: null
  *         headers?: list<scalar|Param|null>,

--- a/config/services/ci/controllers.yml
+++ b/config/services/ci/controllers.yml
@@ -50,6 +50,7 @@ services:
             - '@OpenConext\EngineBlock\Validator\UnsolicitedSsoRequestValidator'
             - '@OpenConext\EngineBlock\Service\AuthenticationStateHelper'
             - '@engineblock.functional_testing.fixture.features'
+            - '@router'
 
     engineblock.functional_test.controller.sbs:
         class: OpenConext\EngineBlockFunctionalTestingBundle\Controllers\SbsController

--- a/config/services/ci/services.yml
+++ b/config/services/ci/services.yml
@@ -149,6 +149,13 @@ services:
             - '@engineblock.functional_testing.fixture.features'
             - '%stepup.sfo.override_engine_entityid%'
 
+    OpenConext\EngineBlockBundle\Twig\Extensions\Extension\Wayf:
+        autoconfigure: true
+        arguments:
+            - '@request_stack'
+            - '@translator'
+            - '@engineblock.functional_testing.fixture.features'
+
     OpenConext\EngineBlockBundle\Twig\Extensions\Extension\FunctionalTestingGlobalSiteNotice:
         autoconfigure: true
         arguments:

--- a/config/services/controllers/authentication.yml
+++ b/config/services/controllers/authentication.yml
@@ -22,6 +22,7 @@ services:
             - '@OpenConext\EngineBlock\Validator\UnsolicitedSsoRequestValidator'
             - '@OpenConext\EngineBlock\Service\AuthenticationStateHelper'
             - '@OpenConext\EngineBlockBundle\Configuration\FeatureConfiguration'
+            - '@router'
 
     OpenConext\EngineBlockBundle\Controller\IndexController:
         arguments:

--- a/languages/messages.en.php
+++ b/languages/messages.en.php
@@ -234,6 +234,8 @@ Your %organisationNoun% does not provide the mandatory information. Therefore, y
     'error_authentication_limit_exceeded' => 'Error - too many authentications in progress',
     'error_authentication_limit_exceeded_desc' => 'Too many authentications in progress',
     'error_no_authentication_request_received' => 'Error - No authentication request received.',
+    'error_bookmarked_page'      => 'Error - This page no longer exists',
+    'error_bookmarked_page_desc' => 'The page you are trying to visit no longer exists. You probably saved a bookmark, but unfortunately that doesn\'t work. Search for the correct link to the application you want to log in to in order to gain access.',
     'error_authn_context_class_ref_blacklisted'                     => 'Error - AuthnContextClassRef value is not allowed',
     'error_authn_context_class_ref_blacklisted_desc'                => 'You cannot login because %idpName% sent a value for AuthnContextClassRef that is not allowed. Please contact the service desk of %idpName% to solve this.',
     'error_authn_context_class_ref_blacklisted_desc_no_idp_name'                => 'You cannot login because your %organisationNoun% sent a value for AuthnContextClassRef that is not allowed. Please contact the service desk of your %organisationNoun% to solve this.',

--- a/languages/messages.nl.php
+++ b/languages/messages.nl.php
@@ -231,6 +231,8 @@ HTML
     'error_authentication_limit_exceeded' => 'Fout - teveel onafgeronde authenticaties tegelijkertijd.',
     'error_authentication_limit_exceeded_desc' => 'Teveel onafgeronde authenticaties tegelijkertijd.',
     'error_no_authentication_request_received' => 'Fout - Geen authenticatie-aanvraag ontvangen.',
+    'error_bookmarked_page'      => 'Fout - Deze pagina bestaat niet meer',
+    'error_bookmarked_page_desc' => 'De pagina die je probeert te bezoeken bestaat niet meer. Waarschijnlijk heb je de pagina als bladwijzer opgeslagen, maar dat werkt helaas niet. Zoek de juiste link naar de applicatie waarop je wilt inloggen om toegang te krijgen.',
     'error_authn_context_class_ref_blacklisted' => 'Fout - Waarde van AuthnContextClassRef is niet toegestaan',
     'error_authn_context_class_ref_blacklisted_desc' => 'Je kunt niet inloggen omdat %idpName% een waarde stuurde voor AuthnContextClassRef die niet is toegestaan. Neem contact op met de helpdesk van %idpName% om dit op te lossen.',
     'error_authn_context_class_ref_blacklisted_desc_no_idp_name' => 'Je kunt niet inloggen omdat je %organisationNoun% een waarde stuurde voor AuthnContextClassRef die niet is toegestaan. Neem contact op met de helpdesk van je %organisationNoun% om dit op te lossen.',

--- a/languages/messages.pt.php
+++ b/languages/messages.pt.php
@@ -231,6 +231,8 @@ A sua %organisationNoun% negou-lhe acesso a este serviço. Terá de entrar em co
     'error_invalid_mfa_authn_context_class_ref_desc' => '<p>A %idpName% requer segurança adicional para este serviço, por meio de um segundo fator de autenticação (2FA). No entanto, o seu segundo fator de autenticação não pôde ser verificado. Entre em contato com o suporte da %idpName% para validar esta situação.</p>',
     'error_invalid_mfa_authn_context_class_ref_desc_no_idp_name' => '<p>A sua %organisationNoun% requer segurança adicional para este serviço, por meio de um segundo fator de autenticação (2FA). No entanto, o seu segundo fator de autenticação não pôde ser verificado. Entre em contato com o suporte da sua %organisationNoun% para validar esta situação.</p>',
     'error_no_authentication_request_received' => 'Não foi recebida nenhuma solicitação de autenticação.',
+    'error_bookmarked_page'      => 'Erro - Esta página já não existe',
+    'error_bookmarked_page_desc' => 'A página que está a tentar visitar já não existe. Provavelmente guardou um marcador, mas infelizmente isso não funciona. Procure o link correto para a aplicação em que pretende iniciar sessão para obter acesso.',
     /**
      * %1 AttributeName
      * %2 Options

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -48,7 +48,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.feature_enable_idp_initiated_flow', true));
         $this->setFeature(new Feature('eb.stepup.send_user_attributes', true));
         $this->setFeature(new Feature('eb.feature_enable_sram_interrupt', true));
-        $this->setFeature(new Feature('eb.hide_bookmarkable_url', false));
+        $this->setFeature(new Feature('eb.hide_bookmarkable_url', true));
     }
 
     public function setFeature(Feature $feature): void

--- a/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/FeedbackController.php
@@ -153,6 +153,15 @@ class FeedbackController
         ],
         methods: ['GET']
     )]
+    #[Route(
+        path: '/authentication/feedback/bookmarked-page',
+        name: 'authentication_feedback_bookmarked_page',
+        defaults: [
+            'pageIdentifier' => 'bookmarked-page',
+            'statusCode' => 400
+        ],
+        methods: ['GET']
+    )]
     public function feedbackAction(string $pageIdentifier, int $statusCode): Response
     {
         return new Response(

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -40,6 +40,8 @@ use Twig\Environment;
  */
 class IdentityProviderController implements AuthenticationLoopThrottlingController
 {
+    private const FEEDBACK_BOOKMARK = 'bookmark';
+
     /**
      * @var EngineBlock_ApplicationSingleton
      */
@@ -132,7 +134,7 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
     #[Route(path: '/authentication/idp/single-sign-on/{idpHash}', name: 'authentication_idp_sso_idphash', methods: ['GET', 'POST'])]
     public function singleSignOnAction(Request $request, ?string $keyId = null, ?string $idpHash = null)
     {
-        if ($request->query->get('feedback') === 'bookmark') {
+        if ($request->query->get('feedback') === self::FEEDBACK_BOOKMARK) {
             return new RedirectResponse(
                 $this->urlGenerator->generate('authentication_feedback_bookmarked_page', [], UrlGeneratorInterface::ABSOLUTE_PATH)
             );

--- a/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
+++ b/src/OpenConext/EngineBlockBundle/Controller/IdentityProviderController.php
@@ -26,14 +26,17 @@ use OpenConext\EngineBlock\Validator\RequestValidator;
 use OpenConext\EngineBlockBridge\ResponseFactory;
 use OpenConext\EngineBlockBundle\Configuration\FeatureConfigurationInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Due to the compatibility requirements
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList) Due to the compatibility requirements
  */
 class IdentityProviderController implements AuthenticationLoopThrottlingController
 {
@@ -82,6 +85,11 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
      */
     private $featureConfiguration;
 
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
     public function __construct(
         EngineBlock_ApplicationSingleton $engineBlockApplicationSingleton,
         Environment $twig,
@@ -91,7 +99,8 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
         RequestValidator $bindingValidator,
         RequestValidator $unsolicitedRequestValidator,
         AuthenticationStateHelperInterface $authenticationStateHelper,
-        FeatureConfigurationInterface $featureConfiguration
+        FeatureConfigurationInterface $featureConfiguration,
+        UrlGeneratorInterface $urlGenerator
     ) {
         $this->engineBlockApplicationSingleton = $engineBlockApplicationSingleton;
         $this->twig = $twig;
@@ -102,6 +111,7 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
         $this->unsolicitedRequestValidator = $unsolicitedRequestValidator;
         $this->authenticationStateHelper = $authenticationStateHelper;
         $this->featureConfiguration = $featureConfiguration;
+        $this->urlGenerator = $urlGenerator;
     }
 
     /**
@@ -122,6 +132,12 @@ class IdentityProviderController implements AuthenticationLoopThrottlingControll
     #[Route(path: '/authentication/idp/single-sign-on/{idpHash}', name: 'authentication_idp_sso_idphash', methods: ['GET', 'POST'])]
     public function singleSignOnAction(Request $request, ?string $keyId = null, ?string $idpHash = null)
     {
+        if ($request->query->get('feedback') === 'bookmark') {
+            return new RedirectResponse(
+                $this->urlGenerator->generate('authentication_feedback_bookmarked_page', [], UrlGeneratorInterface::ABSOLUTE_PATH)
+            );
+        }
+
         $this->requestValidator->isValid($request);
         $this->bindingValidator->isValid($request);
 

--- a/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
+++ b/src/OpenConext/EngineBlockBundle/EventListener/RedirectToFeedbackPageExceptionListener.php
@@ -207,7 +207,7 @@ class RedirectToFeedbackPageExceptionListener
             $redirectToRoute = 'authentication_feedback_authentication_limit_exceeded';
         } elseif ($exception instanceof InvalidRequestMethodException ||
             $exception instanceof InvalidBindingException ||
-            $exception instanceof  MissingParameterException
+            $exception instanceof MissingParameterException
         ) {
             $message = $exception->getMessage();
             $event->getRequest()->getSession()->set('feedback_custom', $exception->getMessage());

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/HideBookmarkableUrl.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/HideBookmarkableUrl.feature
@@ -14,3 +14,20 @@ Feature:
     When I log in at "Dummy SP"
      And I go to Engineblock URL "/authentication/idp/single-sign-on"
     Then I should see "The parameter \"SAMLRequest\" is missing on the SAML SSO request"
+
+  Scenario: Visiting a bookmarked WAYF URL shows the bookmark error page
+    When I log in at "Dummy SP"
+     And I go to Engineblock URL "/authentication/idp/single-sign-on?feedback=bookmark"
+    Then I should see "This page no longer exists"
+
+  Scenario: WAYF page includes hideBookmarkableUrl true in config when feature flag is enabled
+    Given feature "eb.hide_bookmarkable_url" is enabled
+      And an Identity Provider named "Second Idp"
+    When I log in at "Dummy SP"
+    Then the response should contain '"hideBookmarkableUrl": true'
+
+  Scenario: WAYF page includes hideBookmarkableUrl false in config when feature flag is disabled
+    Given feature "eb.hide_bookmarkable_url" is disabled
+      And an Identity Provider named "Second Idp"
+    When I log in at "Dummy SP"
+    Then the response should contain '"hideBookmarkableUrl": false'

--- a/tests/unit/OpenConext/EngineBlockBundle/Controller/IdentityProviderControllerTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Controller/IdentityProviderControllerTest.php
@@ -33,6 +33,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
 class IdentityProviderControllerTest extends TestCase
@@ -50,7 +51,8 @@ class IdentityProviderControllerTest extends TestCase
             Mockery::mock(RequestValidator::class),
             Mockery::mock(RequestValidator::class),
             Mockery::mock(AuthenticationStateHelperInterface::class),
-            Mockery::mock(FeatureConfigurationInterface::class)
+            Mockery::mock(FeatureConfigurationInterface::class),
+            Mockery::mock(UrlGeneratorInterface::class)
         );
     }
 

--- a/theme/base/javascripts/wayf/hideBookmarkableUrl.js
+++ b/theme/base/javascripts/wayf/hideBookmarkableUrl.js
@@ -1,10 +1,18 @@
+import {configurationId} from '../selectors';
+
 export const hideBookmarkableUrl = () => {
-  const configEl = document.getElementById('wayf-configuration');
+  const configEl = document.getElementById(configurationId);
   if (!configEl) {
     return;
   }
 
-  const config = JSON.parse(configEl.innerHTML);
+  let config;
+  try {
+    config = JSON.parse(configEl.innerHTML);
+  } catch (e) {
+    return;
+  }
+
   if (!config.hideBookmarkableUrl) {
     return;
   }


### PR DESCRIPTION
## Summary

- Adds `/authentication/feedback/bookmarked-page` route to `FeedbackController`
- `RedirectToFeedbackPageExceptionListener` detects `?feedback=bookmark` on a `MissingParameterException` and redirects to the new route instead of the generic "no authentication request received" page
- Translations added in EN, NL, and PT

## Context

Follow-up of #1973 / PR #1987. When `eb.hide_bookmarkable_url` is enabled, the JS replaces `?SAMLRequest=…` with `?feedback=bookmark` in the address bar. If the user bookmarks that URL and revisits it, they now see a specific, user-friendly error instead of a generic one.

Closes #1976

## Test plan

- [ ] Unit suite passes (`phpunit --testsuite=unit`)
- [ ] Behat scenario in `HideBookmarkableUrl.feature` passes
- [ ] Manually visit `/authentication/idp/single-sign-on?feedback=bookmark` → redirects to `/authentication/feedback/bookmarked-page` → shows "This page no longer exists"