### PR TITLE
Remove stale open_conext_monitor route block from routes.yaml

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -15,7 +15,3 @@ engineblock_api_controllers:
         domain: ".*"
     defaults:
         domain: "%domain%"
-
-open_conext_monitor:
-    resource: "@OpenConextMonitorBundle/Resources/config/routing.yml"
-    prefix: /


### PR DESCRIPTION
The release/7.0 > main merge (f0e306e97) silently reintroduced the open_conext_monitor route block that was correctly removed from main during the Symfony 6.4 upgrade (ae5fd8d93).

release/7.0 pins openconext/monitor-bundle 4.2.0, which has no Symfony Flex recipe and requires this manual routes.yaml entry. main uses monitor-bundle 4.3.1, which auto-installs its own route file (config/routes/open_conext_monitor.yaml) via Flex, pointing at @OpenConextMonitorBundle/src/Controller instead. The Resources/config/routing.yml path referenced by the stale block no longer exists in 4.3.1, breaking route compilation and failing the build.

Monitoring routes (/internal/health, /internal/info) continue to work via the existing Flex-installed config/routes/open_conext_monitor.yaml.