### PR TITLE
7.x: Fix console on bare-metal installs

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -8,7 +8,7 @@ use Symfony\Component\ErrorHandler\Debug;
 
 set_time_limit(0);
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+require dirname(__DIR__) . '/config/bootstrap.php';
 
 if (!class_exists(Application::class)) {
     throw new RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');


### PR DESCRIPTION
Open for discussion, because I don't know if this is the right solution, but we ran into the issue that the .env file was not loaded automatically when running `bin/console` commands. We run multiple instances of EB on the same machine, so it's crucial that we can set the environment variables (especially APP_SECRET) per instance instead of setting it globally.  This change seems to fix that.