### PR TITLE
Fix Dotenv never loading overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ the [Development Guidelines](https://github.com/OpenConext/OpenConext-enginebloc
 the EngineBlock wiki.
 
 ## UNRELEASED
+
+Fixes:
+* Fix Dotenv never loading `.env.{ENV}` overrides.
+
 Features:
 * Added `coin:azure_domain_hint` configuration option for IdPs. When set, EngineBlock appends a `whr=<domain>` query parameter to the HTTP-Redirect AuthnRequest sent to the IdP, allowing Microsoft Azure / EntraID to skip the account picker (#1864).
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -11,10 +11,10 @@ if (!class_exists(Dotenv::class)) {
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
 if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
-    (new Dotenv(false))->populate($env);
+    (new Dotenv())->populate($env);
 } else {
     // load all the .env files
-    (new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
+    (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 }
 
 $_SERVER += $_ENV;


### PR DESCRIPTION
Prior to this change Dotenv would never load override files. For example, `.env.prod` would never be read. Only `.env` would be parsed. This was caused because we forgot to remove the old constructor parameter that was refactored in v5 of `symfony/dotenv`.

This change removes the erroneous constructor parameter, restoring dotenv functionality to work as expected.

See
https://github.com/symfony/dotenv/blob/8.2/CHANGELOG.md#510