### PR TITLE
Add extra logging around consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ SBS integration:
 * Add support for [SBS](https://github.com/SURFscz/SBS)/[SRAM](https://sram.surf.nl/):
   * Allows autorization based on SBS collaborations/services
   * Allows adding [AARC-G002](https://aarc-community.org/guidelines/aarc-g002/) group/collaboration attributes
+* Add logging why consent is skipped if additional logging is enabled
 
 This version of Engineblock requested [SBS](https://github.com/SURFscz/SBS) v69 (if SBS integration is enabled) and has been
 tested with [Manage](https://github.com/OpenConext/OpenConext-manage/) 9.6.

--- a/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
+++ b/library/EngineBlock/Corto/Module/Service/ProvideConsent.php
@@ -146,6 +146,10 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
 
 
         if ($this->isConsentDisabled($spMetadataChain, $identityProvider)) {
+            if ($requireAdditionalLogging) {
+                $this->logger->info('Consent is disabled, skipping consent screen');
+            }
+
             if (!$consentRepository->implicitConsentWasGivenFor($serviceProviderMetadata)) {
                 $consentRepository->giveImplicitConsentFor($serviceProviderMetadata);
             }
@@ -166,6 +170,10 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
 
         $priorConsent = $consentRepository->explicitConsentWasGivenFor($serviceProviderMetadata);
         if ($priorConsent) {
+            if ($requireAdditionalLogging) {
+                $this->logger->info('Prior consent was found, skipping consent screen');
+            }
+
             $response->setConsent(Constants::CONSENT_PRIOR);
 
             $response->setDestination($response->getReturn());
@@ -247,6 +255,10 @@ class EngineBlock_Corto_Module_Service_ProvideConsent
                 'hideFooter' => true,
             ]
         );
+
+        if ($requireAdditionalLogging) {
+            $this->logger->info('Showing consent screen');
+        }
 
         $this->_server->sendOutput($html);
     }


### PR DESCRIPTION
Consent issues are currently quite hard to debug.  This PR adds extra logging when consent is kipped or displayed if additional logging for the IdP or SP is enabled.