### PR TITLE
fix(logging): filter Doctrine ORM deprecation noise

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -18,6 +18,7 @@
 
 namespace App;
 
+use Doctrine\Deprecations\Deprecation;
 use Override;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -35,6 +36,8 @@ class Kernel extends BaseKernel
 
     public function registerBundles(): iterable
     {
+        Deprecation::ignoreDeprecations('https://github.com/doctrine/orm/pull/12005');
+
         $contents = require $this->getProjectDir().'/config/bundles.php';
         foreach ($contents as $class => $envs) {
             if ($envs[$this->environment] ?? $envs['all'] ?? false) {


### PR DESCRIPTION
## Summary
- Engine floods `application.log` with `"User Deprecated: Class \"Doctrine\\ORM\\Proxy\\Autoloader\" is deprecated ..."` on every request — triggered by `DoctrineBundle::boot()` registering the legacy proxy autoloader. Not actionable from our code; the deprecation lives inside DoctrineBundle's own boot code.
- Fix: call `Deprecation::ignoreDeprecations($link)` (from `doctrine/deprecations`, the library's own purpose-built suppression API) once in `Kernel::registerBundles()` — the earliest point common to both the HTTP and console entrypoints, before `DoctrineBundle::boot()` triggers the deprecation.
- 1-line change in `src/Kernel.php`. No monolog config, no custom handler.

## Test plan
- [x] Reproduced on unpatched `main`: 170 `"User Deprecated"` lines over one `behat --suite default` run
- [x] With this fix: 0 deprecation lines, other log entries (2048 lines) unaffected — checked in both `ci` and `dev` envs
- [x] `phpmd`, `phpcs` (src + legacy), `docheader` — all clean
- [x] `phpunit` unit (957), eb4 (221), integration (103), functional (119) — all green
- [x] `behat` default suite — 297/297 scenarios, 5531/5531 steps green

Fixes #2043