### PR TITLE
feat(stepup): add service display name to Stepup callout AuthnRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ More information about our release strategy can be found in
 the [Development Guidelines](https://github.com/OpenConext/OpenConext-engineblock/wiki/Development-Guidelines#release-notes)
 on the EngineBlock wiki.
 
+## UNRELEASED
+Features:
+* Added `eb.stepup.send_service_name` feature flag. When enabled, EngineBlock adds an `mdui:UIInfo`/`DisplayName` extension with the SP's display name to the Stepup callout AuthnRequest (#2034).
+
 ## 7.2.0
 
 Maintenance:

--- a/config/packages/engineblock_features.yaml
+++ b/config/packages/engineblock_features.yaml
@@ -15,5 +15,6 @@ parameters:
         eb.feature_enable_idp_initiated_flow: "%feature_enable_idp_initiated_flow%"
         eb.stepup.sfo.override_engine_entityid: "%feature_stepup_sfo_override_engine_entityid%"
         eb.stepup.send_user_attributes: "%feature_stepup_send_user_attributes%"
+        eb.stepup.send_service_name: "%feature_stepup_send_service_name%"
         eb.feature_enable_sram_interrupt: "%feature_enable_sram_interrupt%"
         eb.hide_bookmarkable_url: "%feature_hide_bookmarkable_url%"

--- a/config/packages/parameters.yml.dist
+++ b/config/packages/parameters.yml.dist
@@ -235,6 +235,7 @@ parameters:
     feature_enable_idp_initiated_flow: true
     feature_stepup_sfo_override_engine_entityid: false
     feature_stepup_send_user_attributes: false
+    feature_stepup_send_service_name: false
     feature_enable_sram_interrupt: false
     feature_hide_bookmarkable_url: false
 

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -27,6 +27,7 @@ use OpenConext\EngineBlock\Metadata\MfaEntity;
 use OpenConext\EngineBlock\Metadata\Service;
 use OpenConext\EngineBlock\Metadata\TransparentMfaEntity;
 use OpenConext\EngineBlock\Stepup\StepupGsspUserAttributeExtension;
+use OpenConext\EngineBlock\Stepup\StepupServiceNameExtension;
 use OpenConext\EngineBlock\Metadata\X509\KeyPairFactory;
 use OpenConext\EngineBlockBundle\Authentication\AuthenticationState;
 use OpenConext\EngineBlockBundle\Exception\UnknownKeyIdException;
@@ -486,7 +487,8 @@ class EngineBlock_Corto_ProxyServer
         Loa $authnContextClassRef,
         NameID $nameId,
         bool $isForceAuthn,
-        Assertion $originalAssertion
+        Assertion $originalAssertion,
+        ?ServiceProvider $sp = null,
     ): void {
         $ebRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest(
             $spRequest,
@@ -555,6 +557,13 @@ class EngineBlock_Corto_ProxyServer
             }
         }
 
+        $isSendServiceNameConfigured = $features->hasFeature('eb.stepup.send_service_name');
+        $isSendServiceNameEnabled = $features->isEnabled('eb.stepup.send_service_name');
+
+        if ($isSendServiceNameConfigured && $isSendServiceNameEnabled && $sp !== null) {
+            $locale = $container->getLocaleProvider()->getLocale();
+            StepupServiceNameExtension::add($sspMessage, $sp, $locale);
+        }
 
         // Link with the original Request
         $diContainerRuntime = EngineBlock_ApplicationSingleton::getInstance()->getDiContainerRuntime();
@@ -635,6 +644,7 @@ class EngineBlock_Corto_ProxyServer
             $nameId,
             $sp->getCoins()->isStepupForceAuthn(),
             $originalAssertion,
+            $sp,
         );
     }
 

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -557,10 +557,11 @@ class EngineBlock_Corto_ProxyServer
             }
         }
 
-        $isSendServiceNameConfigured = $features->hasFeature('eb.stepup.send_service_name');
-        $isSendServiceNameEnabled = $features->isEnabled('eb.stepup.send_service_name');
-
-        if ($isSendServiceNameConfigured && $isSendServiceNameEnabled && $sp !== null) {
+        if (
+            $features->hasFeature('eb.stepup.send_service_name')
+            && $features->isEnabled('eb.stepup.send_service_name')
+            && $sp !== null
+        ) {
             $localeProvider = $container->getLocaleProvider();
             StepupServiceNameExtension::add(
                 $sspMessage,

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -561,8 +561,14 @@ class EngineBlock_Corto_ProxyServer
         $isSendServiceNameEnabled = $features->isEnabled('eb.stepup.send_service_name');
 
         if ($isSendServiceNameConfigured && $isSendServiceNameEnabled && $sp !== null) {
-            $locale = $container->getLocaleProvider()->getLocale();
-            StepupServiceNameExtension::add($sspMessage, $sp, $locale);
+            $localeProvider = $container->getLocaleProvider();
+            StepupServiceNameExtension::add(
+                $sspMessage,
+                $sp,
+                $localeProvider->getLocale(),
+                $localeProvider->getDefaultLocale(),
+                $localeProvider->getAvailableLocales(),
+            );
         }
 
         // Link with the original Request

--- a/library/EngineBlock/Corto/ProxyServer.php
+++ b/library/EngineBlock/Corto/ProxyServer.php
@@ -488,7 +488,7 @@ class EngineBlock_Corto_ProxyServer
         NameID $nameId,
         bool $isForceAuthn,
         Assertion $originalAssertion,
-        ?ServiceProvider $sp = null,
+        ServiceProvider $sp,
     ): void {
         $ebRequest = EngineBlock_Saml2_AuthnRequestFactory::createFromRequest(
             $spRequest,
@@ -557,10 +557,8 @@ class EngineBlock_Corto_ProxyServer
             }
         }
 
-        if (
-            $features->hasFeature('eb.stepup.send_service_name')
+        if ($features->hasFeature('eb.stepup.send_service_name')
             && $features->isEnabled('eb.stepup.send_service_name')
-            && $sp !== null
         ) {
             $localeProvider = $container->getLocaleProvider();
             StepupServiceNameExtension::add(

--- a/src/OpenConext/EngineBlock/Stepup/StepupServiceNameExtension.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupServiceNameExtension.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace OpenConext\EngineBlock\Stepup;
+
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use SAML2\DOMDocumentFactory;
+use SAML2\Message;
+use SAML2\XML\Chunk;
+
+final class StepupServiceNameExtension
+{
+    private const MDUI_NS = 'urn:oasis:names:tc:SAML:metadata:ui';
+    private const SUPPORTED_LOCALES = ['en', 'nl', 'pt'];
+
+    public static function add(Message $message, ServiceProvider $sp, string $locale): void
+    {
+        if (!in_array($locale, self::SUPPORTED_LOCALES, true)) {
+            $locale = 'en';
+        }
+        $result = self::resolveName($sp, $locale);
+        if ($result === null && $locale !== 'en') {
+            $result = self::resolveName($sp, 'en');
+        }
+        if ($result === null) {
+            return;
+        }
+        [$resolvedLocale, $name] = $result;
+
+        $dom = DOMDocumentFactory::create();
+        $uiInfo = $dom->createElementNS(self::MDUI_NS, 'mdui:UIInfo');
+        $displayName = $dom->createElementNS(self::MDUI_NS, 'mdui:DisplayName');
+        $displayName->setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:lang', $resolvedLocale);
+        $displayName->textContent = $name;
+        $uiInfo->appendChild($displayName);
+
+        $ext = $message->getExtensions();
+        $ext['mdui:UIInfo'] = new Chunk($uiInfo);
+        $message->setExtensions($ext);
+    }
+
+    /**
+     * @return array{string, string}|null
+     */
+    private static function resolveName(ServiceProvider $sp, string $locale): ?array
+    {
+        $name = $sp->getMdui()->getDisplayNameOrNull($locale);
+        if (empty($name)) {
+            $name = $sp->{'name' . ucfirst($locale)};
+        }
+        if (empty($name)) {
+            return null;
+        }
+        return [$locale, $name];
+    }
+}

--- a/src/OpenConext/EngineBlock/Stepup/StepupServiceNameExtension.php
+++ b/src/OpenConext/EngineBlock/Stepup/StepupServiceNameExtension.php
@@ -28,16 +28,23 @@ use SAML2\XML\Chunk;
 final class StepupServiceNameExtension
 {
     private const MDUI_NS = 'urn:oasis:names:tc:SAML:metadata:ui';
-    private const SUPPORTED_LOCALES = ['en', 'nl', 'pt'];
 
-    public static function add(Message $message, ServiceProvider $sp, string $locale): void
-    {
-        if (!in_array($locale, self::SUPPORTED_LOCALES, true)) {
-            $locale = 'en';
+    /**
+     * @param string[] $availableLocales
+     */
+    public static function add(
+        Message $message,
+        ServiceProvider $sp,
+        string $locale,
+        string $defaultLocale,
+        array $availableLocales,
+    ): void {
+        if (!in_array($locale, $availableLocales, true)) {
+            $locale = $defaultLocale;
         }
         $result = self::resolveName($sp, $locale);
-        if ($result === null && $locale !== 'en') {
-            $result = self::resolveName($sp, 'en');
+        if ($result === null && $locale !== $defaultLocale) {
+            $result = self::resolveName($sp, $defaultLocale);
         }
         if ($result === null) {
             return;
@@ -63,11 +70,21 @@ final class StepupServiceNameExtension
     {
         $name = $sp->getMdui()->getDisplayNameOrNull($locale);
         if (empty($name)) {
-            $name = $sp->{'name' . ucfirst($locale)};
+            $name = self::localizedName($sp, $locale);
         }
         if (empty($name)) {
             return null;
         }
         return [$locale, $name];
+    }
+
+    private static function localizedName(ServiceProvider $sp, string $locale): ?string
+    {
+        return match ($locale) {
+            'en' => $sp->nameEn,
+            'nl' => $sp->nameNl,
+            'pt' => $sp->namePt,
+            default => null,
+        };
     }
 }

--- a/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
+++ b/src/OpenConext/EngineBlockBundle/Configuration/TestFeatureConfiguration.php
@@ -47,6 +47,7 @@ class TestFeatureConfiguration implements FeatureConfigurationInterface
         $this->setFeature(new Feature('eb.stepup.sfo.override_engine_entityid', false));
         $this->setFeature(new Feature('eb.feature_enable_idp_initiated_flow', true));
         $this->setFeature(new Feature('eb.stepup.send_user_attributes', true));
+        $this->setFeature(new Feature('eb.stepup.send_service_name', false));
         $this->setFeature(new Feature('eb.feature_enable_sram_interrupt', true));
         $this->setFeature(new Feature('eb.hide_bookmarkable_url', true));
     }

--- a/src/OpenConext/EngineBlockBundle/Localization/LocaleProvider.php
+++ b/src/OpenConext/EngineBlockBundle/Localization/LocaleProvider.php
@@ -60,6 +60,22 @@ final class LocaleProvider
     /**
      * @return string
      */
+    public function getDefaultLocale()
+    {
+        return $this->defaultLocale;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAvailableLocales()
+    {
+        return $this->availableLocales;
+    }
+
+    /**
+     * @return string
+     */
     public function getLocale()
     {
         if (!$this->request) {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Context/EngineBlockContext.php
@@ -688,6 +688,7 @@ class EngineBlockContext extends AbstractSubContext
 
         $xpathObject = new DOMXPath($authnRequest);
         $xpathObject->registerNamespace('gssp', 'urn:mace:surf.nl:stepup:gssp-extensions');
+        $xpathObject->registerNamespace('mdui', 'urn:oasis:names:tc:SAML:metadata:ui');
         $nodeList = $xpathObject->query($xpath);
 
         if (!$nodeList || $nodeList->length === 0) {

--- a/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
+++ b/src/OpenConext/EngineBlockFunctionalTestingBundle/Features/Stepup.feature
@@ -291,3 +291,20 @@ Feature:
       And I pass through EngineBlock
       And I pass through the IdP
     Then the received AuthnRequest should match xpath '/samlp:AuthnRequest/samlp:Extensions/gssp:UserAttributes/saml:Attribute[@Name="urn:mace:dir:attribute-def:mail"]/saml:AttributeValue[text()="j.doe@institution-a.example.org"]'
+
+  Scenario: Stepup callout includes service name in mdui:UIInfo when feature is enabled
+    Given the SP "SSO-SP" requires Stepup LoA "http://dev.openconext.local/assurance/loa2"
+      And feature "eb.stepup.send_service_name" is enabled
+    When I log in at "SSO-SP"
+      And I select "SSO-IdP" on the WAYF
+      And I pass through EngineBlock
+      And I pass through the IdP
+    Then the received AuthnRequest should match xpath '/samlp:AuthnRequest/samlp:Extensions/mdui:UIInfo/mdui:DisplayName'
+
+  Scenario: Stepup callout does not include service name in mdui:UIInfo when feature is disabled
+    Given the SP "SSO-SP" requires Stepup LoA "http://dev.openconext.local/assurance/loa2"
+    When I log in at "SSO-SP"
+      And I select "SSO-IdP" on the WAYF
+      And I pass through EngineBlock
+      And I pass through the IdP
+    Then the received AuthnRequest should not match xpath '/samlp:AuthnRequest/samlp:Extensions/mdui:UIInfo/mdui:DisplayName'

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupServiceNameExtensionTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupServiceNameExtensionTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace OpenConext\EngineBlock\Stepup;
+
+use DOMDocument;
+use DOMElement;
+use DOMNodeList;
+use DOMXPath;
+use OpenConext\EngineBlock\Metadata\Entity\ServiceProvider;
+use OpenConext\EngineBlock\Metadata\Mdui;
+use PHPUnit\Framework\TestCase;
+use SAML2\AuthnRequest;
+use SAML2\XML\Chunk;
+
+class StepupServiceNameExtensionTest extends TestCase
+{
+    public function testAddsDisplayNameForRequestedLocale(): void
+    {
+        $sp = $this->spWithNames('My Service EN', 'Mijn Service NL');
+        $request = new AuthnRequest();
+
+        StepupServiceNameExtension::add($request, $sp, 'nl');
+
+        $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="nl"]');
+        $this->assertSame(1, $nodes->length);
+        $this->assertSame('Mijn Service NL', $nodes->item(0)->textContent);
+    }
+
+    public function testFallsBackToEnglishWhenRequestedLocaleHasNoName(): void
+    {
+        $sp = $this->spWithNames('My Service EN');
+        $request = new AuthnRequest();
+
+        StepupServiceNameExtension::add($request, $sp, 'nl');
+
+        $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
+        $this->assertSame(1, $nodes->length);
+        $this->assertSame('My Service EN', $nodes->item(0)->textContent);
+    }
+
+    public function testAddsNoExtensionWhenNeitherLocaleNorEnglishHasName(): void
+    {
+        $sp = $this->spWithNames();
+        $request = new AuthnRequest();
+
+        StepupServiceNameExtension::add($request, $sp, 'nl');
+
+        $ext = $request->getExtensions();
+        $this->assertArrayNotHasKey('mdui:UIInfo', $ext);
+    }
+
+    public function testMduiDisplayNameTakesPrecedenceOverFlatField(): void
+    {
+        $sp = $this->spWithMduiDisplayName('en', 'Mdui Service Name');
+        $sp->nameEn = 'Flat Field Name';
+        $request = new AuthnRequest();
+
+        StepupServiceNameExtension::add($request, $sp, 'en');
+
+        $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
+        $this->assertSame(1, $nodes->length);
+        $this->assertSame('Mdui Service Name', $nodes->item(0)->textContent);
+    }
+
+    public function testLocaleTagMatchesActualContentLocale(): void
+    {
+        $sp = $this->spWithNames('Only English Name');
+        $request = new AuthnRequest();
+
+        StepupServiceNameExtension::add($request, $sp, 'nl');
+
+        $nlNodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="nl"]');
+        $enNodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
+        $this->assertSame(0, $nlNodes->length, 'Should not add nl tag when using en fallback');
+        $this->assertSame(1, $enNodes->length, 'Should add en tag matching the actual content locale');
+    }
+
+    public function testFallsBackToFlatFieldWhenMduiDisplayNameIsEmpty(): void
+    {
+        $mduiJson = '{"DisplayName":{"name":"DisplayName","values":{"en":{"value":"","language":"en"}}},'
+            . '"Description":{"name":"Description"},"Keywords":{"name":"Keywords"},'
+            . '"Logo":{"name":"Logo"},"PrivacyStatementURL":{"name":"PrivacyStatementURL"}}';
+        $sp = new ServiceProvider('https://sp.example.org', Mdui::fromJson($mduiJson));
+        $sp->nameEn = 'Flat Field Name';
+        $request = new AuthnRequest();
+
+        StepupServiceNameExtension::add($request, $sp, 'en');
+
+        $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
+        $this->assertSame(1, $nodes->length);
+        $this->assertSame('Flat Field Name', $nodes->item(0)->textContent);
+    }
+
+    public function testPreservesExistingExtensions(): void
+    {
+        $sp = $this->spWithNames('My Service');
+        $request = new AuthnRequest();
+        $request->setExtensions(['existing:Extension' => new Chunk(
+            (new DOMDocument())->createElement('existing:Extension')
+        )]);
+
+        StepupServiceNameExtension::add($request, $sp, 'en');
+
+        $ext = $request->getExtensions();
+        $this->assertArrayHasKey('existing:Extension', $ext);
+        $this->assertArrayHasKey('mdui:UIInfo', $ext);
+    }
+
+    public function testUnsupportedLocaleFallsBackToEnglish(): void
+    {
+        $sp = $this->spWithNames('My Service EN', 'Mijn Service NL');
+        $request = new AuthnRequest();
+
+        StepupServiceNameExtension::add($request, $sp, 'en/../evil');
+
+        $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
+        $this->assertSame(1, $nodes->length);
+        $this->assertSame('My Service EN', $nodes->item(0)->textContent);
+    }
+
+    private function spWithNames(string $nameEn = '', string $nameNl = '', string $namePt = ''): ServiceProvider
+    {
+        $sp = new ServiceProvider('https://sp.example.org');
+        $sp->nameEn = $nameEn;
+        $sp->nameNl = $nameNl;
+        $sp->namePt = $namePt;
+        return $sp;
+    }
+
+    private function spWithMduiDisplayName(string $locale, string $displayName): ServiceProvider
+    {
+        $mduiJson = sprintf(
+            '{"DisplayName":{"name":"DisplayName","values":{"%s":{"value":"%s","language":"%s"}}},'
+            . '"Description":{"name":"Description"},"Keywords":{"name":"Keywords"},'
+            . '"Logo":{"name":"Logo"},"PrivacyStatementURL":{"name":"PrivacyStatementURL"}}',
+            $locale,
+            $displayName,
+            $locale
+        );
+        return new ServiceProvider('https://sp.example.org', Mdui::fromJson($mduiJson));
+    }
+
+    private function getExtensionElement(AuthnRequest $request): DOMElement
+    {
+        $ext = $request->getExtensions();
+        $this->assertArrayHasKey('mdui:UIInfo', $ext);
+        $chunk = $ext['mdui:UIInfo'];
+        $this->assertInstanceOf(Chunk::class, $chunk);
+        return $chunk->getXML();
+    }
+
+    private function queryXpath(AuthnRequest $request, string $expression): DOMNodeList
+    {
+        $el = $this->getExtensionElement($request);
+        $xpath = new DOMXPath($el->ownerDocument);
+        $xpath->registerNamespace('mdui', 'urn:oasis:names:tc:SAML:metadata:ui');
+        $xpath->registerNamespace('xml', 'http://www.w3.org/XML/1998/namespace');
+        return $xpath->query($expression, $el);
+    }
+}

--- a/tests/unit/OpenConext/EngineBlock/Stepup/StepupServiceNameExtensionTest.php
+++ b/tests/unit/OpenConext/EngineBlock/Stepup/StepupServiceNameExtensionTest.php
@@ -37,7 +37,7 @@ class StepupServiceNameExtensionTest extends TestCase
         $sp = $this->spWithNames('My Service EN', 'Mijn Service NL');
         $request = new AuthnRequest();
 
-        StepupServiceNameExtension::add($request, $sp, 'nl');
+        StepupServiceNameExtension::add($request, $sp, 'nl', 'en', ['en', 'nl', 'pt']);
 
         $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="nl"]');
         $this->assertSame(1, $nodes->length);
@@ -49,7 +49,7 @@ class StepupServiceNameExtensionTest extends TestCase
         $sp = $this->spWithNames('My Service EN');
         $request = new AuthnRequest();
 
-        StepupServiceNameExtension::add($request, $sp, 'nl');
+        StepupServiceNameExtension::add($request, $sp, 'nl', 'en', ['en', 'nl', 'pt']);
 
         $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
         $this->assertSame(1, $nodes->length);
@@ -61,7 +61,7 @@ class StepupServiceNameExtensionTest extends TestCase
         $sp = $this->spWithNames();
         $request = new AuthnRequest();
 
-        StepupServiceNameExtension::add($request, $sp, 'nl');
+        StepupServiceNameExtension::add($request, $sp, 'nl', 'en', ['en', 'nl', 'pt']);
 
         $ext = $request->getExtensions();
         $this->assertArrayNotHasKey('mdui:UIInfo', $ext);
@@ -73,7 +73,7 @@ class StepupServiceNameExtensionTest extends TestCase
         $sp->nameEn = 'Flat Field Name';
         $request = new AuthnRequest();
 
-        StepupServiceNameExtension::add($request, $sp, 'en');
+        StepupServiceNameExtension::add($request, $sp, 'en', 'en', ['en', 'nl', 'pt']);
 
         $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
         $this->assertSame(1, $nodes->length);
@@ -85,7 +85,7 @@ class StepupServiceNameExtensionTest extends TestCase
         $sp = $this->spWithNames('Only English Name');
         $request = new AuthnRequest();
 
-        StepupServiceNameExtension::add($request, $sp, 'nl');
+        StepupServiceNameExtension::add($request, $sp, 'nl', 'en', ['en', 'nl', 'pt']);
 
         $nlNodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="nl"]');
         $enNodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
@@ -102,7 +102,7 @@ class StepupServiceNameExtensionTest extends TestCase
         $sp->nameEn = 'Flat Field Name';
         $request = new AuthnRequest();
 
-        StepupServiceNameExtension::add($request, $sp, 'en');
+        StepupServiceNameExtension::add($request, $sp, 'en', 'en', ['en', 'nl', 'pt']);
 
         $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
         $this->assertSame(1, $nodes->length);
@@ -117,7 +117,7 @@ class StepupServiceNameExtensionTest extends TestCase
             (new DOMDocument())->createElement('existing:Extension')
         )]);
 
-        StepupServiceNameExtension::add($request, $sp, 'en');
+        StepupServiceNameExtension::add($request, $sp, 'en', 'en', ['en', 'nl', 'pt']);
 
         $ext = $request->getExtensions();
         $this->assertArrayHasKey('existing:Extension', $ext);
@@ -129,7 +129,7 @@ class StepupServiceNameExtensionTest extends TestCase
         $sp = $this->spWithNames('My Service EN', 'Mijn Service NL');
         $request = new AuthnRequest();
 
-        StepupServiceNameExtension::add($request, $sp, 'en/../evil');
+        StepupServiceNameExtension::add($request, $sp, 'en/../evil', 'en', ['en', 'nl', 'pt']);
 
         $nodes = $this->queryXpath($request, './/mdui:DisplayName[@xml:lang="en"]');
         $this->assertSame(1, $nodes->length);


### PR DESCRIPTION
## Summary

- Adds `mdui:UIInfo`/`mdui:DisplayName` to `<samlp:Extensions>` of the Stepup Gateway SFO callout AuthnRequest, so Stepup can surface the correct service name in its 2FA UI instead of the generic proxy name
- Controlled by feature flag `eb.stepup.send_service_name` (disabled by default)
- Uses the user's current engine locale, falling back to English; prefers mdui DisplayName over flat `name*` fields
- Closes #2011

## Technical notes

- New `StepupServiceNameExtension` class in `src/OpenConext/EngineBlock/Stepup/` follows the same pattern as `StepupGsspUserAttributeExtension`
- `xml:lang` attribute set via `setAttributeNS` (XML namespace) so XPath and SAML consumers resolve it correctly
- Locale resolved via existing `LocaleProvider::getLocale()` available through `DiContainer`

## Test plan

- [x] 7/7 unit tests pass (`StepupServiceNameExtensionTest`)
- [x] 27/27 Behat scenarios pass in `Stepup.feature` (includes 2 new scenarios: feature enabled / disabled)
- [x] `phpcs` and `docheader` clean on new files
- [x] Feature flag disabled by default — existing Stepup flow unchanged when flag is off