### PR TITLE
Normalize exceptions in SyslogJsonFormatter log context

### DIFF
--- a/src/OpenConext/EngineBlockBundle/Monolog/Formatter/SyslogJsonFormatter.php
+++ b/src/OpenConext/EngineBlockBundle/Monolog/Formatter/SyslogJsonFormatter.php
@@ -31,8 +31,8 @@ class SyslogJsonFormatter extends JsonFormatter
             'channel' => $record->channel,
             'level'   => $record->level->getName(),
             'message' => $record->message,
-            'context' => $record->context,
-            'extra'   => $record->extra,
+            'context' => $this->normalize($record->context),
+            'extra'   => $this->normalize($record->extra),
         ];
     }
 }

--- a/tests/unit/OpenConext/EngineBlockBundle/Monolog/Formatter/SyslogJsonFormatterTest.php
+++ b/tests/unit/OpenConext/EngineBlockBundle/Monolog/Formatter/SyslogJsonFormatterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace OpenConext\EngineBlockBundle\Monolog\Formatter;
+
+use DateTimeImmutable;
+use EngineBlock_Exception;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SyslogJsonFormatterTest extends TestCase
+{
+    private SyslogJsonFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new SyslogJsonFormatter();
+    }
+
+    #[Test]
+    public function it_normalizes_an_exception_in_the_context_to_its_class_message_code_and_file(): void
+    {
+        $exception = new EngineBlock_Exception('Something went wrong');
+
+        $record = $this->recordWithContext(['exception' => $exception]);
+
+        $decoded = json_decode($this->formatter->format($record), true);
+
+        self::assertSame(EngineBlock_Exception::class, $decoded['context']['exception']['class']);
+        self::assertSame('Something went wrong', $decoded['context']['exception']['message']);
+        self::assertArrayHasKey('code', $decoded['context']['exception']);
+        self::assertArrayHasKey('file', $decoded['context']['exception']);
+        self::assertArrayNotHasKey('sessionId', $decoded['context']['exception']);
+        self::assertArrayNotHasKey('trace', $decoded['context']['exception']);
+    }
+
+    #[Test]
+    public function it_normalizes_previous_exceptions_to_their_string_representation(): void
+    {
+        $exception = new RuntimeException('Outer', 0, new RuntimeException('Inner'));
+
+        $record = $this->recordWithContext(['previous_exceptions' => [(string) $exception->getPrevious()]]);
+
+        $decoded = json_decode($this->formatter->format($record), true);
+
+        self::assertStringContainsString('Inner', $decoded['context']['previous_exceptions'][0]);
+    }
+
+    #[Test]
+    public function it_leaves_scalar_and_array_context_values_unchanged(): void
+    {
+        $record = $this->recordWithContext(['route' => 'api_connections', 'route_parameters' => ['_format' => 'json']]);
+
+        $decoded = json_decode($this->formatter->format($record), true);
+
+        self::assertSame('api_connections', $decoded['context']['route']);
+        self::assertSame(['_format' => 'json'], $decoded['context']['route_parameters']);
+    }
+
+    private function recordWithContext(array $context): LogRecord
+    {
+        return new LogRecord(
+            new DateTimeImmutable(),
+            'app',
+            Level::Error,
+            'An error was caught',
+            $context,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `SyslogJsonFormatter::normalizeRecord()` overrode Monolog's normalization pipeline and passed `$record->context`/`$record->extra` straight to JSON encoding without ever calling `$this->normalize(...)`.
- Every logged exception is stored raw as `context['exception'] = $exception`. `json_encode()` on a plain PHP object only serializes public properties, so `EngineBlock_Exception`-based exceptions (which declare 5 unused public props: `sessionId`, `userId`, `spEntityId`, `idpEntityId`, `description`) logged as `{"sessionId":null,"userId":null,"spEntityId":null,"idpEntityId":null,"description":null}` instead of `class`/`message`/`code`/`file` — making production logs useless for debugging.
- Fix: run `context`/`extra` through `$this->normalize(...)` (inherited from `JsonFormatter`, already handles `Throwable` → `class`/`message`/`code`/`file` via `normalizeException()`) before assembling the record array.

## Test plan
- [x] New unit test `SyslogJsonFormatterTest` — verified it fails against the pre-fix code (`null` instead of exception class) and passes post-fix
- [x] `phpunit --testsuite=eb4/unit/integration/functional` — all pass
- [x] `phpcs`, `phpmd`, `docheader` — clean
- [x] Behat default suite — 300 scenarios / 5557 steps pass
- [x] Live end-to-end: hit `/api/connections` on the running dev container with an invalid payload, tailed `application.log`, confirmed `context.exception` now contains `class`/`message`/`code`/`file`/`previous`

Closes #2055