### PR TITLE
Prevent session errors from swallowing API error responses

### DIFF
--- a/src/OpenConext/EngineBlockBridge/ErrorReporter.php
+++ b/src/OpenConext/EngineBlockBridge/ErrorReporter.php
@@ -27,6 +27,7 @@ use OpenConext\EngineBlock\Service\FeedbackInfoCollectorInterface;
 use OpenConext\EngineBlock\Service\FeedbackStateHelperInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Throwable;
 
 class ErrorReporter
 {
@@ -66,6 +67,10 @@ class ErrorReporter
 
         try {
             $this->storeSessionFeedback($exception);
+        } catch (Throwable $sessionException) {
+            $this->logger->warning(
+                'Unable to store feedback info in session: ' . $sessionException->getMessage(),
+            );
         } finally {
             // flush all messages in queue, something went wrong!
             $this->engineBlockApplicationSingleton->flushLog('An error was caught');

--- a/tests/unit/OpenConext/EngineBlockBridge/ErrorReporterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBridge/ErrorReporterTest.php
@@ -142,4 +142,16 @@ class ErrorReporterTest extends TestCase
 
         self::assertSame($decision, $this->session->get('error_authorization_policy_decision'));
     }
+
+    #[Test]
+    public function it_does_not_propagate_exceptions_thrown_while_storing_feedback_in_the_session(): void
+    {
+        $this->feedbackInfoCollector
+            ->shouldReceive('collect')
+            ->andThrow(new Exception('Failed to start the session because headers have already been sent'));
+
+        $this->applicationSingleton->shouldReceive('flushLog')->with('An error was caught')->once();
+
+        $this->reporter->reportError(new Exception('test'), '');
+    }
 }


### PR DESCRIPTION
## Summary
- `ApiHttpExceptionListener::onKernelException()` calls `ErrorReporter::reportError()` before `$event->setResponse(...)`. `reportError()` only wrapped its session-feedback write in a `finally`, not a `catch` — so on stateless routes (e.g. `/api/connections` metadata push), a session-start failure (e.g. "headers already sent") propagated out, skipped `setResponse()`, and the client got HTTP 200 instead of the intended 400/500.
- Fix: catch `Throwable` around `storeSessionFeedback()` in `ErrorReporter::reportError()`, log it as a warning, and let the caller always finish. This applies to every exception listener that uses `reportError()` (API, feedback page, fallback), not just the push endpoint.

## Test plan
- [x] `phpunit --testsuite=unit --filter ErrorReporterTest` (new regression test added)
- [x] `phpunit --testsuite=eb4/unit/integration/functional` — all pass
- [x] `phpcs`, `phpmd`, `docheader` — clean
- [x] Behat default suite — 300 scenarios / 5557 steps pass
- [x] `lint:twig`, `phpcs-legacy`, `yarn lint` — clean

Closes #2051